### PR TITLE
Change ignition-gazebo2 from exec_depend to build_depend in ros_ign_gazebo

### DIFF
--- a/ros_ign_gazebo/package.xml
+++ b/ros_ign_gazebo/package.xml
@@ -8,6 +8,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>libgflags-dev</depend>
-  <exec_depend>ignition-gazebo2</exec_depend>
+  <depend>ignition-gazebo2</depend>
   <depend>roscpp</depend>
 </package>


### PR DESCRIPTION
It can not build without it https://build.osrfoundation.org/job/ros-ign-gazebo-bloom-debbuilder/7/console