### PR TITLE
[ros2] Extend plugin path instead of overwriting it in ign_gazebo launch script

### DIFF
--- a/ros_ign_gazebo/launch/ign_gazebo.launch.py
+++ b/ros_ign_gazebo/launch/ign_gazebo.launch.py
@@ -23,7 +23,8 @@ from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
-    env = {'IGN_GAZEBO_SYSTEM_PLUGIN_PATH': environ['LD_LIBRARY_PATH']}
+    env = {'IGN_GAZEBO_SYSTEM_PLUGIN_PATH': ':'.join([environ['IGN_GAZEBO_SYSTEM_PLUGIN_PATH'],
+                                                      environ['LD_LIBRARY_PATH']])}
 
     return LaunchDescription([
         DeclareLaunchArgument('ign_args', default_value='',


### PR DESCRIPTION
`IGN_GAZEBO_SYSTEM_PLUGIN_PATH` is currently being overwritten by `LD_LIBRARY_PATH` when using `ign_gazebo.launch.py`. I am failing to find a mention of `LD_LIBRARY_PATH` with respect to plugins in [Finding resources](https://ignitionrobotics.org/api/gazebo/4.0/resources.html), so I am not sure if it is meant to be an alternative. 

Unless I am missing something, I believe that `IGN_GAZEBO_SYSTEM_PLUGIN_PATH` should be treated the same way in both of these cases for worlds with custom plugins.
- `ign gazebo example.sdf`
- `ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_args:="example.sdf"`

To keep this change backwards compatible for people who export `LD_LIBRARY_PATH` to find custom plugins, I suggest extending `IGN_GAZEBO_SYSTEM_PLUGIN_PATH` with `LD_LIBRARY_PATH` instead of overwriting it.