### PR TITLE
Enable QoS overrides

### DIFF
--- a/ros_ign_bridge/src/factory.hpp
+++ b/ros_ign_bridge/src/factory.hpp
@@ -51,8 +51,8 @@ public:
     options.qos_overriding_options =
       rclcpp::QosOverridingOptions::with_default_policies();
     std::shared_ptr<rclcpp::Publisher<ROS_T>> publisher =
-      ros_node->create_publisher<ROS_T>(topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)),
-      options);
+      ros_node->create_publisher<ROS_T>(
+      topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), options);
     return publisher;
   }
 

--- a/ros_ign_bridge/src/factory.hpp
+++ b/ros_ign_bridge/src/factory.hpp
@@ -46,8 +46,13 @@ public:
     const std::string & topic_name,
     size_t queue_size)
   {
+    // Allow QoS overriding
+    auto options = rclcpp::PublisherOptions();
+    options.qos_overriding_options =
+      rclcpp::QosOverridingOptions::with_default_policies();
     std::shared_ptr<rclcpp::Publisher<ROS_T>> publisher =
-      ros_node->create_publisher<ROS_T>(topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)));
+      ros_node->create_publisher<ROS_T>(topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)),
+      options);
     return publisher;
   }
 
@@ -72,9 +77,12 @@ public:
       std::placeholders::_1, ign_pub,
       ros_type_name_, ign_type_name_,
       ros_node);
-    // Ignore messages that are published from this bridge.
     auto options = rclcpp::SubscriptionOptions();
+    // Ignore messages that are published from this bridge.
     options.ignore_local_publications = true;
+    // Allow QoS overriding
+    options.qos_overriding_options =
+      rclcpp::QosOverridingOptions::with_default_policies();
     std::shared_ptr<rclcpp::Subscription<ROS_T>> subscription =
       ros_node->create_subscription<ROS_T>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), fn, options);

--- a/ros_ign_gazebo_demos/README.md
+++ b/ros_ign_gazebo_demos/README.md
@@ -16,6 +16,16 @@ Publishes fluid pressure readings.
 
     ros2 launch ros_ign_gazebo_demos air_pressure.launch.py
 
+This demo also shows the use of custom QoS parameters. The sensor data is
+published as as "best-effort", so trying to subscribe to "reliable" data won't
+work. See the difference between:
+
+    ros2 topic echo /air_pressure --qos-reliability best_effort
+
+And
+
+    ros2 topic echo /air_pressure --qos-reliability reliable
+
 ![](images/air_pressure_demo.png)
 
 ## Camera
@@ -43,6 +53,16 @@ Send commands to a differential drive vehicle and listen to its odometry.
 Then unpause and send a command
 
     ros2 topic pub /model/vehicle_blue/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 5.0}, angular: {z: 0.5}}"
+
+This demo also shows the use of custom QoS parameters. The commands are
+subscribed to as "reliable", so trying to publish "best-effort" commands
+won't work. See the difference between:
+
+    ros2 topic pub /model/vehicle_blue/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 5.0}, angular: {z: 0.0}}" --qos-reliability reliable
+
+And
+
+    ros2 topic pub /model/vehicle_blue/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 5.0}, angular: {z: 0.0}}" --qos-reliability best_effort
 
 ![](images/diff_drive_demo.png)
 

--- a/ros_ign_gazebo_demos/launch/air_pressure.launch.py
+++ b/ros_ign_gazebo_demos/launch/air_pressure.launch.py
@@ -36,7 +36,8 @@ def generate_launch_description():
     bridge = Node(
         package='ros_ign_bridge',
         executable='parameter_bridge',
-        arguments=["/air_pressure@sensor_msgs/msg/FluidPressure@ignition.msgs.FluidPressure"],
+        arguments=['/air_pressure@sensor_msgs/msg/FluidPressure@ignition.msgs.FluidPressure'],
+        parameters=[{'qos_overrides./air_pressure.publisher.reliability' : 'best_effort'}],
         output='screen'
     )
 

--- a/ros_ign_gazebo_demos/launch/diff_drive.launch.py
+++ b/ros_ign_gazebo_demos/launch/diff_drive.launch.py
@@ -55,6 +55,8 @@ def generate_launch_description():
                    '/model/vehicle_blue/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
                    '/model/vehicle_green/cmd_vel@geometry_msgs/msg/Twist@ignition.msgs.Twist',
                    '/model/vehicle_green/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry'],
+        parameters=[{'qos_overrides./model/vehicle_blue.subscriber.reliability' : 'reliable',
+                     'qos_overrides./model/vehicle_green.subscriber.reliability' : 'reliable'}],
         output='screen'
     )
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

From Galactic, it's possible to enable QoS overrides for nodes. This is very important for `ros_ign_bridge` because different topics may require different QoS settings. For example, sensor data ~~should~~ may be published as best-effort, and commands should be subscribed to as reliable.

[This demo](https://github.com/ros2/demos/tree/master/quality_of_service_demo#qos-overrides) is a helpful example.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

The air pressure demo has been updated to override the default reliability (reliable) with best-effort:

1. `ros2 launch ros_ign_gazebo_demos air_pressure.launch.py`
2. `ros2 topic info /air_pressure --verbose`

```                                   
Type: sensor_msgs/msg/FluidPressure                                                                                                         
                                                                                                                                            
Publisher count: 1                                                                                                                          
                                                                                                                                            
Node name: ros_ign_bridge                                                                                                                   
Node namespace: /                                                                                                                           
Topic type: sensor_msgs/msg/FluidPressure                                                                                                   
Endpoint type: PUBLISHER                                                                                                                    
GID: 78.7d.10.01.cc.4b.05.8d.7e.a3.c3.e2.00.00.16.03.00.00.00.00.00.00.00.00                                                                
QoS profile:                                                                                                                                
  Reliability: BEST_EFFORT                                                                                                                  
  Durability: VOLATILE                                                                                                                      
  Lifespan: 2147483651294967295 nanoseconds                                                                                                 
  Deadline: 2147483651294967295 nanoseconds                                                                                                   Liveliness: AUTOMATIC                                                                                                                     
  Liveliness lease duration: 2147483651294967295 nanoseconds                                                                                                                                                                                       
...
```


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests (thought of it, but it would really be adding lots of new lines to test `rclcpp`)
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
