### PR TITLE
ros_ign_gazebo exec depend on ign-gazebo

### DIFF
--- a/ros_ign_gazebo/package.xml
+++ b/ros_ign_gazebo/package.xml
@@ -18,9 +18,11 @@
   <depend>ignition-math6</depend>
 
   <!-- Dome -->
+  <exec_depend condition="$IGNITION_VERSION == dome">ignition-gazebo4</exec_depend>
   <depend condition="$IGNITION_VERSION == dome">ignition-msgs6</depend>
   <depend condition="$IGNITION_VERSION == dome">ignition-transport9</depend>
   <!-- Citadel (default) -->
+  <exec_depend condition="$IGNITION_VERSION != dome">ignition-gazebo3</exec_depend>
   <depend condition="$IGNITION_VERSION != dome">ignition-msgs5</depend>
   <depend condition="$IGNITION_VERSION != dome">ignition-transport8</depend>
 


### PR DESCRIPTION
It was noted on https://github.com/chapulina/dolly/pull/22 that installing `ros-foxy-ros-ign-gazebo` doesn't install `ign-gazebo`. Installing the `ros-ign` metapackage does, because the demos package brings `ign-gazebo`.

Since `ros_ign_gazebo` calls `ign gazebo` on a launch file, it needs to declare the exec dependency.

CC @ruffsl