### PR TITLE
Add Float64 to ignition Double conversions.  This is needed for suppo…

### DIFF
--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -11,6 +11,7 @@ service calls. Its support is limited to only the following message types:
 | std_msgs/Bool                  | ignition::msgs::Boolean          |
 | std_msgs/Empty                 | ignition::msgs::Empty            |
 | std_msgs/Float32               | ignition::msgs::Float            |
+| std_msgs/Float64               | ignition::msgs::Double           |
 | std_msgs/Header                | ignition::msgs::Header           |
 | std_msgs/String                | ignition::msgs::StringMsg        |
 | geometry_msgs/Quaternion       | ignition::msgs::Quaternion       |

--- a/ros_ign_bridge/include/ros_ign_bridge/builtin_interfaces_factories.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/builtin_interfaces_factories.hpp
@@ -39,6 +39,7 @@
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
 #include <std_msgs/Float32.h>
+#include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
 
@@ -118,6 +119,24 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Float & ign_msg,
   std_msgs::Float32 & ros_msg);
+  
+template<>
+void
+Factory<
+  std_msgs::Float64,
+  ignition::msgs::Double
+>::convert_ros_to_ign(
+  const std_msgs::Float64 & ros_msg,
+  ignition::msgs::Double & ign_msg);
+
+template<>
+void
+Factory<
+  std_msgs::Float64,
+  ignition::msgs::Double
+>::convert_ign_to_ros(
+  const ignition::msgs::Double & ign_msg,
+  std_msgs::Float64 & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/include/ros_ign_bridge/convert_builtin_interfaces.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert_builtin_interfaces.hpp
@@ -39,6 +39,7 @@
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
 #include <std_msgs/Float32.h>
+#include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
 
@@ -86,6 +87,18 @@ void
 convert_ign_to_ros(
   const ignition::msgs::Float & ign_msg,
   std_msgs::Float32 & ros_msg);
+  
+template<>
+void
+convert_ros_to_ign(
+  const std_msgs::Float64 & ros_msg,
+  ignition::msgs::Double & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Double & ign_msg,
+  std_msgs::Float64 & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/src/builtin_interfaces_factories.cpp
+++ b/ros_ign_bridge/src/builtin_interfaces_factories.cpp
@@ -62,6 +62,17 @@ get_factory_builtin_interfaces(
     >("std_msgs/Float32", ign_type_name);
   }
   if (
+    (ros_type_name == "std_msgs/Float64" || ros_type_name == "") &&
+     ign_type_name == "ignition.msgs.Double")
+  {
+    return std::make_shared<
+      Factory<
+        std_msgs::Float64,
+        ignition::msgs::Double
+      >
+    >("std_msgs/Float64", ign_type_name);
+  }
+  if (
     (ros_type_name == "std_msgs/Header" || ros_type_name == "") &&
      ign_type_name == "ignition.msgs.Header")
   {
@@ -389,6 +400,30 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Float & ign_msg,
   std_msgs::Float32 & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Float64,
+  ignition::msgs::Double
+>::convert_ros_to_ign(
+  const std_msgs::Float64 & ros_msg,
+  ignition::msgs::Double & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Float64,
+  ignition::msgs::Double
+>::convert_ign_to_ros(
+  const ignition::msgs::Double & ign_msg,
+  std_msgs::Float64 & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
 }

--- a/ros_ign_bridge/src/convert_builtin_interfaces.cpp
+++ b/ros_ign_bridge/src/convert_builtin_interfaces.cpp
@@ -113,6 +113,24 @@ convert_ign_to_ros(
 template<>
 void
 convert_ros_to_ign(
+  const std_msgs::Float64 & ros_msg,
+  ignition::msgs::Double & ign_msg)
+{
+  ign_msg.set_data(ros_msg.data);
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Double & ign_msg,
+  std_msgs::Float64 & ros_msg)
+{
+  ros_msg.data = ign_msg.data();
+}
+
+template<>
+void
+convert_ros_to_ign(
   const std_msgs::Header & ros_msg,
   ignition::msgs::Header & ign_msg)
 {

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch
@@ -6,6 +6,7 @@
         args="/bool@std_msgs/Bool@ignition.msgs.Boolean
               /empty@std_msgs/Empty@ignition.msgs.Empty
               /float@std_msgs/Float32@ignition.msgs.Float
+              /double@std_msgs/Float64@ignition.msgs.Double
               /header@std_msgs/Header@ignition.msgs.Header
               /string@std_msgs/String@ignition.msgs.StringMsg
               /quaternion@geometry_msgs/Quaternion@ignition.msgs.Quaternion

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch
@@ -6,6 +6,7 @@
         args="/bool@std_msgs/Bool@ignition.msgs.Boolean
               /empty@std_msgs/Empty@ignition.msgs.Empty
               /float@std_msgs/Float32@ignition.msgs.Float
+              /double@std_msgs/Float64@ignition.msgs.Double
               /header@std_msgs/Header@ignition.msgs.Header
               /string@std_msgs/String@ignition.msgs.StringMsg
               /quaternion@geometry_msgs/Quaternion@ignition.msgs.Quaternion

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -17,6 +17,7 @@
 #include <ros/ros.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/Float32.h>
+#include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
 #include <geometry_msgs/Quaternion.h>
@@ -60,6 +61,11 @@ int main(int argc, char ** argv)
   ros::Publisher float_pub = n.advertise<std_msgs::Float32>("float", 1000);
   std_msgs::Float32 float_msg;
   ros_ign_bridge::testing::createTestMsg(float_msg);
+  
+  // std_msgs::Float64.
+  ros::Publisher double_pub = n.advertise<std_msgs::Float64>("double", 1000);
+  std_msgs::Float64 double_msg;
+  ros_ign_bridge::testing::createTestMsg(double_msg);
 
   // std_msgs::Header.
   ros::Publisher header_pub = n.advertise<std_msgs::Header>("header", 1000);
@@ -197,6 +203,7 @@ int main(int argc, char ** argv)
     bool_pub.publish(bool_msg);
     empty_pub.publish(empty_msg);
     float_pub.publish(float_msg);
+    double_pub.publish(double_msg);
     header_pub.publish(header_msg);
     string_pub.publish(string_msg);
     quaternion_pub.publish(quaternion_msg);

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
@@ -19,6 +19,7 @@
 #include <ros/ros.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/Float32.h>
+#include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
 #include <geometry_msgs/Point.h>
@@ -99,6 +100,18 @@ TEST(ROSSubscriberTest, Empty)
 TEST(ROSSubscriberTest, Float)
 {
   MyTestClass<std_msgs::Float32> client("float");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROSSubscriberTest, Double)
+{
+  MyTestClass<std_msgs::Float64> client("double");
 
   using namespace std::chrono_literals;
   ros_ign_bridge::testing::waitUntilBoolVarAndSpin(

--- a/ros_ign_bridge/test/test_utils.h
+++ b/ros_ign_bridge/test/test_utils.h
@@ -23,6 +23,7 @@
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
 #include <std_msgs/Float32.h>
+#include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
 #include <geometry_msgs/Point.h>
@@ -135,6 +136,13 @@ namespace testing
   {
     _msg.data = 1.5;
   }
+  
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(std_msgs::Float64 &_msg)
+  {
+    _msg.data = 1.5;
+  }
 
   /// \brief Compare a message with the populated for testing.
   /// \param[in] _msg The message to compare.
@@ -144,6 +152,16 @@ namespace testing
     createTestMsg(expected_msg);
 
     EXPECT_FLOAT_EQ(expected_msg.data, _msg.data);
+  }
+  
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const std_msgs::Float64 &_msg)
+  {
+    std_msgs::Float64 expected_msg;
+    createTestMsg(expected_msg);
+
+    EXPECT_DOUBLE_EQ(expected_msg.data, _msg.data);
   }
 
   /// \brief Create a message used for testing.


### PR DESCRIPTION
Add Float64 to ignition Double conversions.  This is needed for supporting joint controller (such as for a pan/tilt gimbal).  Forthcoming dependent pull requests will be issued on OSRF SubT project to support a pan/tilt gimbal.  