### PR TITLE
[ros2] Add default ign_gazebo version

### DIFF
--- a/ros_ign_gazebo/launch/ign_gazebo.launch.py
+++ b/ros_ign_gazebo/launch/ign_gazebo.launch.py
@@ -14,28 +14,57 @@
 
 """Launch Ignition Gazebo with command line arguments."""
 
-from os import environ
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from catkin_pkg.package import parse_package
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import ExecuteProcess
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
+from launch.launch_context import LaunchContext
 from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
     env = {'IGN_GAZEBO_SYSTEM_PLUGIN_PATH':
-           ':'.join([environ.get('IGN_GAZEBO_SYSTEM_PLUGIN_PATH', default=''),
-                     environ.get('LD_LIBRARY_PATH', default='')])}
+           ':'.join([os.environ.get('IGN_GAZEBO_SYSTEM_PLUGIN_PATH', default=''),
+                     os.environ.get('LD_LIBRARY_PATH', default='')])}
 
     return LaunchDescription([
-        DeclareLaunchArgument('ign_args', default_value='',
-                              description='Arguments to be passed to Ignition Gazebo'),
+        DeclareLaunchArgument(
+            'ign_args', default_value='',
+            description='Arguments to be passed to Ignition Gazebo'),
         ExecuteProcess(
             cmd=['ign gazebo',
-                 LaunchConfiguration('ign_args'),
+                 OpaqueFunction(__get_ign_args)
                  ],
             output='screen',
             additional_env=env,
             shell=True
         )
     ])
+
+
+def __get_ign_args(context: LaunchContext):
+    ign_args = LaunchConfiguration('ign_args').perform(context)
+    if '--force_version' not in ign_args:
+        ign_args += f' --force_version {IGN_GAZEBO_DEFAULT_VERSION}'
+
+    return ign_args
+
+
+def __get_ign_gazebo_default_version():
+    manifest_path = os.path.join(*[get_package_share_directory('ros_ign_gazebo'), 'package.xml'])
+
+    # this will fail if workspace was built with '--merge-install'
+    this_pkg = parse_package(manifest_path)
+
+    this_pkg.evaluate_conditions(os.environ)
+    lookup_name = next(dep.name for dep in this_pkg.exec_depends
+                       if dep.evaluated_condition
+                       if 'ignition-gazebo' in dep.name)
+
+    return lookup_name.replace('ignition-gazebo', '')
+
+
+IGN_GAZEBO_DEFAULT_VERSION = __get_ign_gazebo_default_version()

--- a/ros_ign_gazebo/package.xml
+++ b/ros_ign_gazebo/package.xml
@@ -25,6 +25,9 @@
   <depend condition="$IGNITION_VERSION == citadel">ignition-gazebo3</depend>
   <depend condition="$IGNITION_VERSION == ''">ignition-gazebo3</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>python3-catkin-pkg-modules</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #133 

## Summary
This change uses as the default version the dependency resolved by the package manifest (which uses ignition-gazebo3 for the foxy distro). This is accomplished by appending the flag `--force-version` (only when it's not already set) to the `ign_args`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

- [x] **Depends on**: ignitionrobotics/ign-tools#44 (to allow passing the major version only)

**Note to maintainers**: Remember to use **Squash-Merge**
