### PR TITLE
[ROS2] Fix triage for PRs from forks

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 name: Ticket opened
 jobs:


### PR DESCRIPTION
Use the new [pull_request_target event](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/).