### PR TITLE
Fix catkin_testing warning

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -101,39 +101,40 @@ install(TARGETS ${bridge_lib}
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-# Tests
-find_package(rostest REQUIRED)
-
-set(test_publishers
-  ign_publisher
-  ros_publisher
-)
-
-set(test_subscribers
-  ign_subscriber
-  ros_subscriber
-)
-
-foreach(test_publisher ${test_publishers})
-  add_executable(${test_publisher}
-    test/publishers/${test_publisher}.cpp
+if(CATKIN_ENABLE_TESTING)
+  # Tests
+  find_package(rostest REQUIRED)
+  set(test_publishers
+    ign_publisher
+    ros_publisher
   )
-  target_link_libraries(${test_publisher}
-    ${catkin_LIBRARIES}
-    ignition-msgs${IGN_MSGS_VER}::core
-    ignition-transport${IGN_TRANSPORT_VER}::core
-    gtest
-    gtest_main
-  )
-endforeach(test_publisher)
 
-foreach(test_subscriber ${test_subscribers})
-  add_rostest_gtest(test_${test_subscriber}
-    test/${test_subscriber}.test
-    test/subscribers/${test_subscriber}.cpp)
-  target_link_libraries(test_${test_subscriber}
-    ${catkin_LIBRARIES}
-    ignition-msgs${IGN_MSGS_VER}::core
-    ignition-transport${IGN_TRANSPORT_VER}::core
+  set(test_subscribers
+    ign_subscriber
+    ros_subscriber
   )
-endforeach(test_subscriber)
+
+  foreach(test_publisher ${test_publishers})
+    add_executable(${test_publisher}
+      test/publishers/${test_publisher}.cpp
+    )
+    target_link_libraries(${test_publisher}
+      ${catkin_LIBRARIES}
+      ignition-msgs${IGN_MSGS_VER}::core
+      ignition-transport${IGN_TRANSPORT_VER}::core
+      gtest
+      gtest_main
+    )
+  endforeach(test_publisher)
+
+  foreach(test_subscriber ${test_subscribers})
+    add_rostest_gtest(test_${test_subscriber}
+      test/${test_subscriber}.test
+      test/subscribers/${test_subscriber}.cpp)
+    target_link_libraries(test_${test_subscriber}
+      ${catkin_LIBRARIES}
+      ignition-msgs${IGN_MSGS_VER}::core
+      ignition-transport${IGN_TRANSPORT_VER}::core
+    )
+  endforeach(test_subscriber)
+endif()


### PR DESCRIPTION
This PR fixes the following warning:
```
2021-06-13T00:21:23.1437210Z CMake Warning at /usr/local/miniconda/conda-bld/ros_1623543542471/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/share/catkin/cmake/test/tests.cmake:50 (message):
2021-06-13T00:21:23.1472630Z   add_rostest() should only be used inside a conditional block which checks
2021-06-13T00:21:23.1500790Z   that testing is enabled:
2021-06-13T00:21:23.1545630Z 
2021-06-13T00:21:23.1547960Z   if(CATKIN_ENABLE_TESTING)
2021-06-13T00:21:23.1573800Z 
2021-06-13T00:21:23.1574440Z     add_rostest(...)
2021-06-13T00:21:23.1637110Z 
2021-06-13T00:21:23.1662240Z   endif()
2021-06-13T00:21:23.1668530Z 
```