### PR TITLE
Add ignition::msgs::Pose_V to tf2_msgs::TFMessage conversion

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -16,7 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
                roscpp
                rostest
                sensor_msgs
-               std_msgs)
+               std_msgs
+               tf2_msgs)
 
 # Citadel
 find_package(ignition-transport8 QUIET)

--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -34,6 +34,7 @@ service calls. Its support is limited to only the following message types:
 | sensor_msgs/LaserScan          | ignition::msgs::LaserScan        |
 | sensor_msgs/MagneticField      | ignition::msgs::Magnetometer     |
 | sensor_msgs/PointCloud2        | ignition::msgs::PointCloudPacked |
+| tf_msgs/TFMessage              | ignition::msgs::Pose_V           |
 
 Run `rosmaster & rosrun ros_ign_bridge parameter_bridge -h` for instructions.
 

--- a/ros_ign_bridge/include/ros_ign_bridge/builtin_interfaces_factories.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/builtin_interfaces_factories.hpp
@@ -42,6 +42,7 @@
 #include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
+#include <tf2_msgs/TFMessage.h>
 
 // include Ignition Transport messages
 #include <ignition/msgs.hh>
@@ -119,7 +120,7 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Float & ign_msg,
   std_msgs::Float32 & ros_msg);
-  
+
 template<>
 void
 Factory<
@@ -319,6 +320,24 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Pose & ign_msg,
   geometry_msgs::TransformStamped & ros_msg);
+
+template<>
+void
+Factory<
+  tf2_msgs::TFMessage,
+  ignition::msgs::Pose_V
+>::convert_ros_to_ign(
+  const tf2_msgs::TFMessage & ros_msg,
+  ignition::msgs::Pose_V & ign_msg);
+
+template<>
+void
+Factory<
+  tf2_msgs::TFMessage,
+  ignition::msgs::Pose_V
+>::convert_ign_to_ros(
+  const ignition::msgs::Pose_V & ign_msg,
+  tf2_msgs::TFMessage & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/include/ros_ign_bridge/convert_builtin_interfaces.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert_builtin_interfaces.hpp
@@ -42,6 +42,7 @@
 #include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
+#include <tf2_msgs/TFMessage.h>
 
 // include Ignition builtin messages
 #include <ignition/msgs.hh>
@@ -221,6 +222,18 @@ void
 convert_ign_to_ros(
   const ignition::msgs::Pose & ign_msg,
   geometry_msgs::TransformStamped & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const tf2_msgs::TFMessage & ros_msg,
+  ignition::msgs::Pose_V & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Pose_V & ign_msg,
+  tf2_msgs::TFMessage & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/package.xml
+++ b/ros_ign_bridge/package.xml
@@ -18,6 +18,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2_msgs</depend>
 
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>

--- a/ros_ign_bridge/src/builtin_interfaces_factories.cpp
+++ b/ros_ign_bridge/src/builtin_interfaces_factories.cpp
@@ -183,6 +183,17 @@ get_factory_builtin_interfaces(
     >("geometry_msgs/TransformStamped", ign_type_name);
   }
   if (
+    (ros_type_name == "tf2_msgs/TFMessage" || ros_type_name == "") &&
+     ign_type_name == "ignition.msgs.Pose_V")
+  {
+    return std::make_shared<
+      Factory<
+        tf2_msgs::TFMessage,
+        ignition::msgs::Pose_V
+      >
+    >("tf2_msgs/TFMessage", ign_type_name);
+  }
+  if (
     (ros_type_name == "geometry_msgs/Twist" || ros_type_name == "") &&
      ign_type_name == "ignition.msgs.Twist")
   {
@@ -666,6 +677,30 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Pose & ign_msg,
   geometry_msgs::TransformStamped & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  tf2_msgs::TFMessage,
+  ignition::msgs::Pose_V
+>::convert_ros_to_ign(
+  const tf2_msgs::TFMessage & ros_msg,
+  ignition::msgs::Pose_V & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  tf2_msgs::TFMessage,
+  ignition::msgs::Pose_V
+>::convert_ign_to_ros(
+  const ignition::msgs::Pose_V & ign_msg,
+  tf2_msgs::TFMessage & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
 }

--- a/ros_ign_bridge/src/convert_builtin_interfaces.cpp
+++ b/ros_ign_bridge/src/convert_builtin_interfaces.cpp
@@ -376,6 +376,41 @@ convert_ign_to_ros(
 template<>
 void
 convert_ros_to_ign(
+  const tf2_msgs::TFMessage & ros_msg,
+  ignition::msgs::Pose_V & ign_msg)
+{
+  ign_msg.clear_pose();
+  for (auto const &t : ros_msg.transforms)
+  {
+    auto p = ign_msg.add_pose();
+    convert_ros_to_ign(t, *p);
+  }
+
+  if (!ros_msg.transforms.empty())
+  {
+    convert_ros_to_ign(ros_msg.transforms[0].header,
+        (*ign_msg.mutable_header()));
+  }
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Pose_V & ign_msg,
+  tf2_msgs::TFMessage & ros_msg)
+{
+  ros_msg.transforms.clear();
+  for (auto const &p : ign_msg.pose())
+  {
+    geometry_msgs::TransformStamped tf;
+    convert_ign_to_ros(p, tf);
+    ros_msg.transforms.push_back(tf);
+  }
+}
+
+template<>
+void
+convert_ros_to_ign(
   const geometry_msgs::Twist & ros_msg,
   ignition::msgs::Twist & ign_msg)
 {

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch
@@ -17,6 +17,7 @@
               /pose_stamped@geometry_msgs/PoseStamped@ignition.msgs.Pose
               /transform@geometry_msgs/Transform@ignition.msgs.Pose
               /transform_stamped@geometry_msgs/TransformStamped@ignition.msgs.Pose
+              /tf2_message@tf2_msgs/TFMessage@ignition.msgs.Pose_V
               /twist@geometry_msgs/Twist@ignition.msgs.Twist
               /image@sensor_msgs/Image@ignition.msgs.Image
               /camera_info@sensor_msgs/CameraInfo@ignition.msgs.CameraInfo

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch
@@ -17,6 +17,7 @@
               /pose_stamped@geometry_msgs/PoseStamped@ignition.msgs.Pose
               /transform@geometry_msgs/Transform@ignition.msgs.Pose
               /transform_stamped@geometry_msgs/TransformStamped@ignition.msgs.Pose
+              /tf2_message@tf2_msgs/TFMessage@ignition.msgs.Pose_V
               /twist@geometry_msgs/Twist@ignition.msgs.Twist
               /image@sensor_msgs/Image@ignition.msgs.Image
               /camera_info@sensor_msgs/CameraInfo@ignition.msgs.CameraInfo

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -62,6 +62,11 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::Float float_msg;
   ros_ign_bridge::testing::createTestMsg(float_msg);
 
+  // ignition::msgs::Double.
+  auto double_pub = node.Advertise<ignition::msgs::Double>("double");
+  ignition::msgs::Double double_msg;
+  ros_ign_bridge::testing::createTestMsg(double_msg);
+
   // ignition::msgs::Header.
   auto header_pub = node.Advertise<ignition::msgs::Header>("header");
   ignition::msgs::Header header_msg;
@@ -114,6 +119,12 @@ int main(int /*argc*/, char **/*argv*/)
       node.Advertise<ignition::msgs::Pose>("transform_stamped");
   ignition::msgs::Pose transform_stamped_msg;
   ros_ign_bridge::testing::createTestMsg(transform_stamped_msg);
+
+  // ignition::msgs::Pose_V.
+  auto tf2_message_pub =
+      node.Advertise<ignition::msgs::Pose_V>("tf2_message");
+  ignition::msgs::Pose_V tf2_msg;
+  ros_ign_bridge::testing::createTestMsg(tf2_msg);
 
   // ignition::msgs::Image.
   auto image_pub = node.Advertise<ignition::msgs::Image>("image");
@@ -182,6 +193,7 @@ int main(int /*argc*/, char **/*argv*/)
     bool_pub.Publish(bool_msg);
     empty_pub.Publish(empty_msg);
     float_pub.Publish(float_msg);
+    double_pub.Publish(double_msg);
     header_pub.Publish(header_msg);
     string_pub.Publish(string_msg);
     quaternion_pub.Publish(quaternion_msg);
@@ -192,6 +204,7 @@ int main(int /*argc*/, char **/*argv*/)
     pose_stamped_pub.Publish(pose_stamped_msg);
     transform_pub.Publish(transform_msg);
     transform_stamped_pub.Publish(transform_stamped_msg);
+    tf2_message_pub.Publish(tf2_msg);
     image_pub.Publish(image_msg);
     camera_info_pub.Publish(camera_info_msg);
     fluid_pressure_pub.Publish(fluid_pressure_msg);

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -39,6 +39,7 @@
 #include <sensor_msgs/LaserScan.h>
 #include <sensor_msgs/MagneticField.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <tf2_msgs/TFMessage.h>
 #include "../test_utils.h"
 
 //////////////////////////////////////////////////
@@ -124,6 +125,12 @@ int main(int argc, char ** argv)
     n.advertise<geometry_msgs::TransformStamped>("transform_stamped", 1000);
   geometry_msgs::TransformStamped transform_stamped_msg;
   ros_ign_bridge::testing::createTestMsg(transform_stamped_msg);
+
+  // tf2_msgs::TFMessage.
+  ros::Publisher tf2_message_pub =
+    n.advertise<tf2_msgs::TFMessage>("tf2_message", 1000);
+  tf2_msgs::TFMessage tf2_msg;
+  ros_ign_bridge::testing::createTestMsg(tf2_msg);
 
   // geometry_msgs::Twist.
   ros::Publisher twist_pub =
@@ -214,6 +221,7 @@ int main(int argc, char ** argv)
     pose_stamped_pub.publish(pose_stamped_msg);
     transform_pub.publish(transform_msg);
     transform_stamped_pub.publish(transform_stamped_msg);
+    tf2_message_pub.publish(tf2_msg);
     twist_pub.publish(twist_msg);
     actuators_pub.publish(actuators_msg);
     odometry_pub.publish(odometry_msg);

--- a/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
@@ -204,6 +204,18 @@ TEST(IgnSubscriberTest, TransformStamped)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, TF2Message)
+{
+  MyTestClass<ignition::msgs::Pose_V> client("tf2_message");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(IgnSubscriberTest, Twist)
 {
   MyTestClass<ignition::msgs::Twist> client("twist");

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
@@ -41,6 +41,7 @@
 #include <sensor_msgs/LaserScan.h>
 #include <sensor_msgs/MagneticField.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <tf2_msgs/TFMessage.h>
 #include <chrono>
 #include "../test_utils.h"
 
@@ -232,6 +233,18 @@ TEST(ROSSubscriberTest, Transform)
 TEST(ROSSubscriberTest, TransformStamped)
 {
   MyTestClass<geometry_msgs::TransformStamped> client("transform_stamped");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROSSubscriberTest, TF2Message)
+{
+  MyTestClass<tf2_msgs::TFMessage> client("tf2_message");
 
   using namespace std::chrono_literals;
   ros_ign_bridge::testing::waitUntilBoolVarAndSpin(

--- a/ros_ign_bridge/test/test_utils.h
+++ b/ros_ign_bridge/test/test_utils.h
@@ -47,6 +47,7 @@
 #include <sensor_msgs/MagneticField.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/PointField.h>
+#include <tf2_msgs/TFMessage.h>
 #include <chrono>
 #include <string>
 #include <thread>
@@ -355,6 +356,25 @@ namespace testing
     compareTestMsg(_msg.header);
     compareTestMsg(_msg.transform);
     EXPECT_EQ(expected_msg.child_frame_id, _msg.child_frame_id);
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(tf2_msgs::TFMessage &_msg)
+  {
+    geometry_msgs::TransformStamped tf;
+    createTestMsg(tf);
+    _msg.transforms.push_back(tf);
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const tf2_msgs::TFMessage &_msg)
+  {
+    tf2_msgs::TFMessage expected_msg;
+    createTestMsg(expected_msg);
+
+    compareTestMsg(_msg.transforms[0]);
   }
 
   /// \brief Create a message used for testing.
@@ -857,6 +877,23 @@ namespace testing
 
   /// \brief Create a message used for testing.
   /// \param[out] _msg The message populated.
+  void createTestMsg(ignition::msgs::Double &_msg)
+  {
+    _msg.set_data(1.5);
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const ignition::msgs::Double &_msg)
+  {
+    ignition::msgs::Double expected_msg;
+    createTestMsg(expected_msg);
+
+    EXPECT_DOUBLE_EQ(expected_msg.data(), _msg.data());
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
   void createTestMsg(ignition::msgs::Header &_msg)
   {
     auto seq_entry = _msg.add_data();
@@ -1015,6 +1052,25 @@ namespace testing
 
     compareTestMsg(_msg.position());
     compareTestMsg(_msg.orientation());
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(ignition::msgs::Pose_V &_msg)
+  {
+    createTestMsg(*_msg.mutable_header());
+    createTestMsg(*_msg.add_pose());
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const ignition::msgs::Pose_V &_msg)
+  {
+    ignition::msgs::Pose_V expected_msg;
+    createTestMsg(expected_msg);
+
+    compareTestMsg(_msg.header());
+    compareTestMsg(_msg.pose(0));
   }
 
   /// \brief Create a message used for testing.


### PR DESCRIPTION
For sending a group of transform stamped messages 

Also fixed test that was failing at the `double` msg type.

