### PR TITLE
Update Melodic docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
-[![Build Status](https://travis-ci.org/osrf/ros_ign.svg?branch=master)](https://travis-ci.org/osrf/ros_ign.svg?branch=master)
+[![Build Status](https://travis-ci.org/osrf/ros_ign.svg?branch=melodic)](https://travis-ci.org/osrf/ros_ign/branches)
+
+* ROS 1 branches:
+    * [melodic](https://github.com/osrf/ros_ign/tree/melodic)
+* ROS 2 branches:
+    * [dashing](https://github.com/osrf/ros_ign/tree/dashing)
 
 # Integration between ROS and Ignition
 
 This repository holds packages that provide integration between
 [ROS](http://www.ros.org/) and [Ignition](https://ignitionrobotics.org):
 
-* `ros_ign`: Metapackage which provides all the other packages.
-* `ros_ign_image`: Transport bridge from Ignition transport to ROS using [image_transport](http://wiki.ros.org/image_transport).
-* `ros_ign_bridge`: Transport bridge between ROS and Ignition transport.
-* `ros_ign_gazebo_demos`: Demos using the ROS-Ignition integration.
-* `ros_ign_point_cloud`: Plugins for publishing ROS point clouds from Ignition Gazebo simulations.
-
+* [ros_ign](https://github.com/osrf/ros_ign/tree/melodic/ros_ign):
+  Metapackage which provides all the other packages.
+* [ros_ign_image](https://github.com/osrf/ros_ign/tree/melodic/ros_ign_image):
+  Unidirectional transport bridge for images from
+  [Ignition Transport](https://ignitionrobotics.org/libs/transport)
+  to ROS using
+  [image_transport](http://wiki.ros.org/image_transport).
+* [ros_ign_bridge](https://github.com/osrf/ros_ign/tree/melodic/ros_ign_bridge):
+  Bidirectional transport bridge between
+  [Ignition Transport](https://ignitionrobotics.org/libs/transport)
+  and ROS.
+* [ros_ign_gazebo](https://github.com/osrf/ros_ign/tree/melodic/ros_ign_gazebo):
+  Convenient launch files and executables for using
+  [Ignition Gazebo](https://ignitionrobotics.org/libs/gazebo)
+  with ROS.
+* [ros_ign_gazebo_demos](https://github.com/osrf/ros_ign/tree/melodic/ros_ign_gazebo_demos):
+  Demos using the ROS-Ignition integration.
+* [ros_ign_point_cloud](https://github.com/osrf/ros_ign/tree/melodic/ros_ign_point_cloud):
+  Plugins for publishing point clouds to ROS from
+  [Ignition Gazebo](https://ignitionrobotics.org/libs/gazebo) simulations.

--- a/ros_ign/README.md
+++ b/ros_ign/README.md
@@ -1,0 +1,4 @@
+# ROS-Ignition packages
+
+`ros_ign` is a metapackage that installs all packages integrating
+[ROS](http://www.ros.org/) and [Ignition](https://ignitionrobotics.org):

--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -34,74 +34,77 @@ service calls. Its support is limited to only the following message types:
 | sensor_msgs/MagneticField      | ignition::msgs::Magnetometer     |
 | sensor_msgs/PointCloud2        | ignition::msgs::PointCloudPacked |
 
-Run `parameter_bridge -h` for instructions.
+Run `rosmaster & rosrun ros_ign_bridge parameter_bridge -h` for instructions.
 
 ## Prerequisites
 
-For all examples you need to source the environment of the install space where
-the bridge was built or unpacked to.
-Additionally you will need to either source the ROS environment or at least
-set the `ROS_MASTER_URI` and run a `roscore`.
+### ROS
 
-The following ROS packages are required to build and use the bridge:
-* `catkin`
-* `geometry_msgs`
-* `mav_msgs`
-* `nav_msgs`
-* `rosconsole`
-* `roscpp`
-* `roslaunch` (for `roscore` executable)
-* `rosmsg`
-* `sensor_msgs`
-* `std_msgs`
+Be sure you've installed
+[ROS Melodic](http://wiki.ros.org/melodic/Installation/Ubuntu) (at least ROS-Base).
+More ROS dependencies will be installed below.
 
-To run the following examples you will also need these ROS packages:
-* `rosbash` (for `rosrun` executable)
-* `roscpp_tutorials`
-* `rostopic`
-* `rqt_image_view`
+### Ignition
 
-The following Ignition dependencies are also needed, depending on the Ignition collection that you are using:
+The following Ignition dependencies are also needed, depending on the Ignition
+collection that you are using:
 
 1. Ignition Blueprint:
 
-* `libignition-msgs4-dev`
-* `libignition-transport7-dev`
+    * `libignition-msgs4-dev`
+    * `libignition-transport7-dev`
 
 2. Ignition Citadel:
 
-* `libignition-msgs5-dev`
-* `libignition-transport8-dev`
+    * `libignition-msgs5-dev`
+    * `libignition-transport8-dev`
 
 ### Building the bridge from source
 
 Before continuing you should have the prerequisites for building the bridge from
 source installed.
 
-Here are the steps (for Linux and OSX; you probably don't have ROS installed
-on Windows).
+The following steps are for Linux and OSX.
 
 1. Create a catkin workspace:
 
-```
-# Setup the workspace
-mkdir -p ~/bridge_ws/src
-cd ~/bridge_ws/src
+    ```
+    # Setup the workspace
+    mkdir -p ~/bridge_ws/src
+    cd ~/bridge_ws/src
 
-# Download needed software
-git clone https://github.com/osrf/ros_ign.git -b melodic
-```
+    # Download needed software
+    git clone https://github.com/osrf/ros_ign.git -b melodic
+    ```
 
-2. Build the workspace:
+1. Install ROS dependencies:
 
-```
-# Source ROS distro's setup.bash
-source /opt/ros/melodic/setup.bash
+    ```
+    cd ~/bridge_ws
+    rosdep install --from-paths src -i -y --rosdistro melodic \
+      --skip-keys=ignition-gazebo2 \
+      --skip-keys=ignition-gazebo3 \
+      --skip-keys=ignition-msgs4 \
+      --skip-keys=ignition-msgs5 \
+      --skip-keys=ignition-rendering2 \
+      --skip-keys=ignition-rendering3 \
+      --skip-keys=ignition-sensors2 \
+      --skip-keys=ignition-sensors3 \
+      --skip-keys=ignition-transport7 \
+      --skip-keys=ignition-transport8
 
-# Build and install into workspace
-cd ~/bridge_ws/
-catkin_make install
-```
+    ```
+
+1. Build the workspace:
+
+    ```
+    # Source ROS distro's setup.bash
+    source /opt/ros/melodic/setup.bash
+
+    # Build and install into workspace
+    cd ~/bridge_ws/
+    catkin_make install
+    ```
 
 ## Example 1a: Ignition Transport talker and ROS listener
 

--- a/ros_ign_bridge/src/parameter_bridge.cpp
+++ b/ros_ign_bridge/src/parameter_bridge.cpp
@@ -47,7 +47,7 @@ enum Direction
 //////////////////////////////////////////////////
 void usage()
 {
-  ROS_ERROR_STREAM(
+  ROS_INFO_STREAM(
       "Bridge a collection of ROS and Ignition Transport topics.\n\n"
       << "  parameter_bridge <topic@ROS_type(@,[,])Ign_type> .. "
       << " <topic@ROS_type(@,[,])Ign_type>\n\n"


### PR DESCRIPTION
Some updates:

* Link to each package's README from main README
* Mention both ROS 1 and 2 on main README
* Add `ros_ign_gazebo` to main README
* Simplify install instructions for `ros_ign_bridge`
* Make `parameter_bridge`'s help `INFO` so `-h` doesn't show up red