### PR TITLE
Prevent segfault caused by missing values in sensor_msgs::JointState

### DIFF
--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -867,13 +867,26 @@ convert_ros_to_ign(
 {
   convert_ros_to_ign(ros_msg.header, (*ign_msg.mutable_header()));
 
-  for (auto i = 0u; i < ros_msg.position.size(); ++i)
+  const auto nan = std::numeric_limits<double>::quiet_NaN();
+  for (auto i = 0u; i < ros_msg.name.size(); ++i)
   {
     auto newJoint = ign_msg.add_joint();
     newJoint->set_name(ros_msg.name[i]);
-    newJoint->mutable_axis1()->set_position(ros_msg.position[i]);
-    newJoint->mutable_axis1()->set_velocity(ros_msg.velocity[i]);
-    newJoint->mutable_axis1()->set_force(ros_msg.effort[i]);
+    
+    if (ros_msg.position.size() > i)
+      newJoint->mutable_axis1()->set_position(ros_msg.position[i]);
+    else
+      newJoint->mutable_axis1()->set_position(nan);
+    
+    if (ros_msg.velocity.size() > i)
+      newJoint->mutable_axis1()->set_velocity(ros_msg.velocity[i]);
+    else
+      newJoint->mutable_axis1()->set_velocity(nan);
+    
+    if (ros_msg.effort.size() > i)
+      newJoint->mutable_axis1()->set_force(ros_msg.effort[i]);
+    else
+      newJoint->mutable_axis1()->set_force(nan);
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Currently, if you send a JointState message with uneven number of items in e.g. velocity and position fields, the parameter bridge would segfault.

This PR fixes that. All missing values are substituted with NaN on the Ignition side.

This is helpful if the JointState message is used for control, or if some quantities cannot be measured for a joint (this allows to leave the whole field empty instead of manually filling NaNs/zeros in it).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**