### PR TITLE
Drop melodic/blueprint end-of-life configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 
 env:
   matrix:
-    - DOCKER_IMAGE=ubuntu:18.04 IGNITION_VERSION="blueprint" ROS_DISTRO="melodic"
     - DOCKER_IMAGE=ubuntu:18.04 IGNITION_VERSION="citadel" ROS_DISTRO="melodic"
     - DOCKER_IMAGE=ubuntu:18.04 IGNITION_VERSION="dome" ROS_DISTRO="melodic"
 


### PR DESCRIPTION
Blueprint is end-of-life, I don't think we need to keep CI runing on it.

Signed-off-by: Michael Carroll <michael@openrobotics.org>