### PR TITLE
Avoid the use of --ros-args arguments outside ros

### DIFF
--- a/ros_ign_image/src/image_bridge.cpp
+++ b/ros_ign_image/src/image_bridge.cpp
@@ -84,9 +84,10 @@ int main(int argc, char * argv[])
 
   std::vector<std::shared_ptr<Handler>> handlers;
 
+  auto args = rclcpp::remove_ros_arguments(argc, argv);
+
   // Create publishers and subscribers
-  for (auto i = 1; i < argc; ++i) {
-    auto topic = std::string(argv[i]);
+  for (auto topic: args) {
     handlers.push_back(std::make_shared<Handler>(topic, it_node, ign_node));
   }
 


### PR DESCRIPTION
The Handler class only accepts non-ros arguments. This PR avoid the use `--ros-args` arguments with this class

Signed-off-by: ahcorde <ahcorde@gmail.com>