### PR TITLE
[ROS2] Fix triage for PRs from forks (#124)

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 name: Ticket opened
 jobs:


### PR DESCRIPTION
# ➡️ Forward port

Port #124 from `dashing` to `foxy`

I used cherry-pick instead of a merge because all other changes seem to have already been ported. Dashing is EOL and that branch will no longer be changing, so I think it's ok to keep the branch comparison dirty because we won't be looking at it anymore.

Branch comparison: https://github.com/ignitionrobotics/ros_ign/compare/foxy...dashing

**Note to maintainers**: Remember to **Rebase merge** (this was a cherry-pick)

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
