### PR TITLE
Conform to ros format for header field frame_id of sensor msgs

### DIFF
--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -55,7 +55,9 @@ std::string replace_delimiter(const std::string &input,
 
 std::string frame_id_ign_to_ros(const std::string &frame_id)
 {
-  return replace_delimiter(frame_id, "::", "/");
+  //return replace_delimiter(frame_id, "::", "/");
+  //ROS sensor header frame_id should be unique and without prefix
+  return frame_id.substr(frame_id.find_last_of("::") + 1);
 }
 
 template<>


### PR DESCRIPTION
Should partially solves https://github.com/ignitionrobotics/ign-gazebo/issues/340
The `frame_id` field of the header of a sensor msg will now be the name given in the sdf sensor name attribute instead of the full chain of links.
Example with` <sensor name='laser' type='gpu_lidar'>`
Before:
```
$ rostopic echo --noarr /scan 
header: 
  seq: 384
  stamp: 
    secs: 12
    nsecs: 800000000
  frame_id: "spawned/base_footprint/laser"
angle_min: -2.0899999141693115
angle_max: 2.0899999141693115
angle_increment: 0.0014933905331417918
time_increment: 0.0
scan_time: 0.0
range_min: 0.05000000074505806
range_max: 30.0
ranges: "<array type: float32, length: 2800>"
intensities: "<array type: float32, length: 2800>"

```
After:
```
header: 
  seq: 127
  stamp: 
    secs: 4
    nsecs: 234000000
  frame_id: "laser"
angle_min: -2.0899999141693115
angle_max: 2.0899999141693115
angle_increment: 0.0014933905331417918
time_increment: 0.0
scan_time: 0.0
range_min: 0.05000000074505806
range_max: 30.0
ranges: "<array type: float32, length: 2800>"
intensities: "<array type: float32, length: 2800>"

```
However, in case of multi robot simulation, one should take care of properly prefixing the frame_id names to ensure each stays globally unique. See for instance, an example of a multiple camera launch file with a macro for proper prefixing of the frame_id field in the format `tf_prefix_frame_id_name` and without `/`:
https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/launch/rs_multiple_devices.launch
