### PR TITLE
[ros2] Add JointTrajectory message conversion

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rosgraph_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_msgs REQUIRED)
+find_package(trajectory_msgs REQUIRED)
 
 # Dome
 if("$ENV{IGNITION_VERSION}" STREQUAL "dome")
@@ -71,6 +72,7 @@ ament_target_dependencies(${bridge_lib}
   "sensor_msgs"
   "std_msgs"
   "tf2_msgs"
+  "trajectory_msgs"
 )
 
 install(TARGETS ${bridge_lib}
@@ -103,6 +105,7 @@ foreach(bridge ${bridge_executables})
     "sensor_msgs"
     "std_msgs"
     "tf2_msgs"
+    "trajectory_msgs"
   )
   install(TARGETS ${bridge}
     DESTINATION lib/${PROJECT_NAME}
@@ -126,6 +129,7 @@ if(BUILD_TESTING)
     sensor_msgs
     std_msgs
     tf2_msgs
+    trajectory_msgs
   )
   target_link_libraries(test_ros_publisher
     ${GTEST_LIBRARIES}
@@ -143,6 +147,7 @@ if(BUILD_TESTING)
     sensor_msgs
     std_msgs
     tf2_msgs
+    trajectory_msgs
   )
 
   target_link_libraries(test_ros_subscriber

--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -36,6 +36,7 @@ service calls. Its support is limited to only the following message types:
 | sensor_msgs/msg/MagneticField      | ignition::msgs::Magnetometer     |
 | sensor_msgs/msg/PointCloud2        | ignition::msgs::PointCloudPacked |
 | tf2_msgs/msg/TFMessage             | ignition::msgs::Pose_V           |
+| trajectory_msgs/msg/JointTrajectory | ignition::msgs::JointTrajectory |
 
 Run `ros2 run ros_ign_bridge parameter_bridge -h` for instructions.
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert.hpp
@@ -43,6 +43,7 @@
 #include <std_msgs/msg/int32.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 // Ignition messages
 #include <ignition/msgs.hh>
@@ -395,6 +396,32 @@ void
 convert_ign_to_ros(
   const ignition::msgs::BatteryState & ign_msg,
   sensor_msgs::msg::BatteryState & ros_msg);
+
+// trajectory_msgs
+template<>
+void
+convert_ros_to_ign(
+  const trajectory_msgs::msg::JointTrajectoryPoint & ros_msg,
+  ignition::msgs::JointTrajectoryPoint & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::JointTrajectoryPoint & ign_msg,
+  trajectory_msgs::msg::JointTrajectoryPoint & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const trajectory_msgs::msg::JointTrajectory & ros_msg,
+  ignition::msgs::JointTrajectory & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::JointTrajectory & ign_msg,
+  trajectory_msgs::msg::JointTrajectory & ros_msg);
+
 
 }  // namespace ros_ign_bridge
 

--- a/ros_ign_bridge/package.xml
+++ b/ros_ign_bridge/package.xml
@@ -20,6 +20,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2_msgs</depend>
+  <depend>trajectory_msgs</depend>
 
   <!-- Dome -->
   <depend condition="$IGNITION_VERSION == dome">ignition-msgs6</depend>

--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -1061,20 +1061,16 @@ convert_ros_to_ign(
   const trajectory_msgs::msg::JointTrajectoryPoint & ros_msg,
   ignition::msgs::JointTrajectoryPoint & ign_msg)
 {
-  for (const auto & ros_position : ros_msg.positions)
-  {
+  for (const auto & ros_position : ros_msg.positions) {
     ign_msg.add_positions(ros_position);
   }
-  for (const auto & ros_velocitie : ros_msg.velocities)
-  {
-    ign_msg.add_velocities(ros_velocitie);
+  for (const auto & ros_velocity : ros_msg.velocities) {
+    ign_msg.add_velocities(ros_velocity);
   }
-  for (const auto & ros_acceleration : ros_msg.accelerations)
-  {
+  for (const auto & ros_acceleration : ros_msg.accelerations) {
     ign_msg.add_accelerations(ros_acceleration);
   }
-  for (const auto & ros_effort : ros_msg.effort)
-  {
+  for (const auto & ros_effort : ros_msg.effort) {
     ign_msg.add_effort(ros_effort);
   }
 
@@ -1089,24 +1085,22 @@ convert_ign_to_ros(
   const ignition::msgs::JointTrajectoryPoint & ign_msg,
   trajectory_msgs::msg::JointTrajectoryPoint & ros_msg)
 {
-  for (auto i = 0; i < ign_msg.positions_size(); ++i)
-  {
+  for (auto i = 0; i < ign_msg.positions_size(); ++i) {
     ros_msg.positions.push_back(ign_msg.positions(i));
   }
-  for (auto i = 0; i < ign_msg.velocities_size(); ++i)
-  {
+  for (auto i = 0; i < ign_msg.velocities_size(); ++i) {
     ros_msg.velocities.push_back(ign_msg.velocities(i));
   }
-  for (auto i = 0; i < ign_msg.accelerations_size(); ++i)
-  {
+  for (auto i = 0; i < ign_msg.accelerations_size(); ++i) {
     ros_msg.accelerations.push_back(ign_msg.accelerations(i));
   }
-  for (auto i = 0; i < ign_msg.effort_size(); ++i)
-  {
+  for (auto i = 0; i < ign_msg.effort_size(); ++i) {
     ros_msg.effort.push_back(ign_msg.effort(i));
   }
 
-  ros_msg.time_from_start = rclcpp::Duration(ign_msg.time_from_start().sec(), ign_msg.time_from_start().nsec());
+  ros_msg.time_from_start = rclcpp::Duration(
+    ign_msg.time_from_start().sec(),
+    ign_msg.time_from_start().nsec());
 }
 
 template<>
@@ -1117,8 +1111,7 @@ convert_ros_to_ign(
 {
   convert_ros_to_ign(ros_msg.header, (*ign_msg.mutable_header()));
 
-  for (const auto & ros_joint_name : ros_msg.joint_names)
-  {
+  for (const auto & ros_joint_name : ros_msg.joint_names) {
     ign_msg.add_joint_names(ros_joint_name);
   }
 
@@ -1136,13 +1129,11 @@ convert_ign_to_ros(
 {
   convert_ign_to_ros(ign_msg.header(), ros_msg.header);
 
-  for (auto i = 0; i < ign_msg.joint_names_size(); ++i)
-  {
+  for (auto i = 0; i < ign_msg.joint_names_size(); ++i) {
     ros_msg.joint_names.push_back(ign_msg.joint_names(i));
   }
 
-  for (auto i = 0; i < ign_msg.points_size(); ++i)
-  {
+  for (auto i = 0; i < ign_msg.points_size(); ++i) {
     trajectory_msgs::msg::JointTrajectoryPoint ros_point;
     convert_ign_to_ros(ign_msg.points(i), ros_point);
     ros_msg.points.push_back(ros_point);

--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -1055,4 +1055,98 @@ convert_ign_to_ros(
   ros_msg.present = true;
 }
 
+template<>
+void
+convert_ros_to_ign(
+  const trajectory_msgs::msg::JointTrajectoryPoint & ros_msg,
+  ignition::msgs::JointTrajectoryPoint & ign_msg)
+{
+  for (const auto & ros_position : ros_msg.positions)
+  {
+    ign_msg.add_positions(ros_position);
+  }
+  for (const auto & ros_velocitie : ros_msg.velocities)
+  {
+    ign_msg.add_velocities(ros_velocitie);
+  }
+  for (const auto & ros_acceleration : ros_msg.accelerations)
+  {
+    ign_msg.add_accelerations(ros_acceleration);
+  }
+  for (const auto & ros_effort : ros_msg.effort)
+  {
+    ign_msg.add_effort(ros_effort);
+  }
+
+  ignition::msgs::Duration * ign_duration = ign_msg.mutable_time_from_start();
+  ign_duration->set_sec(ros_msg.time_from_start.sec);
+  ign_duration->set_nsec(ros_msg.time_from_start.nanosec);
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::JointTrajectoryPoint & ign_msg,
+  trajectory_msgs::msg::JointTrajectoryPoint & ros_msg)
+{
+  for (auto i = 0; i < ign_msg.positions_size(); ++i)
+  {
+    ros_msg.positions.push_back(ign_msg.positions(i));
+  }
+  for (auto i = 0; i < ign_msg.velocities_size(); ++i)
+  {
+    ros_msg.velocities.push_back(ign_msg.velocities(i));
+  }
+  for (auto i = 0; i < ign_msg.accelerations_size(); ++i)
+  {
+    ros_msg.accelerations.push_back(ign_msg.accelerations(i));
+  }
+  for (auto i = 0; i < ign_msg.effort_size(); ++i)
+  {
+    ros_msg.effort.push_back(ign_msg.effort(i));
+  }
+
+  ros_msg.time_from_start = rclcpp::Duration(ign_msg.time_from_start().sec(), ign_msg.time_from_start().nsec());
+}
+
+template<>
+void
+convert_ros_to_ign(
+  const trajectory_msgs::msg::JointTrajectory & ros_msg,
+  ignition::msgs::JointTrajectory & ign_msg)
+{
+  convert_ros_to_ign(ros_msg.header, (*ign_msg.mutable_header()));
+
+  for (const auto & ros_joint_name : ros_msg.joint_names)
+  {
+    ign_msg.add_joint_names(ros_joint_name);
+  }
+
+  for (const auto & ros_point : ros_msg.points) {
+    ignition::msgs::JointTrajectoryPoint * ign_point = ign_msg.add_points();
+    convert_ros_to_ign(ros_point, (*ign_point));
+  }
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::JointTrajectory & ign_msg,
+  trajectory_msgs::msg::JointTrajectory & ros_msg)
+{
+  convert_ign_to_ros(ign_msg.header(), ros_msg.header);
+
+  for (auto i = 0; i < ign_msg.joint_names_size(); ++i)
+  {
+    ros_msg.joint_names.push_back(ign_msg.joint_names(i));
+  }
+
+  for (auto i = 0; i < ign_msg.points_size(); ++i)
+  {
+    trajectory_msgs::msg::JointTrajectoryPoint ros_point;
+    convert_ign_to_ros(ign_msg.points(i), ros_point);
+    ros_msg.points.push_back(ros_point);
+  }
+}
+
 }  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/factories.cpp
+++ b/ros_ign_bridge/src/factories.cpp
@@ -311,6 +311,16 @@ get_factory_impl(
       >
     >("sensor_msgs/msg/BatteryState", ign_type_name);
   }
+  if ((ros_type_name == "trajectory_msgs/msg/JointTrajectory" || ros_type_name.empty()) &&
+    ign_type_name == "ignition.msgs.JointTrajectory")
+  {
+    return std::make_shared<
+      Factory<
+        trajectory_msgs::msg::JointTrajectory,
+        ignition::msgs::JointTrajectory
+      >
+    >("trajectory_msgs/msg/JointTrajectory", ign_type_name);
+  }
   return std::shared_ptr<FactoryInterface>();
 }
 
@@ -1005,6 +1015,55 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::BatteryState & ign_msg,
   sensor_msgs::msg::BatteryState & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+// trajectory_msgs
+template<>
+void
+Factory<
+  trajectory_msgs::msg::JointTrajectoryPoint,
+  ignition::msgs::JointTrajectoryPoint
+>::convert_ros_to_ign(
+  const trajectory_msgs::msg::JointTrajectoryPoint & ros_msg,
+  ignition::msgs::JointTrajectoryPoint & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  trajectory_msgs::msg::JointTrajectoryPoint,
+  ignition::msgs::JointTrajectoryPoint
+>::convert_ign_to_ros(
+  const ignition::msgs::JointTrajectoryPoint & ign_msg,
+  trajectory_msgs::msg::JointTrajectoryPoint & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  trajectory_msgs::msg::JointTrajectory,
+  ignition::msgs::JointTrajectory
+>::convert_ros_to_ign(
+  const trajectory_msgs::msg::JointTrajectory & ros_msg,
+  ignition::msgs::JointTrajectory & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  trajectory_msgs::msg::JointTrajectory,
+  ignition::msgs::JointTrajectory
+>::convert_ign_to_ros(
+  const ignition::msgs::JointTrajectory & ign_msg,
+  trajectory_msgs::msg::JointTrajectory & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
 }

--- a/ros_ign_bridge/src/factories.hpp
+++ b/ros_ign_bridge/src/factories.hpp
@@ -41,6 +41,7 @@
 #include <std_msgs/msg/int32.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 // Ignition messages
 #include <ignition/msgs.hh>
@@ -570,6 +571,44 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::BatteryState & ign_msg,
   sensor_msgs::msg::BatteryState & ros_msg);
+
+// trajectory_msgs
+template<>
+void
+Factory<
+  trajectory_msgs::msg::JointTrajectoryPoint,
+  ignition::msgs::JointTrajectoryPoint
+>::convert_ros_to_ign(
+  const trajectory_msgs::msg::JointTrajectoryPoint & ros_msg,
+  ignition::msgs::JointTrajectoryPoint & ign_msg);
+
+template<>
+void
+Factory<
+  trajectory_msgs::msg::JointTrajectoryPoint,
+  ignition::msgs::JointTrajectoryPoint
+>::convert_ign_to_ros(
+  const ignition::msgs::JointTrajectoryPoint & ign_msg,
+  trajectory_msgs::msg::JointTrajectoryPoint & ros_msg);
+
+
+template<>
+void
+Factory<
+  trajectory_msgs::msg::JointTrajectory,
+  ignition::msgs::JointTrajectory
+>::convert_ros_to_ign(
+  const trajectory_msgs::msg::JointTrajectory & ros_msg,
+  ignition::msgs::JointTrajectory & ign_msg);
+
+template<>
+void
+Factory<
+  trajectory_msgs::msg::JointTrajectory,
+  ignition::msgs::JointTrajectory
+>::convert_ign_to_ros(
+  const ignition::msgs::JointTrajectory & ign_msg,
+  trajectory_msgs::msg::JointTrajectory & ros_msg);
 
 }  // namespace ros_ign_bridge
 

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
@@ -65,7 +65,8 @@ def generate_test_description():
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
-          '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState'
+          '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',
+          '/joint_trajectory@trajectory_msgs/msg/JointTrajectory@ignition.msgs.JointTrajectory'
         ],
         output='screen'
     )

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
@@ -65,7 +65,8 @@ def generate_test_description():
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
-          '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState'
+          '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',
+          '/joint_trajectory@trajectory_msgs/msg/JointTrajectory@ignition.msgs.JointTrajectory'
         ],
         output='screen'
     )

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -187,6 +187,11 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::BatteryState battery_state_msg;
   ros_ign_bridge::testing::createTestMsg(battery_state_msg);
 
+  // ignition::msgs::JointTrajectory.
+  auto joint_trajectory_pub = node.Advertise<ignition::msgs::JointTrajectory>("joint_trajectory");
+  ignition::msgs::JointTrajectory joint_trajectory_msg;
+  ros_ign_bridge::testing::createTestMsg(joint_trajectory_msg);
+
   // Publish messages at 1Hz.
   while (!g_terminatePub) {
     bool_pub.Publish(bool_msg);
@@ -216,6 +221,7 @@ int main(int /*argc*/, char **/*argv*/)
     twist_pub.Publish(twist_msg);
     pointcloudpacked_pub.Publish(pointcloudpacked_msg);
     battery_state_pub.Publish(battery_state_msg);
+    joint_trajectory_pub.Publish(joint_trajectory_msg);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -38,6 +38,7 @@
 #include <std_msgs/msg/float64.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include "../test_utils.hpp"
 
@@ -203,6 +204,12 @@ int main(int argc, char ** argv)
   sensor_msgs::msg::BatteryState battery_state_msg;
   ros_ign_bridge::testing::createTestMsg(battery_state_msg);
 
+  // trajectory_msgs::msg::JointTrajectory.
+  auto joint_trajectory_pub =
+    node->create_publisher<trajectory_msgs::msg::JointTrajectory>("joint_trajectory", 1000);
+  trajectory_msgs::msg::JointTrajectory joint_trajectory_msg;
+  ros_ign_bridge::testing::createTestMsg(joint_trajectory_msg);
+
   while (rclcpp::ok()) {
     // Publish all messages.
     bool_pub->publish(bool_msg);
@@ -232,6 +239,7 @@ int main(int argc, char ** argv)
     joint_states_pub->publish(joint_states_msg);
     pointcloud2_pub->publish(pointcloud2_msg);
     battery_state_pub->publish(battery_state_msg);
+    joint_trajectory_pub->publish(joint_trajectory_msg);
 
     rclcpp::spin_some(node);
     loop_rate.sleep();

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -38,8 +38,8 @@
 #include <std_msgs/msg/float64.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <std_msgs/msg/string.hpp>
-#include <trajectory_msgs/msg/joint_trajectory.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 #include "../test_utils.hpp"
 
 //////////////////////////////////////////////////

--- a/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
@@ -380,6 +380,18 @@ TEST(IgnSubscriberTest, BatteryState)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, JointTrajectory)
+{
+  MyTestClass<ignition::msgs::JointTrajectory> client("joint_trajectory");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 100ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
@@ -41,8 +41,8 @@
 #include "std_msgs/msg/float32.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "std_msgs/msg/string.hpp"
-#include "trajectory_msgs/msg/joint_trajectory.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+#include "trajectory_msgs/msg/joint_trajectory.hpp"
 
 #include "../test_utils.hpp"
 

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
@@ -41,6 +41,7 @@
 #include "std_msgs/msg/float32.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "trajectory_msgs/msg/joint_trajectory.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 
 #include "../test_utils.hpp"
@@ -399,6 +400,18 @@ TEST(ROSSubscriberTest, PointCloud2)
 TEST(ROSSubscriberTest, BatteryState)
 {
   MyTestClass<sensor_msgs::msg::BatteryState> client("battery_state");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    node, client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROSSubscriberTest, JointTrajectory)
+{
+  MyTestClass<trajectory_msgs::msg::JointTrajectory> client("joint_trajectory");
 
   using namespace std::chrono_literals;
   ros_ign_bridge::testing::waitUntilBoolVarAndSpin(

--- a/ros_ign_bridge/test/test_utils.hpp
+++ b/ros_ign_bridge/test/test_utils.hpp
@@ -886,9 +886,9 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::BatteryState> & _msg
 /// \param[out] _msg The message populated.
 void createTestMsg(trajectory_msgs::msg::JointTrajectoryPoint & _msg)
 {
-  const auto NUMBER_OF_JOINTS = 7;
+  const auto number_of_joints = 7;
 
-  for (auto i = 0; i < NUMBER_OF_JOINTS; ++i) {
+  for (auto i = 0; i < number_of_joints; ++i) {
     _msg.positions.push_back(1.1 * i);
     _msg.velocities.push_back(2.2 * i);
     _msg.accelerations.push_back(3.3 * i);
@@ -929,18 +929,18 @@ void compareTestMsg(const std::shared_ptr<trajectory_msgs::msg::JointTrajectoryP
 /// \param[out] _msg The message populated.
 void createTestMsg(trajectory_msgs::msg::JointTrajectory & _msg)
 {
-  const auto NUMBER_OF_JOINTS = 7;
-  const auto NUMBER_OF_TRAJECTORY_POINTS = 10;
+  const auto number_of_joints = 7;
+  const auto number_of_trajectory_points = 10;
 
   std_msgs::msg::Header header_msg;
   createTestMsg(header_msg);
   _msg.header = header_msg;
 
-  for (auto i = 0; i < NUMBER_OF_JOINTS; ++i) {
+  for (auto i = 0; i < number_of_joints; ++i) {
     _msg.joint_names.push_back("joint_" + std::to_string(i));
   }
 
-  for (auto j = 0; j < NUMBER_OF_TRAJECTORY_POINTS; ++j) {
+  for (auto j = 0; j < number_of_trajectory_points; ++j) {
     trajectory_msgs::msg::JointTrajectoryPoint point;
     createTestMsg(point);
     _msg.points.push_back(point);
@@ -1720,8 +1720,9 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::BatteryState> & _msg)
 /// \param[out] _msg The message populated.
 void createTestMsg(ignition::msgs::JointTrajectoryPoint & _msg)
 {
-  const auto NUMBER_OF_JOINTS = 7;
-  for (auto i = 0; i < NUMBER_OF_JOINTS; ++i) {
+  const auto number_of_joints = 7;
+
+  for (auto i = 0; i < number_of_joints; ++i) {
     _msg.add_positions(1.1 * i);
     _msg.add_velocities(2.2 * i);
     _msg.add_accelerations(3.3 * i);
@@ -1763,18 +1764,18 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::JointTrajectoryPoint> 
 /// \param[out] _msg The message populated.
 void createTestMsg(ignition::msgs::JointTrajectory & _msg)
 {
-  const auto NUMBER_OF_JOINTS = 7;
-  const auto NUMBER_OF_TRAJECTORY_POINTS = 10;
+  const auto number_of_joints = 7;
+  const auto number_of_trajectory_points = 10;
 
   ignition::msgs::Header header_msg;
   createTestMsg(header_msg);
   _msg.mutable_header()->CopyFrom(header_msg);
 
-  for (auto i = 0; i < NUMBER_OF_JOINTS; ++i) {
+  for (auto i = 0; i < number_of_joints; ++i) {
     _msg.add_joint_names("joint_" + std::to_string(i));
   }
 
-  for (auto j = 0; j < NUMBER_OF_TRAJECTORY_POINTS; ++j) {
+  for (auto j = 0; j < number_of_trajectory_points; ++j) {
     ignition::msgs::JointTrajectoryPoint point;
     createTestMsg(point);
     _msg.add_points();

--- a/ros_ign_bridge/test/test_utils.hpp
+++ b/ros_ign_bridge/test/test_utils.hpp
@@ -49,8 +49,8 @@
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
-#include <trajectory_msgs/msg/joint_trajectory.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 #include <chrono>
 #include <string>

--- a/ros_ign_bridge/test/test_utils.hpp
+++ b/ros_ign_bridge/test/test_utils.hpp
@@ -49,6 +49,7 @@
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 #include <chrono>
@@ -881,6 +882,89 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::BatteryState> & _msg
   EXPECT_EQ(expected_msg.power_supply_status, _msg->power_supply_status);
 }
 
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(trajectory_msgs::msg::JointTrajectoryPoint & _msg)
+{
+  const auto NUMBER_OF_JOINTS = 7;
+
+  for (auto i = 0; i < NUMBER_OF_JOINTS; ++i) {
+    _msg.positions.push_back(1.1 * i);
+    _msg.velocities.push_back(2.2 * i);
+    _msg.accelerations.push_back(3.3 * i);
+    _msg.effort.push_back(4.4 * i);
+  }
+  _msg.time_from_start.sec = 12345;
+  _msg.time_from_start.nanosec = 67890;
+}
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<trajectory_msgs::msg::JointTrajectoryPoint> & _msg)
+{
+  trajectory_msgs::msg::JointTrajectoryPoint expected_msg;
+  createTestMsg(expected_msg);
+
+  for (size_t i = 0; i < _msg->positions.size(); ++i) {
+    EXPECT_EQ(expected_msg.positions[i], _msg->positions[i]);
+  }
+
+  for (size_t i = 0; i < _msg->velocities.size(); ++i) {
+    EXPECT_EQ(expected_msg.velocities[i], _msg->velocities[i]);
+  }
+
+  for (size_t i = 0; i < _msg->accelerations.size(); ++i) {
+    EXPECT_EQ(expected_msg.accelerations[i], _msg->accelerations[i]);
+  }
+
+  for (size_t i = 0; i < _msg->effort.size(); ++i) {
+    EXPECT_EQ(expected_msg.effort[i], _msg->effort[i]);
+  }
+
+  EXPECT_EQ(expected_msg.time_from_start.sec, _msg->time_from_start.sec);
+  EXPECT_EQ(expected_msg.time_from_start.nanosec, _msg->time_from_start.nanosec);
+}
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(trajectory_msgs::msg::JointTrajectory & _msg)
+{
+  const auto NUMBER_OF_JOINTS = 7;
+  const auto NUMBER_OF_TRAJECTORY_POINTS = 10;
+
+  std_msgs::msg::Header header_msg;
+  createTestMsg(header_msg);
+  _msg.header = header_msg;
+
+  for (auto i = 0; i < NUMBER_OF_JOINTS; ++i) {
+    _msg.joint_names.push_back("joint_" + std::to_string(i));
+  }
+
+  for (auto j = 0; j < NUMBER_OF_TRAJECTORY_POINTS; ++j) {
+    trajectory_msgs::msg::JointTrajectoryPoint point;
+    createTestMsg(point);
+    _msg.points.push_back(point);
+  }
+}
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & _msg)
+{
+  trajectory_msgs::msg::JointTrajectory expected_msg;
+  createTestMsg(expected_msg);
+
+  compareTestMsg(_msg->header);
+
+  for (size_t i = 0; i < _msg->joint_names.size(); ++i) {
+    EXPECT_EQ(expected_msg.joint_names[i], _msg->joint_names[i]);
+  }
+
+  for (size_t i = 0; i < _msg->points.size(); ++i) {
+    compareTestMsg(std::make_shared<trajectory_msgs::msg::JointTrajectoryPoint>(_msg->points[i]));
+  }
+}
+
 //////////////////////////////////////////////////
 /// Ignition::msgs test utils
 //////////////////////////////////////////////////
@@ -1631,6 +1715,92 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::BatteryState> & _msg)
   EXPECT_EQ(expected_msg.percentage(), _msg->percentage());
   EXPECT_EQ(expected_msg.power_supply_status(), _msg->power_supply_status());
 }
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ignition::msgs::JointTrajectoryPoint & _msg)
+{
+  const auto NUMBER_OF_JOINTS = 7;
+  for (auto i = 0; i < NUMBER_OF_JOINTS; ++i) {
+    _msg.add_positions(1.1 * i);
+    _msg.add_velocities(2.2 * i);
+    _msg.add_accelerations(3.3 * i);
+    _msg.add_effort(4.4 * i);
+  }
+  auto time_from_start = _msg.mutable_time_from_start();
+  time_from_start->set_sec(12345);
+  time_from_start->set_nsec(67890);
+}
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ignition::msgs::JointTrajectoryPoint> & _msg)
+{
+  ignition::msgs::JointTrajectoryPoint expected_msg;
+  createTestMsg(expected_msg);
+
+  for (int i = 0; i < _msg->positions_size(); ++i) {
+    EXPECT_EQ(expected_msg.positions(i), _msg->positions(i));
+  }
+
+  for (int i = 0; i < _msg->velocities_size(); ++i) {
+    EXPECT_EQ(expected_msg.velocities(i), _msg->velocities(i));
+  }
+
+  for (int i = 0; i < _msg->accelerations_size(); ++i) {
+    EXPECT_EQ(expected_msg.accelerations(i), _msg->accelerations(i));
+  }
+
+  for (int i = 0; i < _msg->effort_size(); ++i) {
+    EXPECT_EQ(expected_msg.effort(i), _msg->effort(i));
+  }
+
+  EXPECT_EQ(expected_msg.time_from_start().sec(), _msg->time_from_start().sec());
+  EXPECT_EQ(expected_msg.time_from_start().nsec(), _msg->time_from_start().nsec());
+}
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ignition::msgs::JointTrajectory & _msg)
+{
+  const auto NUMBER_OF_JOINTS = 7;
+  const auto NUMBER_OF_TRAJECTORY_POINTS = 10;
+
+  ignition::msgs::Header header_msg;
+  createTestMsg(header_msg);
+  _msg.mutable_header()->CopyFrom(header_msg);
+
+  for (auto i = 0; i < NUMBER_OF_JOINTS; ++i) {
+    _msg.add_joint_names("joint_" + std::to_string(i));
+  }
+
+  for (auto j = 0; j < NUMBER_OF_TRAJECTORY_POINTS; ++j) {
+    ignition::msgs::JointTrajectoryPoint point;
+    createTestMsg(point);
+    _msg.add_points();
+    _msg.mutable_points(j)->CopyFrom(point);
+  }
+}
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ignition::msgs::JointTrajectory> & _msg)
+{
+  ignition::msgs::JointTrajectory expected_msg;
+  createTestMsg(expected_msg);
+
+  ASSERT_TRUE(expected_msg.has_header());
+  ASSERT_TRUE(_msg->has_header());
+
+  for (int i = 0; i < _msg->joint_names_size(); ++i) {
+    EXPECT_EQ(expected_msg.joint_names(i), _msg->joint_names(i));
+  }
+
+  for (int i = 0; i < _msg->points_size(); ++i) {
+    compareTestMsg(std::make_shared<ignition::msgs::JointTrajectoryPoint>(_msg->points(i)));
+  }
+}
+
 }  // namespace testing
 }  // namespace ros_ign_bridge
 

--- a/ros_ign_bridge/test/test_utils.hpp
+++ b/ros_ign_bridge/test/test_utils.hpp
@@ -905,19 +905,19 @@ void compareTestMsg(const std::shared_ptr<trajectory_msgs::msg::JointTrajectoryP
   trajectory_msgs::msg::JointTrajectoryPoint expected_msg;
   createTestMsg(expected_msg);
 
-  for (size_t i = 0; i < _msg->positions.size(); ++i) {
+  for (auto i = 0u; i < _msg->positions.size(); ++i) {
     EXPECT_EQ(expected_msg.positions[i], _msg->positions[i]);
   }
 
-  for (size_t i = 0; i < _msg->velocities.size(); ++i) {
+  for (auto i = 0u; i < _msg->velocities.size(); ++i) {
     EXPECT_EQ(expected_msg.velocities[i], _msg->velocities[i]);
   }
 
-  for (size_t i = 0; i < _msg->accelerations.size(); ++i) {
+  for (auto i = 0u; i < _msg->accelerations.size(); ++i) {
     EXPECT_EQ(expected_msg.accelerations[i], _msg->accelerations[i]);
   }
 
-  for (size_t i = 0; i < _msg->effort.size(); ++i) {
+  for (auto i = 0u; i < _msg->effort.size(); ++i) {
     EXPECT_EQ(expected_msg.effort[i], _msg->effort[i]);
   }
 
@@ -956,11 +956,11 @@ void compareTestMsg(const std::shared_ptr<trajectory_msgs::msg::JointTrajectory>
 
   compareTestMsg(_msg->header);
 
-  for (size_t i = 0; i < _msg->joint_names.size(); ++i) {
+  for (auto i = 0u; i < _msg->joint_names.size(); ++i) {
     EXPECT_EQ(expected_msg.joint_names[i], _msg->joint_names[i]);
   }
 
-  for (size_t i = 0; i < _msg->points.size(); ++i) {
+  for (auto i = 0u; i < _msg->points.size(); ++i) {
     compareTestMsg(std::make_shared<trajectory_msgs::msg::JointTrajectoryPoint>(_msg->points[i]));
   }
 }


### PR DESCRIPTION
This PR adds conversion between [`trajectory_msgs/msg/JointTrajectory`](https://github.com/ros2/common_interfaces/blob/foxy/trajectory_msgs/msg/JointTrajectory.msg) and `ignition.msgs.JointTrajectory` (PR - https://github.com/ignitionrobotics/ign-msgs/pull/106).

Direction `ROS 2 -> Ignition Transport` is tested with [`ign_moveit2`](https://github.com/AndrejOrsula/ign_moveit2). However, I did NOT explicitly try `Ignition Transport -> ROS 2` (besides running the automated tests).

CI fails because it is not using fork of `ign-msgs` with `ignition.msgs.JointTrajectory`, hence it cannot be found. I am unsure about the best way to resolve this problem. Any help/suggestions are appreciated :slightly_smiling_face:.

Also, I am currently not using ROS 1 and therefore I unfortunately won't be looking into adding this conversion there.