### PR TITLE
Bring ros2 branch up-to-date with Rolling

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -97,6 +97,7 @@ set(bridge_lib
 add_library(${bridge_lib}
   SHARED
   src/factories.cpp
+  src/factory_interface.cpp
 )
 
 target_include_directories(${bridge_lib}

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/geometry_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/geometry_msgs.hpp
@@ -15,14 +15,6 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__GEOMETRY_MSGS_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__GEOMETRY_MSGS_HPP_
 
-#include <geometry_msgs/msg/point.hpp>
-#include <geometry_msgs/msg/pose.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/quaternion.hpp>
-#include <geometry_msgs/msg/transform_stamped.hpp>
-#include <geometry_msgs/msg/twist.hpp>
-#include <geometry_msgs/msg/wrench.hpp>
-
 // Ignition messages
 #include <ignition/msgs/quaternion.pb.h>
 #include <ignition/msgs/vector3d.pb.h>
@@ -30,6 +22,15 @@
 #include <ignition/msgs/pose_v.pb.h>
 #include <ignition/msgs/twist.pb.h>
 #include <ignition/msgs/wrench.pb.h>
+
+// ROS 2 messages
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/wrench.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/nav_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/nav_msgs.hpp
@@ -15,10 +15,11 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__NAV_MSGS_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__NAV_MSGS_HPP_
 
-#include <nav_msgs/msg/odometry.hpp>
-
 // Ignition messages
 #include <ignition/msgs/odometry.pb.h>
+
+// ROS 2 messages
+#include <nav_msgs/msg/odometry.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/ros_ign_interfaces.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/ros_ign_interfaces.hpp
@@ -15,18 +15,19 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__ROS_IGN_INTERFACES_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__ROS_IGN_INTERFACES_HPP_
 
-#include <ros_ign_interfaces/msg/entity.hpp>
-#include <ros_ign_interfaces/msg/joint_wrench.hpp>
-#include <ros_ign_interfaces/msg/contact.hpp>
-#include <ros_ign_interfaces/msg/contacts.hpp>
-#include <ros_ign_interfaces/msg/light.hpp>
-
 // Ignition messages
 #include <ignition/msgs/entity.pb.h>
 #include <ignition/msgs/joint_wrench.pb.h>
 #include <ignition/msgs/contact.pb.h>
 #include <ignition/msgs/contacts.pb.h>
 #include <ignition/msgs/light.pb.h>
+
+// ROS 2 messages
+#include <ros_ign_interfaces/msg/entity.hpp>
+#include <ros_ign_interfaces/msg/joint_wrench.hpp>
+#include <ros_ign_interfaces/msg/contact.hpp>
+#include <ros_ign_interfaces/msg/contacts.hpp>
+#include <ros_ign_interfaces/msg/light.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/rosgraph_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/rosgraph_msgs.hpp
@@ -15,10 +15,11 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__ROSGRAPH_MSGS_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__ROSGRAPH_MSGS_HPP_
 
-#include <rosgraph_msgs/msg/clock.hpp>
-
 // Ignition messages
 #include <ignition/msgs.hh>
+
+// ROS 2 messages
+#include <rosgraph_msgs/msg/clock.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/sensor_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/sensor_msgs.hpp
@@ -15,16 +15,6 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__SENSOR_MSGS_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__SENSOR_MSGS_HPP_
 
-#include <sensor_msgs/msg/battery_state.hpp>
-#include <sensor_msgs/msg/camera_info.hpp>
-#include <sensor_msgs/msg/fluid_pressure.hpp>
-#include <sensor_msgs/msg/image.hpp>
-#include <sensor_msgs/msg/imu.hpp>
-#include <sensor_msgs/msg/joint_state.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-#include <sensor_msgs/msg/magnetic_field.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-
 // Ignition messages
 #include <ignition/msgs/battery_state.pb.h>
 #include <ignition/msgs/camera_info.pb.h>
@@ -35,6 +25,17 @@
 #include <ignition/msgs/magnetometer.pb.h>
 #include <ignition/msgs/model.pb.h>
 #include <ignition/msgs/pointcloud_packed.pb.h>
+
+// ROS 2 messages
+#include <sensor_msgs/msg/battery_state.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/fluid_pressure.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <sensor_msgs/msg/magnetic_field.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/std_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/std_msgs.hpp
@@ -15,16 +15,6 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__STD_MSGS_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__STD_MSGS_HPP_
 
-#include <std_msgs/msg/bool.hpp>
-#include <std_msgs/msg/color_rgba.hpp>
-#include <std_msgs/msg/empty.hpp>
-#include <std_msgs/msg/float32.hpp>
-#include <std_msgs/msg/float64.hpp>
-#include <std_msgs/msg/header.hpp>
-#include <std_msgs/msg/int32.hpp>
-#include <std_msgs/msg/u_int32.hpp>
-#include <std_msgs/msg/string.hpp>
-
 // Ignition messages
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/color.pb.h>
@@ -35,6 +25,17 @@
 #include <ignition/msgs/int32.pb.h>
 #include <ignition/msgs/uint32.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
+
+// ROS 2 messages
+#include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
+#include <std_msgs/msg/empty.hpp>
+#include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/float64.hpp>
+#include <std_msgs/msg/header.hpp>
+#include <std_msgs/msg/int32.hpp>
+#include <std_msgs/msg/u_int32.hpp>
+#include <std_msgs/msg/string.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/tf2_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/tf2_msgs.hpp
@@ -15,8 +15,11 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__TF2_MSGS_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__TF2_MSGS_HPP_
 
-#include <tf2_msgs/msg/tf_message.hpp>
+// Ignition messages
 #include <ignition/msgs/pose_v.pb.h>
+
+// ROS 2 messages
+#include <tf2_msgs/msg/tf_message.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/trajectory_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/trajectory_msgs.hpp
@@ -15,10 +15,11 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__TRAJECTORY_MSGS_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__TRAJECTORY_MSGS_HPP_
 
-#include <trajectory_msgs/msg/joint_trajectory.hpp>
-
 // Ignition messages
 #include <ignition/msgs/joint_trajectory.pb.h>
+
+// ROS 2 messages
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 

--- a/ros_ign_bridge/src/factory.hpp
+++ b/ros_ign_bridge/src/factory.hpp
@@ -17,13 +17,13 @@
 
 #include <ignition/transport/Node.hh>
 
-// include ROS 2
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp/subscription_options.hpp>
-
 #include <functional>
 #include <memory>
 #include <string>
+
+// include ROS 2
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/subscription_options.hpp>
 
 #include "factory_interface.hpp"
 

--- a/ros_ign_bridge/src/factory_interface.cpp
+++ b/ros_ign_bridge/src/factory_interface.cpp
@@ -1,0 +1,24 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "factory_interface.hpp"
+
+namespace ros_ign_bridge
+{
+
+FactoryInterface::~FactoryInterface()
+{
+}
+
+}  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/factory_interface.hpp
+++ b/ros_ign_bridge/src/factory_interface.hpp
@@ -15,14 +15,14 @@
 #ifndef  FACTORY_INTERFACE_HPP_
 #define  FACTORY_INTERFACE_HPP_
 
-// include ROS 2
-#include <rclcpp/rclcpp.hpp>
-
 // include Ignition Transport
 #include <ignition/transport/Node.hh>
 
 #include <memory>
 #include <string>
+
+// include ROS 2
+#include <rclcpp/rclcpp.hpp>
 
 namespace ros_ign_bridge
 {

--- a/ros_ign_bridge/src/factory_interface.hpp
+++ b/ros_ign_bridge/src/factory_interface.hpp
@@ -31,6 +31,9 @@ class FactoryInterface
 {
 public:
   virtual
+  ~FactoryInterface() = 0;
+
+  virtual
   rclcpp::PublisherBase::SharedPtr
   create_ros_publisher(
     rclcpp::Node::SharedPtr ros_node,

--- a/ros_ign_bridge/src/parameter_bridge.cpp
+++ b/ros_ign_bridge/src/parameter_bridge.cpp
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// include ROS 2
-#include <rclcpp/rclcpp.hpp>
-
 // include Ignition Transport
 #include <ignition/transport/Node.hh>
 
@@ -23,6 +20,9 @@
 #include <memory>
 #include <string>
 #include <vector>
+
+// include ROS 2
+#include <rclcpp/rclcpp.hpp>
 
 #include "bridge.hpp"
 

--- a/ros_ign_bridge/src/static_bridge.cpp
+++ b/ros_ign_bridge/src/static_bridge.cpp
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rclcpp/rclcpp.hpp>
-
 // include Ignition Transport
 #include <ignition/transport/Node.hh>
 
 #include <memory>
 #include <string>
+
+// include ROS 2
+#include <rclcpp/rclcpp.hpp>
 
 #include "bridge.hpp"
 

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
@@ -14,11 +14,11 @@
 
 #include <gtest/gtest.h>
 
-#include <rclcpp/rclcpp.hpp>
-
 #include <chrono>
 #include <memory>
 #include <string>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include "utils/test_utils.hpp"
 #include "utils/ros_test_msg.hpp"

--- a/ros_ign_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.hpp
@@ -15,6 +15,8 @@
 #ifndef UTILS__ROS_TEST_MSG_HPP_
 #define UTILS__ROS_TEST_MSG_HPP_
 
+#include <memory>
+
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/color_rgba.hpp>
 #include <std_msgs/msg/empty.hpp>
@@ -51,8 +53,6 @@
 #include <sensor_msgs/msg/point_field.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
-
-#include <memory>
 
 namespace ros_ign_bridge
 {

--- a/ros_ign_bridge/test/utils/test_utils.hpp
+++ b/ros_ign_bridge/test/utils/test_utils.hpp
@@ -15,11 +15,11 @@
 #ifndef UTILS__TEST_UTILS_HPP_
 #define UTILS__TEST_UTILS_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-
 #include <chrono>
 #include <memory>
 #include <thread>
+
+#include <rclcpp/rclcpp.hpp>
 
 namespace ros_ign_bridge
 {

--- a/ros_ign_gazebo/src/create.cpp
+++ b/ros_ign_gazebo/src/create.cpp
@@ -91,7 +91,7 @@ int main(int _argc, char ** _argv)
   if (!FLAGS_file.empty()) {
     req.set_sdf_filename(FLAGS_file);
   } else if (!FLAGS_param.empty()) {  // Param
-    ros2_node->declare_parameter(FLAGS_param);
+    ros2_node->declare_parameter<std::string>(FLAGS_param);
 
     std::string xmlStr;
     if (ros2_node->get_parameter(FLAGS_param, xmlStr)) {

--- a/ros_ign_gazebo/src/create.cpp
+++ b/ros_ign_gazebo/src/create.cpp
@@ -17,11 +17,13 @@
 #include <ignition/msgs/entity_factory.pb.h>
 #include <ignition/msgs/Utility.hh>
 #include <ignition/transport/Node.hh>
-#include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/string.hpp>
 
 #include <sstream>
 #include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
 
 DEFINE_string(world, "", "World name.");
 DEFINE_string(file, "", "Load XML from a file.");

--- a/ros_ign_image/src/image_bridge.cpp
+++ b/ros_ign_image/src/image_bridge.cpp
@@ -14,14 +14,14 @@
 
 #include <ignition/transport/Node.hh>
 
-#include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.hpp>
-#include <ros_ign_bridge/convert.hpp>
-
 #include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+#include <image_transport/image_transport.hpp>
+#include <ros_ign_bridge/convert.hpp>
 
 //////////////////////////////////////////////////
 /// \brief Bridges one topic


### PR DESCRIPTION
In order to build clean on rolling:

* change the deprecated use of `declare_parameters`
* Add a pure virtual destructor to FactoryInterface (at least for clang/llvm)
* Make linters pass

Broke this off of #212 for easier review