### PR TITLE
Add conversions for ros_ign_interfaces/WorldControl and builtin_interfaces/Time

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -42,13 +43,14 @@ else()
 endif()
 
 set(PACKAGES
-  std_msgs
+  builtin_interfaces
   geometry_msgs
   nav_msgs
-  tf2_msgs
   ros_ign_interfaces
   rosgraph_msgs
   sensor_msgs
+  std_msgs
+  tf2_msgs
   trajectory_msgs
 )
 
@@ -84,6 +86,8 @@ foreach(PKG ${PACKAGES})
     PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 endforeach()
+target_link_libraries(ros_ign_interfaces_bridge builtin_interfaces_bridge)
+target_link_libraries(std_msgs_bridge builtin_interfaces_bridge)
 
 set(bridge_executables
   parameter_bridge
@@ -162,6 +166,7 @@ if(BUILD_TESTING)
     ignition-transport${IGN_TRANSPORT_VER}::core
   )
   ament_target_dependencies(test_utils
+    builtin_interfaces
     geometry_msgs
     nav_msgs
     rclcpp

--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -86,8 +86,6 @@ foreach(PKG ${PACKAGES})
     PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 endforeach()
-target_link_libraries(ros_ign_interfaces_bridge builtin_interfaces_bridge)
-target_link_libraries(std_msgs_bridge builtin_interfaces_bridge)
 
 set(bridge_executables
   parameter_bridge

--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -183,6 +183,7 @@ if(BUILD_TESTING)
 
   add_executable(test_ros_subscriber
         test/subscribers/ros_subscriber/ros_subscriber.cpp
+        test/subscribers/ros_subscriber/builtin_interfaces_subscriber.cpp
         test/subscribers/ros_subscriber/geometry_msgs_subscriber.cpp
         test/subscribers/ros_subscriber/nav_msgs_subscriber.cpp
         test/subscribers/ros_subscriber/ros_ign_interfaces_subscriber.cpp

--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -38,7 +38,7 @@ service calls. Its support is limited to only the following message types:
 | ros_ign_interfaces/msg/StringVec     | ignition::msgs::StringMsg_V          |
 | ros_ign_interfaces/msg/TrackVisual   | ignition::msgs::TrackVisual          |
 | ros_ign_interfaces/msg/VideoRecord   | ignition::msgs::VideoRecord          |
-| ros_ign_interfaces/msg/WorldControl  | ignition::msgs::WorldContro          |
+| ros_ign_interfaces/msg/WorldControl  | ignition::msgs::WorldControl         |
 | rosgraph_msgs/msg/Clock              | ignition::msgs::Clock                |
 | sensor_msgs/msg/BatteryState         | ignition::msgs::BatteryState         |
 | sensor_msgs/msg/CameraInfo           | ignition::msgs::CameraInfo           |

--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -8,6 +8,7 @@ service calls. Its support is limited to only the following message types:
 
 | ROS type                             | Ignition Transport type              |
 |--------------------------------------|:------------------------------------:|
+| builtin_interfaces/msg/Time          | ignition::msgs::Time                 |
 | std_msgs/msg/Bool                    | ignition::msgs::Boolean              |
 | std_msgs/msg/ColorRGBA               | ignition::msgs::Color                |
 | std_msgs/msg/Empty                   | ignition::msgs::Empty                |
@@ -37,6 +38,7 @@ service calls. Its support is limited to only the following message types:
 | ros_ign_interfaces/msg/StringVec     | ignition::msgs::StringMsg_V          |
 | ros_ign_interfaces/msg/TrackVisual   | ignition::msgs::TrackVisual          |
 | ros_ign_interfaces/msg/VideoRecord   | ignition::msgs::VideoRecord          |
+| ros_ign_interfaces/msg/WorldControl  | ignition::msgs::WorldContro          |
 | rosgraph_msgs/msg/Clock              | ignition::msgs::Clock                |
 | sensor_msgs/msg/BatteryState         | ignition::msgs::BatteryState         |
 | sensor_msgs/msg/CameraInfo           | ignition::msgs::CameraInfo           |

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/builtin_interfaces.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/builtin_interfaces.hpp
@@ -1,0 +1,41 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS_IGN_BRIDGE__CONVERT__BUILTIN_INTERFACES_HPP_
+#define ROS_IGN_BRIDGE__CONVERT__BUILTIN_INTERFACES_HPP_
+
+#include <builtin_interfaces/msg/time.hpp>
+
+#include <ignition/msgs/time.pb.h>
+
+#include "ros_ign_bridge/convert_decl.hpp"
+
+namespace ros_ign_bridge
+{
+
+template<>
+void
+convert_ros_to_ign(
+  const builtin_interfaces::msg::Time & ros_msg,
+  ignition::msgs::Time & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Time & ign_msg,
+  builtin_interfaces::msg::Time & ros_msg);
+
+}  // namespace ros_ign_bridge
+
+#endif  // ROS_IGN_BRIDGE__CONVERT__BUILTIN_INTERFACES_HPP_

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/builtin_interfaces.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/builtin_interfaces.hpp
@@ -15,9 +15,9 @@
 #ifndef ROS_IGN_BRIDGE__CONVERT__BUILTIN_INTERFACES_HPP_
 #define ROS_IGN_BRIDGE__CONVERT__BUILTIN_INTERFACES_HPP_
 
-#include <builtin_interfaces/msg/time.hpp>
-
 #include <ignition/msgs/time.pb.h>
+
+#include <builtin_interfaces/msg/time.hpp>
 
 #include "ros_ign_bridge/convert_decl.hpp"
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/ros_ign_interfaces.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/ros_ign_interfaces.hpp
@@ -25,6 +25,7 @@
 #include <ignition/msgs/stringmsg_v.pb.h>
 #include <ignition/msgs/track_visual.pb.h>
 #include <ignition/msgs/video_record.pb.h>
+#include <ignition/msgs/world_control.pb.h>
 
 // ROS 2 messages
 #include <ros_ign_interfaces/msg/entity.hpp>
@@ -36,6 +37,7 @@
 #include <ros_ign_interfaces/msg/string_vec.hpp>
 #include <ros_ign_interfaces/msg/track_visual.hpp>
 #include <ros_ign_interfaces/msg/video_record.hpp>
+#include <ros_ign_interfaces/msg/world_control.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
 
@@ -149,6 +151,30 @@ void
 convert_ign_to_ros(
   const ignition::msgs::VideoRecord & ign_msg,
   ros_ign_interfaces::msg::VideoRecord & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const ros_ign_interfaces::msg::WorldControl & ros_msg,
+  ignition::msgs::WorldControl & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::WorldControl & ign_msg,
+  ros_ign_interfaces::msg::WorldControl & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const ros_ign_interfaces::msg::WorldReset & ros_msg,
+  ignition::msgs::WorldReset & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::WorldReset & ign_msg,
+  ros_ign_interfaces::msg::WorldReset & ros_msg);
 }  // namespace ros_ign_bridge
 
 #endif  // ROS_IGN_BRIDGE__CONVERT__ROS_IGN_INTERFACES_HPP_

--- a/ros_ign_bridge/src/convert/builtin_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/builtin_interfaces.cpp
@@ -1,0 +1,38 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros_ign_bridge/convert/builtin_interfaces.hpp"
+
+namespace ros_ign_bridge
+{
+template<>
+void
+convert_ros_to_ign(
+  const builtin_interfaces::msg::Time & ros_msg,
+  ignition::msgs::Time & ign_msg)
+{
+  ign_msg.set_sec(ros_msg.sec);
+  ign_msg.set_nsec(ros_msg.nanosec);
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Time & ign_msg,
+  builtin_interfaces::msg::Time & ros_msg)
+{
+  ros_msg.sec = ign_msg.sec();
+  ros_msg.nanosec = ign_msg.nsec();
+}
+}  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -391,4 +391,53 @@ convert_ign_to_ros(
   ros_msg.save_filename = ign_msg.save_filename();
 }
 
+template<>
+void
+convert_ros_to_ign(
+  const ros_ign_interfaces::msg::WorldControl & ros_msg,
+  ignition::msgs::WorldControl & ign_msg)
+{
+  ign_msg.set_pause(ros_msg.pause);
+  ign_msg.set_step(ros_msg.step);
+  ign_msg.set_multi_step(ros_msg.multi_step);
+  convert_ros_to_ign(ros_msg.reset, *ign_msg.mutable_reset());
+  ign_msg.set_seed(ros_msg.seed);
+  convert_ros_to_ign(ros_msg.run_to_sim_time, *ign_msg.mutable_run_to_sim_time());
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::WorldControl & ign_msg,
+  ros_ign_interfaces::msg::WorldControl & ros_msg)
+{
+  ros_msg.pause = ign_msg.pause();
+  ros_msg.step = ign_msg.step();
+  ros_msg.multi_step = ign_msg.multi_step();
+  convert_ign_to_ros(ign_msg.reset(), ros_msg.reset);
+  ros_msg.seed = ign_msg.seed();
+  convert_ign_to_ros(ign_msg.run_to_sim_time(), ros_msg.run_to_sim_time);
+}
+
+template<>
+void
+convert_ros_to_ign(
+  const ros_ign_interfaces::msg::WorldReset & ros_msg,
+  ignition::msgs::WorldReset & ign_msg)
+{
+  ign_msg.set_all(ros_msg.all);
+  ign_msg.set_time_only(ros_msg.time_only);
+  ign_msg.set_model_only(ros_msg.model_only);
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::WorldReset & ign_msg,
+  ros_ign_interfaces::msg::WorldReset & ros_msg)
+{
+  ros_msg.all = ign_msg.all();
+  ros_msg.time_only = ign_msg.time_only();
+  ros_msg.model_only = ign_msg.model_only();
+}
 }  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/convert/std_msgs.cpp
+++ b/ros_ign_bridge/src/convert/std_msgs.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rclcpp/time.hpp>
-
 #include "convert/utils.hpp"
+#include "ros_ign_bridge/convert/builtin_interfaces.hpp"
 #include "ros_ign_bridge/convert/std_msgs.hpp"
 
 namespace ros_ign_bridge
@@ -138,8 +137,7 @@ convert_ros_to_ign(
   const std_msgs::msg::Header & ros_msg,
   ignition::msgs::Header & ign_msg)
 {
-  ign_msg.mutable_stamp()->set_sec(ros_msg.stamp.sec);
-  ign_msg.mutable_stamp()->set_nsec(ros_msg.stamp.nanosec);
+  convert_ros_to_ign(ros_msg.stamp, *ign_msg.mutable_stamp());
   auto newPair = ign_msg.add_data();
   newPair->set_key("frame_id");
   newPair->add_value(ros_msg.frame_id);
@@ -169,7 +167,7 @@ convert_ign_to_ros(
   const ignition::msgs::Header & ign_msg,
   std_msgs::msg::Header & ros_msg)
 {
-  ros_msg.stamp = rclcpp::Time(ign_msg.stamp().sec(), ign_msg.stamp().nsec());
+  convert_ign_to_ros(ign_msg.stamp(), ros_msg.stamp);
   for (auto i = 0; i < ign_msg.data_size(); ++i) {
     auto aPair = ign_msg.data(i);
     if (aPair.key() == "frame_id" && aPair.value_size() > 0) {

--- a/ros_ign_bridge/src/factories.cpp
+++ b/ros_ign_bridge/src/factories.cpp
@@ -17,6 +17,7 @@
 
 #include "factories.hpp"
 
+#include "factories/builtin_interfaces.hpp"
 #include "factories/geometry_msgs.hpp"
 #include "factories/nav_msgs.hpp"
 #include "factories/ros_ign_interfaces.hpp"
@@ -35,6 +36,9 @@ get_factory_impl(
   const std::string & ign_type_name)
 {
   std::shared_ptr<FactoryInterface> impl;
+  impl = get_factory__builtin_interfaces(ros_type_name, ign_type_name);
+  if (impl) {return impl;}
+
   impl = get_factory__std_msgs(ros_type_name, ign_type_name);
   if (impl) {return impl;}
 

--- a/ros_ign_bridge/src/factories/builtin_interfaces.cpp
+++ b/ros_ign_bridge/src/factories/builtin_interfaces.cpp
@@ -1,0 +1,68 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "factories/builtin_interfaces.hpp"
+
+#include <memory>
+#include <string>
+
+#include "factory.hpp"
+#include "ros_ign_bridge/convert/builtin_interfaces.hpp"
+
+namespace ros_ign_bridge
+{
+
+std::shared_ptr<FactoryInterface>
+get_factory__builtin_interfaces(
+  const std::string & ros_type_name,
+  const std::string & ign_type_name)
+{
+  if (
+    (ros_type_name == "builtin_interfaces/msg/Time" || ros_type_name.empty()) &&
+    ign_type_name == "ignition.msgs.Time")
+  {
+    return std::make_shared<
+      Factory<
+        builtin_interfaces::msg::Time,
+        ignition::msgs::Time
+      >
+    >("builtin_interfaces/msg/Time", ign_type_name);
+  }
+  return nullptr;
+}
+
+template<>
+void
+Factory<
+  builtin_interfaces::msg::Time,
+  ignition::msgs::Time
+>::convert_ros_to_ign(
+  const builtin_interfaces::msg::Time & ros_msg,
+  ignition::msgs::Time & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  builtin_interfaces::msg::Time,
+  ignition::msgs::Time
+>::convert_ign_to_ros(
+  const ignition::msgs::Time & ign_msg,
+  builtin_interfaces::msg::Time & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+}  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/factories/builtin_interfaces.hpp
+++ b/ros_ign_bridge/src/factories/builtin_interfaces.hpp
@@ -1,0 +1,33 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FACTORIES__BUILTIN_INTERFACES_HPP_
+#define FACTORIES__BUILTIN_INTERFACES_HPP_
+
+#include <memory>
+#include <string>
+
+#include "factory_interface.hpp"
+
+namespace ros_ign_bridge
+{
+
+std::shared_ptr<FactoryInterface>
+get_factory__builtin_interfaces(
+  const std::string & ros_type_name,
+  const std::string & ign_type_name);
+
+}  // namespace ros_ign_bridge
+
+#endif  // FACTORIES__BUILTIN_INTERFACES_HPP_

--- a/ros_ign_bridge/src/factories/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/factories/ros_ign_interfaces.cpp
@@ -122,6 +122,16 @@ get_factory__ros_ign_interfaces(
       >
     >("ros_ign_interfaces/msg/VideoRecord", ign_type_name);
   }
+  if ((ros_type_name == "ros_ign_interfaces/msg/WorldControl" ||
+    ros_type_name.empty()) && ign_type_name == "ignition.msgs.WorldControl")
+  {
+    return std::make_shared<
+      Factory<
+        ros_ign_interfaces::msg::WorldControl,
+        ignition::msgs::WorldControl
+      >
+    >("ros_ign_interfaces/msg/WorldControl", ign_type_name);
+  }
   return nullptr;
 }
 
@@ -337,6 +347,30 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::VideoRecord & ign_msg,
   ros_ign_interfaces::msg::VideoRecord & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  ros_ign_interfaces::msg::WorldControl,
+  ignition::msgs::WorldControl
+>::convert_ros_to_ign(
+  const ros_ign_interfaces::msg::WorldControl & ros_msg,
+  ignition::msgs::WorldControl & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  ros_ign_interfaces::msg::WorldControl,
+  ignition::msgs::WorldControl
+>::convert_ign_to_ros(
+  const ignition::msgs::WorldControl & ign_msg,
+  ros_ign_interfaces::msg::WorldControl & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
 }

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
@@ -39,6 +39,7 @@ def generate_test_description():
         package='ros_ign_bridge',
         executable='parameter_bridge',
         arguments=[
+          '/time@builtin_interfaces/msg/Time@ignition.msgs.Time',
           '/bool@std_msgs/msg/Bool@ignition.msgs.Boolean',
           '/color@std_msgs/msg/ColorRGBA@ignition.msgs.Color',
           '/empty@std_msgs/msg/Empty@ignition.msgs.Empty',

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
@@ -39,6 +39,7 @@ def generate_test_description():
         package='ros_ign_bridge',
         executable='parameter_bridge',
         arguments=[
+          '/time@builtin_interfaces/msg/Time@ignition.msgs.Time',
           '/bool@std_msgs/msg/Bool@ignition.msgs.Boolean',
           '/color@std_msgs/msg/ColorRGBA@ignition.msgs.Color',
           '/empty@std_msgs/msg/Empty@ignition.msgs.Empty',

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -243,6 +243,11 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::StringMsg_V stringmsg_v_msg;
   ros_ign_bridge::testing::createTestMsg(stringmsg_v_msg);
 
+  // ignition::msgs::Time.
+  auto time_pub = node.Advertise<ignition::msgs::Time>("time");
+  ignition::msgs::Time time_msg;
+  ros_ign_bridge::testing::createTestMsg(time_msg);
+
   // ignition::msgs::TrackVisual.
   auto track_visual_pub = node.Advertise<ignition::msgs::TrackVisual>("track_visual");
   ignition::msgs::TrackVisual track_visual_msg;
@@ -293,6 +298,7 @@ int main(int /*argc*/, char **/*argv*/)
     joint_trajectory_pub.Publish(joint_trajectory_msg);
     gui_camera_pub.Publish(gui_camera_msg);
     stringmsg_v_pub.Publish(stringmsg_v_msg);
+    time_pub.Publish(time_msg);
     track_visual_pub.Publish(track_visual_msg);
     video_record_pub.Publish(video_record_msg);
 

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -23,6 +23,11 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("ros_string_publisher");
 
   rclcpp::Rate loop_rate(1);
+  // builtin_interfaces::msg::Time.
+  auto time_pub = node->create_publisher<builtin_interfaces::msg::Time>("time", 1000);
+  builtin_interfaces::msg::Time time_msg;
+  ros_ign_bridge::testing::createTestMsg(time_msg);
+
   // std_msgs::msg::Color.
   auto color_pub = node->create_publisher<std_msgs::msg::ColorRGBA>("color", 1000);
   std_msgs::msg::ColorRGBA color_msg;
@@ -255,6 +260,7 @@ int main(int argc, char ** argv)
 
   while (rclcpp::ok()) {
     // Publish all messages.
+    time_pub->publish(time_msg);
     color_pub->publish(color_msg);
     bool_pub->publish(bool_msg);
     empty_pub->publish(empty_msg);

--- a/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
@@ -490,6 +490,18 @@ TEST(IgnSubscriberTest, StringMsg_V)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, Time)
+{
+  MyTestClass<ignition::msgs::Time> client("time");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 100ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(IgnSubscriberTest, TrackVisual)
 {
   MyTestClass<ignition::msgs::TrackVisual> client("track_visual");

--- a/ros_ign_bridge/test/subscribers/ros_subscriber/builtin_interfaces_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber/builtin_interfaces_subscriber.cpp
@@ -1,0 +1,34 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "ros_subscriber.hpp"
+
+using ros_subscriber::MyTestClass;
+
+/////////////////////////////////////////////////
+TEST(ROSSubscriberTest, Time)
+{
+  MyTestClass<builtin_interfaces::msg::Time> client("time");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    ros_subscriber::TestNode(), client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -1074,6 +1074,21 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::StringMsg_V> & _msg)
   EXPECT_EQ(expected_msg.data(0), _msg->data(0));
 }
 
+void createTestMsg(ignition::msgs::Time & _msg)
+{
+  _msg.set_sec(12);
+  _msg.set_nsec(150);
+}
+
+void compareTestMsg(const std::shared_ptr<ignition::msgs::Time> & _msg)
+{
+  ignition::msgs::Time expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.sec(), _msg->sec());
+  EXPECT_EQ(expected_msg.nsec(), _msg->nsec());
+}
+
 void createTestMsg(ignition::msgs::TrackVisual & _msg)
 {
   ignition::msgs::Header header_msg;

--- a/ros_ign_bridge/test/utils/ign_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.hpp
@@ -345,6 +345,14 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::StringMsg_V> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.
+void createTestMsg(ignition::msgs::Time & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ignition::msgs::Time> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
 void createTestMsg(ignition::msgs::TrackVisual & _msg);
 
 /// \brief Compare a message with the populated for testing.

--- a/ros_ign_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.cpp
@@ -23,6 +23,20 @@ namespace ros_ign_bridge
 {
 namespace testing
 {
+void createTestMsg(builtin_interfaces::msg::Time & _msg)
+{
+  _msg.sec = 12;
+  _msg.nanosec = 150;
+}
+
+void compareTestMsg(const std::shared_ptr<builtin_interfaces::msg::Time> & _msg)
+{
+  builtin_interfaces::msg::Time expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.sec, _msg->sec);
+  EXPECT_EQ(expected_msg.nanosec, _msg->nanosec);
+}
 
 void createTestMsg(std_msgs::msg::Bool & _msg)
 {

--- a/ros_ign_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 
+#include <builtin_interfaces/msg/time.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/color_rgba.hpp>
 #include <std_msgs/msg/empty.hpp>
@@ -66,6 +67,16 @@ namespace testing
 //////////////////////////////////////////////////
 /// ROS test utils
 //////////////////////////////////////////////////
+
+/// builtin_interfaces
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(builtin_interfaces::msg::Time & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<builtin_interfaces::msg::Time> & _msg);
 
 /// std_msgs
 


### PR DESCRIPTION
# 🎉 New feature

Split from #211.

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
Add the following conversions:

* ros_ign_interfaces/WorldControl <-> ignition.msgs.WorldControl
* builtin_interfaces/Time <-> ignition.msgs.Time

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.