### PR TITLE
[melodic] 🏁 Dome EOL

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -9,14 +9,10 @@ export DEBIAN_FRONTEND=noninteractive
 apt update -qq
 apt install -qq -y lsb-release wget curl build-essential
 
-if [ "$IGNITION_VERSION" == "blueprint" ]; then
-  IGN_DEPS="libignition-gazebo2-dev"
-elif [ "$IGNITION_VERSION" == "citadel" ]; then
-  IGN_DEPS="libignition-gazebo3-dev"
-elif [ "$IGNITION_VERSION" == "dome" ]; then
-  IGN_DEPS="libignition-gazebo4-dev"
+if [ "$IGNITION_VERSION" == "citadel" ]; then
+  IGN_DEPS="ignition-citadel"
 elif [ "$IGNITION_VERSION" == "fortress" ]; then
-  IGN_DEPS="libignition-gazebo6-dev"
+  IGN_DEPS="ignition-fortress"
 else
   exit 1
 fi

--- a/.github/workflows/melodic-ci.yml
+++ b/.github/workflows/melodic-ci.yml
@@ -13,9 +13,6 @@ jobs:
             ignition-version: "citadel"
             ros-distro: "melodic"
           - docker-image: "ubuntu:18.04"
-            ignition-version: "dome"
-            ros-distro: "melodic"
-          - docker-image: "ubuntu:18.04"
             ignition-version: "fortress"
             ros-distro: "melodic"
     container:

--- a/README.md
+++ b/README.md
@@ -3,14 +3,11 @@
 ROS version | Ignition version | Branch | Binaries hosted at
 -- | -- | -- | --
 Melodic | Citadel | [melodic](https://github.com/osrf/ros_ign/tree/melodic) | only from source
-Melodic | Dome | [melodic](https://github.com/osrf/ros_ign/tree/melodic) | https://packages.osrfoundation.org
 Melodic | Fortress | [melodic](https://github.com/osrf/ros_ign/tree/melodic) | only from source
 Noetic | Citadel | [noetic](https://github.com/osrf/ros_ign/tree/noetic) | https://packages.ros.org
-Noetic | Dome | [noetic](https://github.com/osrf/ros_ign/tree/noetic) | only from source
 Noetic | Edifice | [noetic](https://github.com/osrf/ros_ign/tree/noetic) | only from source
 Noetic | Fortress (not released) | [noetic](https://github.com/osrf/ros_ign/tree/noetic) | only from source
 Foxy | Citadel | [foxy](https://github.com/osrf/ros_ign/tree/foxy) | https://packages.ros.org
-Foxy | Dome | [foxy](https://github.com/osrf/ros_ign/tree/foxy) | only from source
 Foxy | Edifice | [foxy](https://github.com/osrf/ros_ign/tree/foxy) | only from source
 Galactic | Edifice | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | https://packages.ros.org
 Rolling | Edifice | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | https://packages.ros.org
@@ -52,18 +49,7 @@ This branch supports ROS Melodic. See above for other ROS versions.
 
 ### Binaries
 
-At the moment, Melodic binaries are only available for Dome.
-They are hosted at https://packages.osrfoundation.org.
-
-1. Add https://packages.osrfoundation.org
-
-        sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-        wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-        sudo apt-get update
-
-1. Install `ros_ign`
-
-        sudo apt install ros-melodic-ros-ign
+There are no binaries available for Melodic.
 
 ### From source
 
@@ -75,7 +61,7 @@ More ROS dependencies will be installed below.
 
 #### Ignition
 
-Install either [Citadel or Dome](https://ignitionrobotics.org/docs).
+Install either [Citadel or Fortress](https://ignitionrobotics.org/docs).
 
 Set the `IGNITION_VERSION` environment variable to the Ignition version you'd
 like to compile against. For example:

--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -20,18 +20,8 @@ find_package(catkin REQUIRED COMPONENTS
                tf2_msgs
                visualization_msgs)
 
-# Default to Dome, support Citadel and Blueprint
-if ("$ENV{IGNITION_VERSION}" STREQUAL "blueprint")
-  find_package(ignition-transport7 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport7_VERSION_MAJOR})
-
-  find_package(ignition-msgs4 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs4_VERSION_MAJOR})
-
-  message(STATUS "Compiling against Ignition Blueprint")
-  
-  add_definitions(-DIGNITION_BLUEPRINT)
-elseif("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
+# Citadel
+if("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
   find_package(ignition-transport8 REQUIRED)
   set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
@@ -40,7 +30,8 @@ elseif("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
 
   message(STATUS "Compiling against Ignition Citadel")
   add_definitions(-DIGNITION_CITADEL)
-elseif("$ENV{IGNITION_VERSION}" STREQUAL "fortress")
+# Fortress (default)
+else()
   find_package(ignition-transport11 REQUIRED)
   set(IGN_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
 
@@ -49,15 +40,6 @@ elseif("$ENV{IGNITION_VERSION}" STREQUAL "fortress")
 
   message(STATUS "Compiling against Ignition Fortress")
   add_definitions(-DIGNITION_FORTRESS)
-else()
-  find_package(ignition-transport9 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport9_VERSION_MAJOR})
-
-  find_package(ignition-msgs6 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
-
-  message(STATUS "Compiling against Ignition Dome")
-  add_definitions(-DIGNITION_DOME)
 endif()
 
 catkin_package()

--- a/ros_ign_bridge/package.xml
+++ b/ros_ign_bridge/package.xml
@@ -19,17 +19,14 @@
   <depend>tf2_msgs</depend>
   <depend>visualization_msgs</depend>
 
-  <!-- Default to Dome, support Citadel and Blueprint -->
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-msgs4</depend>
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-transport7</depend>
+  <!-- Citadel -->
   <depend condition="$IGNITION_VERSION == citadel">ignition-msgs5</depend>
   <depend condition="$IGNITION_VERSION == citadel">ignition-transport8</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-msgs6</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-transport9</depend>
+  <!-- Fortress (default) -->
   <depend condition="$IGNITION_VERSION == fortress">ignition-msgs8</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-transport11</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-msgs6</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-transport9</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-msgs8</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-transport11</depend>
 
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>

--- a/ros_ign_bridge/src/convert.cpp
+++ b/ros_ign_bridge/src/convert.cpp
@@ -554,7 +554,7 @@ convert_ros_to_ign(
   ign_msg.mutable_info()->set_height(
       ros_msg.info.height);
 
-  convert_ros_to_ign(ros_msg.info.origin, 
+  convert_ros_to_ign(ros_msg.info.origin,
       (*ign_msg.mutable_info()->mutable_origin()));
 
   ign_msg.set_data(&ros_msg.data[0], ros_msg.data.size());
@@ -1012,17 +1012,17 @@ convert_ros_to_ign(
   {
     auto newJoint = ign_msg.add_joint();
     newJoint->set_name(ros_msg.name[i]);
-    
+
     if (ros_msg.position.size() > i)
       newJoint->mutable_axis1()->set_position(ros_msg.position[i]);
     else
       newJoint->mutable_axis1()->set_position(nan);
-    
+
     if (ros_msg.velocity.size() > i)
       newJoint->mutable_axis1()->set_velocity(ros_msg.velocity[i]);
     else
       newJoint->mutable_axis1()->set_velocity(nan);
-    
+
     if (ros_msg.effort.size() > i)
       newJoint->mutable_axis1()->set_force(ros_msg.effort[i]);
     else
@@ -1353,7 +1353,7 @@ convert_ros_to_ign(
 {
   convert_ros_to_ign(ros_msg.header, (*ign_msg.mutable_header()));
 
-  // Note, in ROS's Marker message ADD and MODIFY both map to a value of "0", 
+  // Note, in ROS's Marker message ADD and MODIFY both map to a value of "0",
   // so that case is not needed here.
   switch(ros_msg.action)
   {
@@ -1379,7 +1379,7 @@ convert_ros_to_ign(
   // Type
   switch(ros_msg.type)
   {
-#ifdef IGNITION_DOME
+#ifndef IGNITION_CITADEL
     case visualization_msgs::Marker::ARROW:
       ign_msg.set_type(ignition::msgs::Marker::ARROW);
       break;
@@ -1485,7 +1485,7 @@ convert_ign_to_ros(
 
   switch(ign_msg.type())
   {
-#ifdef IGNITION_DOME
+#ifndef IGNITION_CITADEL
     case ignition::msgs::Marker::ARROW:
       ros_msg.type = visualization_msgs::Marker::TRIANGLE_LIST;
       break;

--- a/ros_ign_gazebo/CMakeLists.txt
+++ b/ros_ign_gazebo/CMakeLists.txt
@@ -8,19 +8,8 @@ find_package(catkin
     roscpp
 )
 
-# Default to Dome, support Citadel and Blueprint
-if ("$ENV{IGNITION_VERSION}" STREQUAL "blueprint")
-  find_package(ignition-gazebo2 REQUIRED)
-  set(IGN_GAZEBO_VER ${ignition-gazebo2_VERSION_MAJOR})
-
-  find_package(ignition-transport7 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport7_VERSION_MAJOR})
-
-  find_package(ignition-msgs4 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs4_VERSION_MAJOR})
-
-  message(STATUS "Compiling against Ignition Blueprint")
-elseif("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
+# Citadel
+if("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
   find_package(ignition-gazebo3 REQUIRED)
   set(IGN_GAZEBO_VER ${ignition-gazebo3_VERSION_MAJOR})
 
@@ -31,7 +20,9 @@ elseif("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
   set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
   message(STATUS "Compiling against Ignition Citadel")
-elseif("$ENV{IGNITION_VERSION}" STREQUAL "fortress")
+  add_definitions(-DIGNITION_CITADEL)
+# Fortress (default)
+else()
   find_package(ignition-gazebo6 REQUIRED)
   set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
 
@@ -42,17 +33,7 @@ elseif("$ENV{IGNITION_VERSION}" STREQUAL "fortress")
   set(IGN_MSGS_VER ${ignition-msgs8_VERSION_MAJOR})
 
   message(STATUS "Compiling against Ignition Fortress")
-else()
-  find_package(ignition-gazebo4 REQUIRED)
-  set(IGN_GAZEBO_VER ${ignition-gazebo4_VERSION_MAJOR})
-
-  find_package(ignition-transport9 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport9_VERSION_MAJOR})
-
-  find_package(ignition-msgs6 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
-
-  message(STATUS "Compiling against Ignition Dome")
+  add_definitions(-DIGNITION_FORTRESS)
 endif()
 
 ign_find_package(gflags

--- a/ros_ign_gazebo/package.xml
+++ b/ros_ign_gazebo/package.xml
@@ -9,12 +9,11 @@
 
   <depend>libgflags-dev</depend>
 
-  <!-- Default to Dome, support Citadel and  Blueprint -->
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-gazebo2</depend>
+  <!-- Citadel -->
   <depend condition="$IGNITION_VERSION == citadel">ignition-gazebo3</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-gazebo4</depend>
+  <!-- Fortress (default) -->
   <depend condition="$IGNITION_VERSION == fortress">ignition-gazebo6</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo4</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo6</depend>
 
   <depend>roscpp</depend>
 </package>

--- a/ros_ign_gazebo_demos/package.xml
+++ b/ros_ign_gazebo_demos/package.xml
@@ -7,12 +7,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <!-- Default to Dome, support Citadel and  Blueprint -->
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-gazebo2</depend>
+  <!-- Citadel -->
   <depend condition="$IGNITION_VERSION == citadel">ignition-gazebo3</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-gazebo4</depend>
+  <!-- Fortress (default) -->
   <depend condition="$IGNITION_VERSION == fortress">ignition-gazebo6</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo4</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo6</depend>
 
   <exec_depend>image_transport_plugins</exec_depend>
   <exec_depend>ros_ign_bridge</exec_depend>

--- a/ros_ign_image/CMakeLists.txt
+++ b/ros_ign_image/CMakeLists.txt
@@ -16,39 +16,26 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs)
 
-# Default to Dome, support Citadel and Blueprint
-if ("$ENV{IGNITION_VERSION}" STREQUAL "blueprint")
-  find_package(ignition-transport7 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport7_VERSION_MAJOR})
-
-  find_package(ignition-msgs4 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs4_VERSION_MAJOR})
-
-  message(STATUS "Compiling against Ignition Blueprint")
-elseif("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
-  find_package(ignition-transport8 QUIET)
+# Citadel
+if("$ENV{IGNITION_VERSION}" STREQUAL "citadel")
+  find_package(ignition-transport8 REQUIRED)
   set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
   find_package(ignition-msgs5 REQUIRED)
   set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
   message(STATUS "Compiling against Ignition Citadel")
-elseif("$ENV{IGNITION_VERSION}" STREQUAL "fortress")
-  find_package(ignition-transport11 QUIET)
+  add_definitions(-DIGNITION_CITADEL)
+# Fortress (default)
+else()
+  find_package(ignition-transport11 REQUIRED)
   set(IGN_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
 
   find_package(ignition-msgs8 REQUIRED)
   set(IGN_MSGS_VER ${ignition-msgs8_VERSION_MAJOR})
 
   message(STATUS "Compiling against Ignition Fortress")
-else()
-  find_package(ignition-transport9 QUIET)
-  set(IGN_TRANSPORT_VER ${ignition-transport9_VERSION_MAJOR})
-
-  find_package(ignition-msgs6 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
-
-  message(STATUS "Compiling against Ignition Dome")
+  add_definitions(-DIGNITION_FORTRESS)
 endif()
 
 catkin_package()

--- a/ros_ign_image/package.xml
+++ b/ros_ign_image/package.xml
@@ -7,17 +7,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <!-- Default to Dome, support Citadel and blueprint -->
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-msgs4</depend>
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-transport7</depend>
+  <!-- Citadel -->
   <depend condition="$IGNITION_VERSION == citadel">ignition-msgs5</depend>
   <depend condition="$IGNITION_VERSION == citadel">ignition-transport8</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-msgs6</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-transport9</depend>
+  <!-- Fortress (default) -->
   <depend condition="$IGNITION_VERSION == fortress">ignition-msgs8</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-transport11</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-msgs6</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-transport9</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-msgs8</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-transport11</depend>
 
   <depend>image_transport</depend>
   <depend>ros_ign_bridge</depend>

--- a/ros_ign_point_cloud/package.xml
+++ b/ros_ign_point_cloud/package.xml
@@ -7,22 +7,17 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <!-- Default to citadel, support blueprint -->
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-gazebo2</depend>
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-rendering2</depend>
-  <depend condition="$IGNITION_VERSION == blueprint">ignition-sensors2</depend>
+  <!-- Citadel -->
   <depend condition="$IGNITION_VERSION == citadel">ignition-gazebo3</depend>
   <depend condition="$IGNITION_VERSION == citadel">ignition-rendering3</depend>
   <depend condition="$IGNITION_VERSION == citadel">ignition-sensors3</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-gazebo4</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-rendering4</depend>
-  <depend condition="$IGNITION_VERSION == dome">ignition-sensors4</depend>
+  <!-- Fortress (default) -->
   <depend condition="$IGNITION_VERSION == fortress">ignition-gazebo6</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-rendering6</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-sensors6</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo4</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-rendering4</depend>
-  <depend condition="$IGNITION_VERSION == ''">ignition-sensors4</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-gazebo6</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-rendering6</depend>
+  <depend condition="$IGNITION_VERSION == ''">ignition-sensors6</depend>
 
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
* Part of https://github.com/ignition-tooling/release-tools/issues/600

I also went ahead and removed what was left of Blueprint here.

Melodic used to default to Dome, now it defaults to Fortress. We're not planning to release new `ros-melodic-ros-ign` binaries using Fortress though; let us know if you're interested in it.