### PR TITLE
Ignore ros-args in parameter bridge

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(std_msgs REQUIRED)
 
 # Citadel
 find_package(ignition-transport8 QUIET)
-if (ignition-transport8_FOUND)
+if(ignition-transport8_FOUND)
   set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
   find_package(ignition-msgs5 REQUIRED)

--- a/ros_ign_bridge/src/parameter_bridge.cpp
+++ b/ros_ign_bridge/src/parameter_bridge.cpp
@@ -72,11 +72,13 @@ std::vector<std::string> filter_args(int argc, char * argv[])
   auto rosArgsPos = std::find(args.begin(), args.end(), rosArgsBeginDelim);
   auto rosArgsEndPos = std::find(rosArgsPos, args.end(), rosArgsEndDelim);
   // If -- was found, delete it as well
-  if (rosArgsEndPos != args.end())
+  if (rosArgsEndPos != args.end()) {
     ++rosArgsEndPos;
+  }
   // Delete args between --ros-args and -- (or --ros-args to end if not found)
-  if (rosArgsPos != args.end())
+  if (rosArgsPos != args.end()) {
     args.erase(rosArgsPos, rosArgsEndPos);
+  }
   return args;
 }
 
@@ -104,7 +106,7 @@ int main(int argc, char * argv[])
   const std::string delim = "@";
   const size_t queue_size = 10;
   auto filteredArgs = filter_args(argc, argv);
-  for (auto& arg : filteredArgs) {
+  for (auto & arg : filteredArgs) {
     auto delimPos = arg.find(delim);
     if (delimPos == std::string::npos || delimPos == 0) {
       usage();

--- a/ros_ign_bridge/src/parameter_bridge.cpp
+++ b/ros_ign_bridge/src/parameter_bridge.cpp
@@ -86,6 +86,9 @@ int main(int argc, char * argv[])
   const size_t queue_size = 10;
   for (auto i = 1; i < argc; ++i) {
     std::string arg = std::string(argv[i]);
+    // Don't parse appended ros args
+    if (arg == "--ros-args")
+      break;
     auto delimPos = arg.find(delim);
     if (delimPos == std::string::npos || delimPos == 0) {
       usage();


### PR DESCRIPTION
Starting from eloquent, the --ros-args flag becomes mandatory and, according to the [design document](http://design.ros2.org/articles/ros_command_line_arguments.html), even an empty `--ros-flags` is valid.

When embedding the parameter_bridge in a launch file in eloquent, i.e. in the following way (forwarding ignition clock to ROS2):

``` 
    <node pkg="ros_ign_bridge" exec="parameter_bridge"
        args="/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock"
    />
```

ros_ign_bridge crashes because it doesn't expect the --ros-args flag:

`[ERROR] [parameter_bridge-1]: process has died [pid 1398, exit code 255, cmd '/home/luca/demos_ws/install/ros_ign_bridge/lib/ros_ign_bridge/parameter_bridge /clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock --ros-args'].
` 

This PR ignores every command line argument after the --ros-args (since it's not used anyway in the bridge), fixing the crash.