### PR TITLE
Add support for Pose_V to PoseArray

### DIFF
--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -18,6 +18,7 @@ service calls. Its support is limited to only the following message types:
 | geometry_msgs/Vector3          | ignition::msgs::Vector3d         |
 | geometry_msgs/Point            | ignition::msgs::Vector3d         |
 | geometry_msgs/Pose             | ignition::msgs::Pose             |
+| geometry_msgs/PoseArray        | ignition::msgs::Pose_V           |
 | geometry_msgs/PoseStamped      | ignition::msgs::Pose             |
 | geometry_msgs/Transform        | ignition::msgs::Pose             |
 | geometry_msgs/TransformStamped | ignition::msgs::Pose             |

--- a/ros_ign_bridge/include/ros_ign_bridge/convert.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert.hpp
@@ -19,6 +19,7 @@
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Vector3.h>
 #include <rosgraph_msgs/Clock.h>
@@ -186,6 +187,18 @@ void
 convert_ign_to_ros(
   const ignition::msgs::Pose & ign_msg,
   geometry_msgs::Pose & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const geometry_msgs::PoseArray & ros_msg,
+  ignition::msgs::Pose_V & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Pose_V & ign_msg,
+  geometry_msgs::PoseArray & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -303,6 +303,38 @@ convert_ign_to_ros(
 template<>
 void
 convert_ros_to_ign(
+  const geometry_msgs::PoseArray & ros_msg,
+  ignition::msgs::Pose_V & ign_msg)
+{
+  ign_msg.clear_pose();
+  for (auto const &t : ros_msg.poses)
+  {
+    auto p = ign_msg.add_pose();
+    convert_ros_to_ign(t, *p);
+  }
+
+  convert_ros_to_ign(ros_msg.header, (*ign_msg.mutable_header()));
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Pose_V & ign_msg,
+  geometry_msgs::PoseArray & ros_msg)
+{
+  ros_msg.poses.clear();
+  for (auto const &p : ign_msg.pose())
+  {
+    geometry_msgs::Pose pose;
+    convert_ign_to_ros(p, pose);
+    ros_msg.poses.push_back(pose);
+  }
+  convert_ign_to_ros(ign_msg.header(), ros_msg.header);
+}
+
+template<>
+void
+convert_ros_to_ign(
   const geometry_msgs::PoseStamped & ros_msg,
   ignition::msgs::Pose & ign_msg)
 {

--- a/ros_ign_bridge/src/factories.cpp
+++ b/ros_ign_bridge/src/factories.cpp
@@ -149,6 +149,17 @@ get_factory_impl(
     >("geometry_msgs/Pose", ign_type_name);
   }
   if (
+    (ros_type_name == "geometry_msgs/PoseArray" || ros_type_name == "") &&
+     ign_type_name == "ignition.msgs.Pose_V")
+  {
+    return std::make_shared<
+      Factory<
+        geometry_msgs::PoseArray,
+        ignition::msgs::Pose_V
+      >
+    >("geometry_msgs/PoseArray", ign_type_name);
+  }
+  if (
     (ros_type_name == "geometry_msgs/PoseStamped" || ros_type_name == "") &&
      ign_type_name == "ignition.msgs.Pose")
   {
@@ -604,6 +615,30 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Pose & ign_msg,
   geometry_msgs::Pose & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::PoseArray,
+  ignition::msgs::Pose_V
+>::convert_ros_to_ign(
+  const geometry_msgs::PoseArray & ros_msg,
+  ignition::msgs::Pose_V & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::PoseArray,
+  ignition::msgs::Pose_V
+>::convert_ign_to_ros(
+  const ignition::msgs::Pose_V & ign_msg,
+  geometry_msgs::PoseArray & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
 }

--- a/ros_ign_bridge/src/factories.hpp
+++ b/ros_ign_bridge/src/factories.hpp
@@ -19,6 +19,7 @@
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Transform.h>
 #include <geometry_msgs/TransformStamped.h>
@@ -260,6 +261,24 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Pose & ign_msg,
   geometry_msgs::Pose & ros_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::PoseArray,
+  ignition::msgs::Pose_V
+>::convert_ros_to_ign(
+  const geometry_msgs::PoseArray & ros_msg,
+  ignition::msgs::Pose_V & ign_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::PoseArray,
+  ignition::msgs::Pose_V
+>::convert_ign_to_ros(
+  const ignition::msgs::Pose_V & ign_msg,
+  geometry_msgs::PoseArray & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch
@@ -14,6 +14,7 @@
               /clock@rosgraph_msgs/Clock@ignition.msgs.Clock
               /point@geometry_msgs/Point@ignition.msgs.Vector3d
               /pose@geometry_msgs/Pose@ignition.msgs.Pose
+              /pose_array@geometry_msgs/PoseArray@ignition.msgs.Pose_V
               /pose_stamped@geometry_msgs/PoseStamped@ignition.msgs.Pose
               /transform@geometry_msgs/Transform@ignition.msgs.Pose
               /transform_stamped@geometry_msgs/TransformStamped@ignition.msgs.Pose

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch
@@ -14,6 +14,7 @@
               /clock@rosgraph_msgs/Clock@ignition.msgs.Clock
               /point@geometry_msgs/Point@ignition.msgs.Vector3d
               /pose@geometry_msgs/Pose@ignition.msgs.Pose
+              /pose_array@geometry_msgs/PoseArray@ignition.msgs.Pose_V
               /pose_stamped@geometry_msgs/PoseStamped@ignition.msgs.Pose
               /transform@geometry_msgs/Transform@ignition.msgs.Pose
               /transform_stamped@geometry_msgs/TransformStamped@ignition.msgs.Pose

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -108,7 +108,7 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::Pose pose_stamped_msg;
   ros_ign_bridge::testing::createTestMsg(pose_stamped_msg);
 
-  // ignition::msgs::PoseStamped.
+  // ignition::msgs::Pose_V.
   auto pose_v_pub = node.Advertise<ignition::msgs::Pose_V>("pose_array");
   ignition::msgs::Pose_V pose_v_msg;
   ros_ign_bridge::testing::createTestMsg(pose_v_msg);

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -108,6 +108,11 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::Pose pose_stamped_msg;
   ros_ign_bridge::testing::createTestMsg(pose_stamped_msg);
 
+  // ignition::msgs::PoseStamped.
+  auto pose_v_pub = node.Advertise<ignition::msgs::Pose_V>("pose_array");
+  ignition::msgs::Pose_V pose_v_msg;
+  ros_ign_bridge::testing::createTestMsg(pose_v_msg);
+
   // ignition::msgs::Transform.
   auto transform_pub =
       node.Advertise<ignition::msgs::Pose>("transform");
@@ -201,6 +206,7 @@ int main(int /*argc*/, char **/*argv*/)
     clock_pub.Publish(clock_msg);
     point_pub.Publish(point_msg);
     pose_pub.Publish(pose_msg);
+    pose_v_pub.Publish(pose_v_msg);
     pose_stamped_pub.Publish(pose_stamped_msg);
     transform_pub.Publish(transform_msg);
     transform_stamped_pub.Publish(transform_stamped_msg);

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -24,6 +24,7 @@
 #include <geometry_msgs/Vector3.h>
 #include <rosgraph_msgs/Clock.h>
 #include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Transform.h>
 #include <geometry_msgs/TransformStamped.h>
@@ -107,6 +108,12 @@ int main(int argc, char ** argv)
     n.advertise<geometry_msgs::Pose>("pose", 1000);
   geometry_msgs::Pose pose_msg;
   ros_ign_bridge::testing::createTestMsg(pose_msg);
+
+  // geometry_msgs::PoseArray.
+  ros::Publisher pose_array_pub =
+    n.advertise<geometry_msgs::PoseArray>("pose_array", 1000);
+  geometry_msgs::PoseArray pose_array_msg;
+  ros_ign_bridge::testing::createTestMsg(pose_array_msg);
 
   // geometry_msgs::PoseStamped.
   ros::Publisher pose_stamped_pub =
@@ -218,6 +225,7 @@ int main(int argc, char ** argv)
     clock_pub.publish(clock_msg);
     point_pub.publish(point_msg);
     pose_pub.publish(pose_msg);
+    pose_array_pub.publish(pose_array_msg);
     pose_stamped_pub.publish(pose_stamped_msg);
     transform_pub.publish(transform_msg);
     transform_stamped_pub.publish(transform_stamped_msg);

--- a/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
@@ -168,6 +168,18 @@ TEST(IgnSubscriberTest, Pose)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, Pose_V)
+{
+  MyTestClass<ignition::msgs::Pose_V> client("pose_array");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(IgnSubscriberTest, PoseStamped)
 {
   MyTestClass<ignition::msgs::Pose> client("pose_stamped");

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
@@ -24,6 +24,7 @@
 #include <std_msgs/String.h>
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Transform.h>
 #include <geometry_msgs/TransformStamped.h>
@@ -197,6 +198,18 @@ TEST(ROSSubscriberTest, Point)
 TEST(ROSSubscriberTest, Pose)
 {
   MyTestClass<geometry_msgs::Pose> client("pose");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROSSubscriberTest, PoseArray)
+{
+  MyTestClass<geometry_msgs::PoseArray> client("pose_array");
 
   using namespace std::chrono_literals;
   ros_ign_bridge::testing::waitUntilBoolVarAndSpin(

--- a/ros_ign_bridge/test/test_utils.h
+++ b/ros_ign_bridge/test/test_utils.h
@@ -28,6 +28,7 @@
 #include <std_msgs/String.h>
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Transform.h>
 #include <geometry_msgs/TransformStamped.h>
@@ -303,6 +304,25 @@ namespace testing
   {
     compareTestMsg(_msg.position);
     compareTestMsg(_msg.orientation);
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(geometry_msgs::PoseArray &_msg)
+  {
+    geometry_msgs::Pose pose;
+    createTestMsg(pose);
+    _msg.poses.push_back(pose);
+
+    createTestMsg(_msg.header);
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const geometry_msgs::PoseArray &_msg)
+  {
+    compareTestMsg(_msg.poses[0]);
+    compareTestMsg(_msg.header);
   }
 
   /// \brief Create a message used for testing.


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>

# Pose_V to PoseArray Support

## Summary

Adds the ability to translate between an Ignition Pose_V and a ROS geometry_msgs::PoseArray

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**


