### PR TITLE
[ros2] Add default value for plugin path in ign_gazebo launch script 

### DIFF
--- a/ros_ign_gazebo/launch/ign_gazebo.launch.py
+++ b/ros_ign_gazebo/launch/ign_gazebo.launch.py
@@ -23,8 +23,9 @@ from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
-    env = {'IGN_GAZEBO_SYSTEM_PLUGIN_PATH': ':'.join([environ['IGN_GAZEBO_SYSTEM_PLUGIN_PATH'],
-                                                      environ['LD_LIBRARY_PATH']])}
+    env = {'IGN_GAZEBO_SYSTEM_PLUGIN_PATH':
+           ':'.join([environ.get('IGN_GAZEBO_SYSTEM_PLUGIN_PATH', default=''),
+                     environ.get('LD_LIBRARY_PATH', default='')])}
 
     return LaunchDescription([
         DeclareLaunchArgument('ign_args', default_value='',


### PR DESCRIPTION
In https://github.com/ignitionrobotics/ros_ign/pull/122, I have unfortunately introduced a regression in case `IGN_GAZEBO_SYSTEM_PLUGIN_PATH` was not previously set. My mistake... I forgot to test such use case prior to submitting that PR. 

This PR should fix it by having a default value in case it is not set. The same logic is applied also for `LD_LIBRARY_PATH` because a similar issue could occur for non-Linux systems. I am not that familiar with Python, so I am unsure if there is a more standard way of doing this.