### PR TITLE
Add std_msgs/Int32

### DIFF
--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -11,6 +11,7 @@ service calls. Its support is limited to only the following message types:
 | std_msgs/Bool                  | ignition::msgs::Boolean          |
 | std_msgs/ColorRGBA             | ignition::msgs::Color            |
 | std_msgs/Empty                 | ignition::msgs::Empty            |
+| std_msgs/Int32                 | ignition::msgs::Int32            |
 | std_msgs/Float32               | ignition::msgs::Float            |
 | std_msgs/Float64               | ignition::msgs::Double           |
 | std_msgs/Header                | ignition::msgs::Header           |

--- a/ros_ign_bridge/include/ros_ign_bridge/convert.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert.hpp
@@ -43,6 +43,7 @@
 #include <std_msgs/Float32.h>
 #include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
+#include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 #include <tf2_msgs/TFMessage.h>
 #include <visualization_msgs/Marker.h>
@@ -92,6 +93,18 @@ void
 convert_ign_to_ros(
   const ignition::msgs::Empty & ign_msg,
   std_msgs::Empty & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const std_msgs::Int32 & ros_msg,
+  ignition::msgs::Int32 & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Int32 & ign_msg,
+  std_msgs::Int32 & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -119,6 +119,24 @@ convert_ign_to_ros(
 template<>
 void
 convert_ros_to_ign(
+  const std_msgs::Int32 & ros_msg,
+  ignition::msgs::Int32 & ign_msg)
+{
+  ign_msg.set_data(ros_msg.data);
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Int32 & ign_msg,
+  std_msgs::Int32 & ros_msg)
+{
+  ros_msg.data = ign_msg.data();
+}
+
+template<>
+void
+convert_ros_to_ign(
   const std_msgs::Float32 & ros_msg,
   ignition::msgs::Float & ign_msg)
 {

--- a/ros_ign_bridge/src/factories.cpp
+++ b/ros_ign_bridge/src/factories.cpp
@@ -61,6 +61,17 @@ get_factory_impl(
     >("std_msgs/Empty", ign_type_name);
   }
   if (
+    (ros_type_name == "std_msgs/Int32" || ros_type_name == "") &&
+     ign_type_name == "ignition.msgs.Int32")
+  {
+    return std::make_shared<
+      Factory<
+        std_msgs::Int32,
+        ignition::msgs::Int32
+      >
+    >("std_msgs/Int32", ign_type_name);
+  }
+  if (
     (ros_type_name == "std_msgs/Float32" || ros_type_name == "") &&
      ign_type_name == "ignition.msgs.Float")
   {
@@ -456,6 +467,30 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Empty & ign_msg,
   std_msgs::Empty & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Int32,
+  ignition::msgs::Int32
+>::convert_ros_to_ign(
+  const std_msgs::Int32 & ros_msg,
+  ignition::msgs::Int32 & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Int32,
+  ignition::msgs::Int32
+>::convert_ign_to_ros(
+  const ignition::msgs::Int32 & ign_msg,
+  std_msgs::Int32 & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
 }

--- a/ros_ign_bridge/src/factories.hpp
+++ b/ros_ign_bridge/src/factories.hpp
@@ -43,6 +43,7 @@
 #include <std_msgs/Float32.h>
 #include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
+#include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 #include <tf2_msgs/TFMessage.h>
 #include <visualization_msgs/Marker.h>
@@ -118,6 +119,24 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Empty & ign_msg,
   std_msgs::Empty & ros_msg);
+
+template<>
+void
+Factory<
+  std_msgs::Int32,
+  ignition::msgs::Int32
+>::convert_ros_to_ign(
+  const std_msgs::Int32 & ros_msg,
+  ignition::msgs::Int32 & ign_msg);
+
+template<>
+void
+Factory<
+  std_msgs::Int32,
+  ignition::msgs::Int32
+>::convert_ign_to_ros(
+  const ignition::msgs::Int32 & ign_msg,
+  std_msgs::Int32 & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch
@@ -6,6 +6,7 @@
         args="/bool@std_msgs/Bool@ignition.msgs.Boolean
               /color@std_msgs/ColorRGBA@ignition.msgs.Color
               /empty@std_msgs/Empty@ignition.msgs.Empty
+              /int32@std_msgs/Int32@ignition.msgs.Int32
               /float@std_msgs/Float32@ignition.msgs.Float
               /double@std_msgs/Float64@ignition.msgs.Double
               /header@std_msgs/Header@ignition.msgs.Header

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch
@@ -6,6 +6,7 @@
         args="/bool@std_msgs/Bool@ignition.msgs.Boolean
               /color@std_msgs/ColorRGBA@ignition.msgs.Color
               /empty@std_msgs/Empty@ignition.msgs.Empty
+              /int32@std_msgs/Int32@ignition.msgs.Int32
               /float@std_msgs/Float32@ignition.msgs.Float
               /double@std_msgs/Float64@ignition.msgs.Double
               /header@std_msgs/Header@ignition.msgs.Header

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -62,6 +62,11 @@ int main(int /*argc*/, char **/*argv*/)
   auto empty_pub = node.Advertise<ignition::msgs::Empty>("empty");
   ignition::msgs::Empty empty_msg;
 
+  // ignition::msgs::Int32.
+  auto int32_pub = node.Advertise<ignition::msgs::Int32>("int32");
+  ignition::msgs::Int32 int32_msg;
+  ros_ign_bridge::testing::createTestMsg(int32_msg);
+
   // ignition::msgs::Float.
   auto float_pub = node.Advertise<ignition::msgs::Float>("float");
   ignition::msgs::Float float_msg;
@@ -211,6 +216,7 @@ int main(int /*argc*/, char **/*argv*/)
     bool_pub.Publish(bool_msg);
     color_pub.Publish(color_msg);
     empty_pub.Publish(empty_msg);
+    int32_pub.Publish(int32_msg);
     float_pub.Publish(float_msg);
     double_pub.Publish(double_msg);
     header_pub.Publish(header_msg);

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -20,6 +20,7 @@
 #include <std_msgs/Float32.h>
 #include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
+#include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Vector3.h>
@@ -67,11 +68,16 @@ int main(int argc, char ** argv)
   ros::Publisher empty_pub = n.advertise<std_msgs::Empty>("empty", 1000);
   std_msgs::Empty empty_msg;
 
+  // std_msgs::Int32.
+  ros::Publisher int32_pub = n.advertise<std_msgs::Int32>("int32", 1000);
+  std_msgs::Int32 int32_msg;
+  ros_ign_bridge::testing::createTestMsg(int32_msg);
+
   // std_msgs::Float32.
   ros::Publisher float_pub = n.advertise<std_msgs::Float32>("float", 1000);
   std_msgs::Float32 float_msg;
   ros_ign_bridge::testing::createTestMsg(float_msg);
-  
+
   // std_msgs::Float64.
   ros::Publisher double_pub = n.advertise<std_msgs::Float64>("double", 1000);
   std_msgs::Float64 double_msg;
@@ -237,6 +243,7 @@ int main(int argc, char ** argv)
     bool_pub.publish(bool_msg);
     color_pub.publish(color_msg);
     empty_pub.publish(empty_msg);
+    int32_pub.publish(int32_msg);
     float_pub.publish(float_msg);
     double_pub.publish(double_msg);
     header_pub.publish(header_msg);

--- a/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
@@ -84,6 +84,18 @@ TEST(IgnSubscriberTest, Empty)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, Int32)
+{
+  MyTestClass<ignition::msgs::Int32> client("int32");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(IgnSubscriberTest, Float)
 {
   MyTestClass<ignition::msgs::Float> client("float");

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
@@ -22,6 +22,7 @@
 #include <std_msgs/Float32.h>
 #include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
+#include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Pose.h>
@@ -105,6 +106,18 @@ TEST(ROSSubscriberTest, ColorRGBA)
 TEST(ROSSubscriberTest, Empty)
 {
   MyTestClass<std_msgs::Empty> client("empty");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROSSubscriberTest, Int32)
+{
+  MyTestClass<std_msgs::Int32> client("int32");
 
   using namespace std::chrono_literals;
   ros_ign_bridge::testing::waitUntilBoolVarAndSpin(

--- a/ros_ign_bridge/test/test_utils.h
+++ b/ros_ign_bridge/test/test_utils.h
@@ -25,6 +25,7 @@
 #include <std_msgs/Float32.h>
 #include <std_msgs/Float64.h>
 #include <std_msgs/Header.h>
+#include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Pose.h>
@@ -160,16 +161,33 @@ namespace testing
 
   /// \brief Create a message used for testing.
   /// \param[out] _msg The message populated.
+  void createTestMsg(std_msgs::Int32 &_msg)
+  {
+    _msg.data = 5;
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
   void createTestMsg(std_msgs::Float32 &_msg)
   {
     _msg.data = 1.5;
   }
-  
+
   /// \brief Create a message used for testing.
   /// \param[out] _msg The message populated.
   void createTestMsg(std_msgs::Float64 &_msg)
   {
     _msg.data = 1.5;
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const std_msgs::Int32 &_msg)
+  {
+    std_msgs::Int32 expected_msg;
+    createTestMsg(expected_msg);
+
+    EXPECT_EQ(expected_msg.data, _msg.data);
   }
 
   /// \brief Compare a message with the populated for testing.
@@ -181,7 +199,7 @@ namespace testing
 
     EXPECT_FLOAT_EQ(expected_msg.data, _msg.data);
   }
-  
+
   /// \brief Compare a message with the populated for testing.
   /// \param[in] _msg The message to compare.
   void compareTestMsg(const std_msgs::Float64 &_msg)
@@ -998,6 +1016,23 @@ namespace testing
   /// \param[in] _msg The message to compare.
   void compareTestMsg(const ignition::msgs::Empty &)
   {
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(ignition::msgs::Int32 &_msg)
+  {
+    _msg.set_data(5);
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const ignition::msgs::Int32 &_msg)
+  {
+    ignition::msgs::Int32 expected_msg;
+    createTestMsg(expected_msg);
+
+    EXPECT_EQ(expected_msg.data(), _msg.data());
   }
 
   /// \brief Create a message used for testing.


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary
 support bridging `ignition.msgs.Int32` <-> `std_msgs/Int32`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
