### PR TITLE
[ros2] Minor updates for demos

### DIFF
--- a/ros_ign_gazebo_demos/README.md
+++ b/ros_ign_gazebo_demos/README.md
@@ -12,8 +12,6 @@ There's a convenient launch file, try for example:
 
 ## Air pressure
 
-*TODO*: Pending bridge for `sensor_msgs/msg/FluidPressure`, [issue](https://github.com/osrf/ros_ign/issues/78).
-
 Publishes fluid pressure readings.
 
     ros2 launch ros_ign_gazebo_demos air_pressure.launch.py

--- a/ros_ign_gazebo_demos/README.md
+++ b/ros_ign_gazebo_demos/README.md
@@ -55,7 +55,7 @@ Depth camera data can be obtained as:
 
 Using the image bridge (unidirectional, uses [image_transport](http://wiki.ros.org/image_transport)):
 
-    ros2 launch ros_ign_gazebo_demos image_bridge.launch.py
+    ros2 launch ros_ign_gazebo_demos image_bridge.launch.py image_topic:=/depth_camera
 
 *TODO*: Blocked by `ros_ign_point_cloud` [issue](https://github.com/osrf/ros_ign/issues/40).
 
@@ -111,7 +111,10 @@ RGBD camera data can be obtained as:
 
 Using the image bridge (unidirectional, uses [image_transport](http://wiki.ros.org/image_transport)):
 
-    ros2 launch ros_ign_gazebo_demos image_bridge.launch.py
+    # RGB image
+    ros2 launch ros_ign_gazebo_demos image_bridge.launch.py image_topic:=/rgbd_camera/image
+    # Depth image
+    ros2 launch ros_ign_gazebo_demos image_bridge.launch.py image_topic:=/rgbd_camera/depth_image
 
 Using the regular bridge:
 

--- a/ros_ign_gazebo_demos/launch/air_pressure.launch.py
+++ b/ros_ign_gazebo_demos/launch/air_pressure.launch.py
@@ -27,23 +27,18 @@ from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
 
-# TODO; execution broken
-# Failed to create a bridge for topic [/air_pressure] with ROS2 type
-# [sensor_msgs/FluidPressure] and Ignition Transport type
-# [ignition.msgs.FluidPressure]
 
 def generate_launch_description():
 
     pkg_ros_ign_gazebo = get_package_share_directory('ros_ign_gazebo')
 
     # Bridge
-    # TODO: Needs sensor_msgs/msg/FluidPressure to be supported on bridge
-    # bridge = Node(
-    #     package='ros_ign_bridge',
-    #     executable='parameter_bridge',
-    #     arguments=["/air_pressure@sensor_msgs/msg/FluidPressure@ignition.msgs.FluidPressure"],
-    #     output='screen'
-    # )
+    bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        arguments=["/air_pressure@sensor_msgs/msg/FluidPressure@ignition.msgs.FluidPressure"],
+        output='screen'
+    )
 
     ign_gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
@@ -62,6 +57,6 @@ def generate_launch_description():
         ign_gazebo,
         DeclareLaunchArgument('rqt', default_value='true',
                               description='Open RQt.'),
-        # bridge,
+        bridge,
         rqt
     ])

--- a/ros_ign_gazebo_demos/launch/image_bridge.launch.py
+++ b/ros_ign_gazebo_demos/launch/image_bridge.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
     rqt = Node(
         package='rqt_image_view',
         executable='rqt_image_view',
-        arguments=['/camera'],
+        arguments=[LaunchConfiguration('image_topic')],
         condition=IfCondition(LaunchConfiguration('rqt'))
     )
 
@@ -58,6 +58,8 @@ def generate_launch_description():
         ign_gazebo,
         DeclareLaunchArgument('rqt', default_value='true',
                               description='Open RQt.'),
+        DeclareLaunchArgument('image_topic', default_value='/camera',
+                              description='Topic to start viewing in RQt.'),
         bridge,
         rqt
     ])

--- a/ros_ign_gazebo_demos/launch/imu.launch.py
+++ b/ros_ign_gazebo_demos/launch/imu.launch.py
@@ -19,7 +19,9 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
 
@@ -34,6 +36,14 @@ def generate_launch_description():
         launch_arguments={
             'ign_args': '-r sensors.sdf'
         }.items(),
+    )
+
+    # RQt
+    rqt = Node(
+        package='rqt_topic',
+        executable='rqt_topic',
+        arguments=['-t'],
+        condition=IfCondition(LaunchConfiguration('rqt'))
     )
 
     # RViz
@@ -56,8 +66,11 @@ def generate_launch_description():
 
     return LaunchDescription([
         ign_gazebo,
+        DeclareLaunchArgument('rqt', default_value='true',
+                        description='Open RQt.'),
         DeclareLaunchArgument('rviz', default_value='true',
                               description='Open RViz.'),
         bridge,
+        rqt
         # rviz
     ])

--- a/ros_ign_gazebo_demos/rviz/rgbd_camera_bridge.rviz
+++ b/ros_ign_gazebo_demos/rviz/rgbd_camera_bridge.rviz
@@ -56,11 +56,11 @@ Visualization Manager:
       Value: true
     - Class: rviz_default_plugins/Image
       Enabled: true
-      Max Value: 1
+      Max Value: 10
       Median window: 5
       Min Value: 0
       Name: Image
-      Normalize Range: true
+      Normalize Range: false
       Queue Size: 10
       Topic: /rgbd_camera/depth_image
       Unreliable: false


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Few small changes, nothing significant
- Re-enable air pressure demo
   - Fixes #78
- Add `image_topic` launch argument for `image_bridge` demo and use corresponding topics for depth and rgbd camera demos (instead of manually searching for the topic in drop-down menu) 
- Add RQt topic viewer to IMU demo, so that people have a way to see the output until RViz2 has IMU topic visualisation
- Do not normalize depth image in RViz2 config and set its corresponding clip range. This allows it to be viewed (see comparison below - I am not sure about the glitch in the first few pixels though)

Before:
![ros2_ign_rviz2_depth_image_viewer](https://user-images.githubusercontent.com/22929099/112677686-5ba2b700-8e6a-11eb-9ab9-113608eb4214.png)
After:
![ros2_ign_rviz2_depth_image_viewer_fixed](https://user-images.githubusercontent.com/22929099/112677695-5c3b4d80-8e6a-11eb-9b6e-159e48e60028.png)

## Issues not resolved by this PR
The following issues still remain, but they all already have a TODO/FIXME note connected with them:
- All demos blocked by "Blocked by ros_ign_point_cloud issue"
   - Depth camera, RGBD camera, GPU lidar (they all have a TODO note connected with them)
- Battery
   - RQt is not plotting the data properly
   - There is a FIXME for this inside `battery.launch.py` script
- IMU
   - RViz2 still does not seem to have IMU topic visualisation

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge**
