### PR TITLE
Default to Edifice for Rolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Eloquent | Blueprint | [dashing](https://github.com/osrf/ros_ign/tree/dashing) |
 Eloquent | Citadel | [dashing](https://github.com/osrf/ros_ign/tree/dashing) | only from source
 Eloquent | Dome | not supported |
 Foxy | Blueprint | not supported |
-Foxy | Citadel | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | https://packages.ros.org
-Foxy | Dome | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | only from source
-Foxy | Edifice | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | only from source
+Foxy | Citadel | [foxy](https://github.com/osrf/ros_ign/tree/foxy) | https://packages.ros.org
+Foxy | Dome | [foxy](https://github.com/osrf/ros_ign/tree/foxy) | only from source
+Foxy | Edifice | [foxy](https://github.com/osrf/ros_ign/tree/foxy) | only from source
 Rolling | Edifice | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | only from source
 
 > Please [ticket an issue](https://github.com/ignitionrobotics/ros_ign/issues/) if you'd like support to be added for some combination.

--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -20,15 +20,15 @@ find_package(std_msgs REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 
-# Edifice
-if("$ENV{IGNITION_VERSION}" STREQUAL "edifice")
-  find_package(ignition-transport10 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
+# Citadel
+if("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
+  find_package(ignition-transport8 REQUIRED)
+  set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
-  find_package(ignition-msgs7 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
+  find_package(ignition-msgs5 REQUIRED)
+  set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
-  message(STATUS "Compiling against Ignition Edifice")
+  message(STATUS "Compiling against Ignition Citadel")
 # Dome
 elseif("$ENV{IGNITION_VERSION}" STREQUAL "dome")
   find_package(ignition-transport9 REQUIRED)
@@ -38,15 +38,15 @@ elseif("$ENV{IGNITION_VERSION}" STREQUAL "dome")
   set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
 
   message(STATUS "Compiling against Ignition Dome")
-# Default to Citadel
+# Default to Edifice
 else()
-  find_package(ignition-transport8 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
+  find_package(ignition-transport10 REQUIRED)
+  set(IGN_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
 
-  find_package(ignition-msgs5 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
+  find_package(ignition-msgs7 REQUIRED)
+  set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
 
-  message(STATUS "Compiling against Ignition Citadel")
+  message(STATUS "Compiling against Ignition Edifice")
 endif()
 
 include_directories(include)

--- a/ros_ign_bridge/package.xml
+++ b/ros_ign_bridge/package.xml
@@ -22,17 +22,17 @@
   <depend>tf2_msgs</depend>
   <depend>trajectory_msgs</depend>
 
-  <!-- Edifice -->
+  <!-- Edifice (default) -->
   <depend condition="$IGNITION_VERSION == edifice">ignition-msgs7</depend>
   <depend condition="$IGNITION_VERSION == edifice">ignition-transport10</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-msgs7</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-transport10</depend>
   <!-- Dome -->
   <depend condition="$IGNITION_VERSION == dome">ignition-msgs6</depend>
   <depend condition="$IGNITION_VERSION == dome">ignition-transport9</depend>
-  <!-- Citadel (default) -->
+  <!-- Citadel -->
   <depend condition="$IGNITION_VERSION == citadel">ignition-msgs5</depend>
   <depend condition="$IGNITION_VERSION == citadel">ignition-transport8</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-msgs5</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-transport8</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/ros_ign_gazebo/CMakeLists.txt
+++ b/ros_ign_gazebo/CMakeLists.txt
@@ -14,18 +14,15 @@ find_package(ament_cmake REQUIRED)
 find_package(ignition-math6 REQUIRED)
 find_package(rclcpp REQUIRED)
 
-# Edifice
-if("$ENV{IGNITION_VERSION}" STREQUAL "edifice")
-  find_package(ignition-transport10 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
+# Citadel
+if("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
+  find_package(ignition-transport8 REQUIRED)
+  set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
-  find_package(ignition-msgs7 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
+  find_package(ignition-msgs5 REQUIRED)
+  set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
-  find_package(ignition-gazebo5 REQUIRED)
-  set(IGN_GAZEBO_VER ${ignition-gazebo5_VERSION_MAJOR})
-
-  message(STATUS "Compiling against Ignition Edifice")
+  message(STATUS "Compiling against Ignition Citadel")
 # Dome
 elseif("$ENV{IGNITION_VERSION}" STREQUAL "dome")
   find_package(ignition-transport9 REQUIRED)
@@ -35,15 +32,15 @@ elseif("$ENV{IGNITION_VERSION}" STREQUAL "dome")
   set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
 
   message(STATUS "Compiling against Ignition Dome")
-# Default to Citadel
+# Default to Edifice
 else()
-  find_package(ignition-transport8 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
+  find_package(ignition-transport10 REQUIRED)
+  set(IGN_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
 
-  find_package(ignition-msgs5 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
+  find_package(ignition-msgs7 REQUIRED)
+  set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
 
-  message(STATUS "Compiling against Ignition Citadel")
+  message(STATUS "Compiling against Ignition Edifice")
 endif()
 
 ign_find_package(gflags

--- a/ros_ign_gazebo/package.xml
+++ b/ros_ign_gazebo/package.xml
@@ -17,13 +17,13 @@
   <depend>rclcpp</depend>
   <depend>ignition-math6</depend>
 
-  <!-- Edifice -->
+  <!-- Edifice (default) -->
   <depend condition="$IGNITION_VERSION == edifice">ignition-gazebo5</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo5</depend>
   <!-- Dome -->
   <depend condition="$IGNITION_VERSION == dome">ignition-gazebo4</depend>
-  <!-- Citadel (default) -->
+  <!-- Citadel -->
   <depend condition="$IGNITION_VERSION == citadel">ignition-gazebo3</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo3</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/ros_ign_gazebo_demos/package.xml
+++ b/ros_ign_gazebo_demos/package.xml
@@ -7,13 +7,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <!-- Edifice -->
+  <!-- Edifice (default) -->
   <exec_depend condition="$IGNITION_VERSION == edifice">ignition-gazebo5</exec_depend>
+  <exec_depend condition="$IGNITION_VERSION == ''">ignition-gazebo5</exec_depend>
   <!-- Dome -->
   <exec_depend condition="$IGNITION_VERSION == dome">ignition-gazebo4</exec_depend>
-  <!-- Citadel (default) -->
+  <!-- Citadel -->
   <exec_depend condition="$IGNITION_VERSION == citadel">ignition-gazebo3</exec_depend>
-  <exec_depend condition="$IGNITION_VERSION == ''">ignition-gazebo3</exec_depend>
 
   <exec_depend>image_transport_plugins</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/ros_ign_image/CMakeLists.txt
+++ b/ros_ign_image/CMakeLists.txt
@@ -16,15 +16,15 @@ find_package(ros_ign_bridge REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-# Edifice
-if("$ENV{IGNITION_VERSION}" STREQUAL "edifice")
-  find_package(ignition-transport10 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
+# Citadel
+if("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
+  find_package(ignition-transport8 REQUIRED)
+  set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
-  find_package(ignition-msgs7 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
+  find_package(ignition-msgs5 REQUIRED)
+  set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
-  message(STATUS "Compiling against Ignition Edifice")
+  message(STATUS "Compiling against Ignition Citadel")
 # Dome
 elseif("$ENV{IGNITION_VERSION}" STREQUAL "dome")
   find_package(ignition-transport9 REQUIRED)
@@ -34,15 +34,15 @@ elseif("$ENV{IGNITION_VERSION}" STREQUAL "dome")
   set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
 
   message(STATUS "Compiling against Ignition Dome")
-# Default to Citadel
+# Default to Edifice
 else()
-  find_package(ignition-transport8 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
+  find_package(ignition-transport10 REQUIRED)
+  set(IGN_TRANSPORT_VER ${ignition-transport10_VERSION_MAJOR})
 
-  find_package(ignition-msgs5 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
+  find_package(ignition-msgs7 REQUIRED)
+  set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
 
-  message(STATUS "Compiling against Ignition Citadel")
+  message(STATUS "Compiling against Ignition Edifice")
 endif()
 
 include_directories(include)

--- a/ros_ign_image/package.xml
+++ b/ros_ign_image/package.xml
@@ -13,17 +13,17 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
 
-  <!-- Edifice -->
+  <!-- Edifice (default) -->
   <depend condition="$IGNITION_VERSION == edifice">ignition-msgs7</depend>
   <depend condition="$IGNITION_VERSION == edifice">ignition-transport10</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-msgs7</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-transport10</depend>
   <!-- Dome -->
   <depend condition="$IGNITION_VERSION == dome">ignition-msgs6</depend>
   <depend condition="$IGNITION_VERSION == dome">ignition-transport9</depend>
-  <!-- Citadel (default) -->
+  <!-- Citadel -->
   <depend condition="$IGNITION_VERSION == citadel">ignition-msgs5</depend>
   <depend condition="$IGNITION_VERSION == citadel">ignition-transport8</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-msgs5</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-transport8</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While releasing `ros_ign` for Rolling, I noticed pretty late during the release process that bloom doesn't respect local conditionals, see https://github.com/ros-infrastructure/bloom/issues/517.

I was using the `ros2` branch to release. That branch supported both Foxy and Rolling. Foxy is supposed to be released with Citadel, and Rolling (future Galactic) with Edifice. For that reason, the branch would default to Citadel if `IGNITION_VERSION` was not set. The problem is that there was no way to pass the env var to bloom to tell it to release with Edifice for Rolling.

The quickest solution right now is branching off for Rolling. I created a new `foxy` branch off the last commit before I created the changelog for the rolling release.

This PR flips the default on the `ros2` branch from Citadel to Edifice. Once this is merged, I'll rerun bloom-release.

CC @nuclearsandwich

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
