### PR TITLE
update maintainer

### DIFF
--- a/ros_ign_interfaces/package.xml
+++ b/ros_ign_interfaces/package.xml
@@ -4,8 +4,7 @@
   <description>Message and service data structures for interacting with Ignition from ROS2.</description>
   <license>Apache 2.0</license>
   <maintainer email="louise@openrobotics.org">Louise Poubel</maintainer>
-  <maintainer email="zhenpeng.ge@qq.com">Zhenpeng Ge</maintainer>
-  <author>Zhenpeng Ge</author>
+  <author email="zhenpeng.ge@qq.com">Zhenpeng Ge</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 


### PR DESCRIPTION
Signed-off-by: gezp <zhenpeng.ge@qq.com>
 
removing Zhenpeng Ge from `ros_ign_interfaces` package, i added myself as maintainer by mistake in https://github.com/ignitionrobotics/ros_ign/pull/152 .