### PR TITLE
Check imu orientation field

### DIFF
--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -958,7 +958,14 @@ convert_ros_to_ign(
   // ToDo: Verify that this is the expected value (probably not).
   ign_msg.set_entity_name(ros_msg.header.frame_id);
 
-  convert_ros_to_ign(ros_msg.orientation, (*ign_msg.mutable_orientation()));
+  if (!ignition::math::equal(ros_msg.orientation_covariance[0], -1.0))
+  {
+    // -1 in orientation covariance matrix means there are no orientation
+    // values, see
+    // http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/Imu.html
+    convert_ros_to_ign(ros_msg.orientation, (*ign_msg.mutable_orientation()));
+  }
+
   convert_ros_to_ign(ros_msg.angular_velocity,
                    (*ign_msg.mutable_angular_velocity()));
   convert_ros_to_ign(ros_msg.linear_acceleration,
@@ -981,7 +988,7 @@ convert_ign_to_ros(
   {
     // ign may not publish orientation values.
     // So set 1st element of orientation covariance matrix to -1 to indicate
-    // there are not orientation estimates, see ROS imu msg documentation:
+    // there are no orientation estimates, see ROS imu msg documentation:
     // http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/Imu.html
     ros_msg.orientation_covariance[0] = -1.0f;
   }

--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -972,7 +972,20 @@ convert_ign_to_ros(
   sensor_msgs::Imu & ros_msg)
 {
   convert_ign_to_ros(ign_msg.header(), ros_msg.header);
-  convert_ign_to_ros(ign_msg.orientation(), ros_msg.orientation);
+
+  if (ign_msg.has_orientation())
+  {
+    convert_ign_to_ros(ign_msg.orientation(), ros_msg.orientation);
+  }
+  else
+  {
+    // ign may not publish orientation values.
+    // So set 1st element of orientation covariance matrix to -1 to indicate
+    // there are not orientation estimates, see ROS imu msg documentation:
+    // http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/Imu.html
+    ros_msg.orientation_covariance[0] = -1.0f;
+  }
+
   convert_ign_to_ros(ign_msg.angular_velocity(), ros_msg.angular_velocity);
   convert_ign_to_ros(ign_msg.linear_acceleration(), ros_msg.linear_acceleration);
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

related PRs 
* https://github.com/ignitionrobotics/ign-sensors/pull/142
* https://github.com/ignitionrobotics/ign-gazebo/pull/899

Ign may not always publish imu orientation values (see PRs above). The changes here make sure that the bridge checks to see if the field exists before converting to the orientation field in the ROS imu msg. If the field does not exist, we set the 1st element of the orientation covariance matrix to -1 per [ROS imu msg documentation](http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/Imu.html)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

