### PR TITLE
Add pkg-config as a buildtool dependency

### DIFF
--- a/ros_ign_bridge/package.xml
+++ b/ros_ign_bridge/package.xml
@@ -11,6 +11,7 @@
   <author>Shivesh Khaitan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>ignition-msgs5</depend>
   <depend>ignition-transport8</depend>

--- a/ros_ign_gazebo/package.xml
+++ b/ros_ign_gazebo/package.xml
@@ -11,6 +11,7 @@
   <author>Alejandro Hernandez</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>libgflags-dev</depend>
   <depend>rclcpp</depend>

--- a/ros_ign_image/package.xml
+++ b/ros_ign_image/package.xml
@@ -6,6 +6,7 @@
   <maintainer email="louise@openrobotics.org">Louise Poubel</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>ignition-msgs5</depend>
   <depend>ignition-transport8</depend>


### PR DESCRIPTION
@nuclearsandwich kindly helped me investigate why the `ros_ign` packages are failing to build for Foxy and this is a promising band-aid solution.