### PR TITLE
Adds pose and twist with covariance messages bridging

### DIFF
--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -6,51 +6,54 @@ between ROS and Ignition Transport.
 The bridge is currently implemented in C++. At this point there's no support for
 service calls. Its support is limited to only the following message types:
 
-| ROS type                             | Ignition Transport type              |
-|--------------------------------------|:------------------------------------:|
-| builtin_interfaces/msg/Time          | ignition::msgs::Time                 |
-| std_msgs/msg/Bool                    | ignition::msgs::Boolean              |
-| std_msgs/msg/ColorRGBA               | ignition::msgs::Color                |
-| std_msgs/msg/Empty                   | ignition::msgs::Empty                |
-| std_msgs/msg/Float32                 | ignition::msgs::Float                |
-| std_msgs/msg/Float64                 | ignition::msgs::Double               |
-| std_msgs/msg/Header                  | ignition::msgs::Header               |
-| std_msgs/msg/Int32                   | ignition::msgs::Int32                |
-| std_msgs/msg/UInt32                  | ignition::msgs::UInt32               |
-| std_msgs/msg/String                  | ignition::msgs::StringMsg            |
-| geometry_msgs/msg/Wrench             | ignition::msgs::Wrench               |
-| geometry_msgs/msg/Quaternion         | ignition::msgs::Quaternion           |
-| geometry_msgs/msg/Vector3            | ignition::msgs::Vector3d             |
-| geometry_msgs/msg/Point              | ignition::msgs::Vector3d             |
-| geometry_msgs/msg/Pose               | ignition::msgs::Pose                 |
-| geometry_msgs/msg/PoseStamped        | ignition::msgs::Pose                 |
-| geometry_msgs/msg/Transform          | ignition::msgs::Pose                 |
-| geometry_msgs/msg/TransformStamped   | ignition::msgs::Pose                 |
-| geometry_msgs/msg/Twist              | ignition::msgs::Twist                |
-| mav_msgs/msg/Actuators (TODO)        | ignition::msgs::Actuators (TODO)     |
-| nav_msgs/msg/Odometry                | ignition::msgs::Odometry             |
-| ros_ign_interfaces/msg/Contact       | ignition::msgs::Contact              |
-| ros_ign_interfaces/msg/Contacts      | ignition::msgs::Contacts             |
-| ros_ign_interfaces/msg/Entity        | ignition::msgs::Entity               |
-| ros_ign_interfaces/msg/GuiCamera     | ignition::msgs::GUICamera            |
-| ros_ign_interfaces/msg/JointWrench   | ignition::msgs::JointWrench          |
-| ros_ign_interfaces/msg/Light         | ignition::msgs::Light                |
-| ros_ign_interfaces/msg/StringVec     | ignition::msgs::StringMsg_V          |
-| ros_ign_interfaces/msg/TrackVisual   | ignition::msgs::TrackVisual          |
-| ros_ign_interfaces/msg/VideoRecord   | ignition::msgs::VideoRecord          |
-| ros_ign_interfaces/msg/WorldControl  | ignition::msgs::WorldControl         |
-| rosgraph_msgs/msg/Clock              | ignition::msgs::Clock                |
-| sensor_msgs/msg/BatteryState         | ignition::msgs::BatteryState         |
-| sensor_msgs/msg/CameraInfo           | ignition::msgs::CameraInfo           |
-| sensor_msgs/msg/FluidPressure        | ignition::msgs::FluidPressure        |
-| sensor_msgs/msg/Imu                  | ignition::msgs::IMU                  |
-| sensor_msgs/msg/Image                | ignition::msgs::Image                |
-| sensor_msgs/msg/JointState           | ignition::msgs::Model                |
-| sensor_msgs/msg/LaserScan            | ignition::msgs::LaserScan            |
-| sensor_msgs/msg/MagneticField        | ignition::msgs::Magnetometer         |
-| sensor_msgs/msg/PointCloud2          | ignition::msgs::PointCloudPacked     |
-| tf2_msgs/msg/TFMessage               | ignition::msgs::Pose_V               |
-| trajectory_msgs/msg/JointTrajectory  | ignition::msgs::JointTrajectory      |
+| ROS type                             | Ignition Transport type                |
+|--------------------------------------|:--------------------------------------:|
+| builtin_interfaces/msg/Time          | ignition::msgs::Time                   |
+| std_msgs/msg/Bool                    | ignition::msgs::Boolean                |
+| std_msgs/msg/ColorRGBA               | ignition::msgs::Color                  |
+| std_msgs/msg/Empty                   | ignition::msgs::Empty                  |
+| std_msgs/msg/Float32                 | ignition::msgs::Float                  |
+| std_msgs/msg/Float64                 | ignition::msgs::Double                 |
+| std_msgs/msg/Header                  | ignition::msgs::Header                 |
+| std_msgs/msg/Int32                   | ignition::msgs::Int32                  |
+| std_msgs/msg/UInt32                  | ignition::msgs::UInt32                 |
+| std_msgs/msg/String                  | ignition::msgs::StringMsg              |
+| geometry_msgs/msg/Wrench             | ignition::msgs::Wrench                 |
+| geometry_msgs/msg/Quaternion         | ignition::msgs::Quaternion             |
+| geometry_msgs/msg/Vector3            | ignition::msgs::Vector3d               |
+| geometry_msgs/msg/Point              | ignition::msgs::Vector3d               |
+| geometry_msgs/msg/Pose               | ignition::msgs::Pose                   |
+| geometry_msgs/msg/PoseWithCovariance | ignition::msgs::PoseWithCovariance     |
+| geometry_msgs/msg/PoseStamped        | ignition::msgs::Pose                   |
+| geometry_msgs/msg/Transform          | ignition::msgs::Pose                   |
+| geometry_msgs/msg/TransformStamped   | ignition::msgs::Pose                   |
+| geometry_msgs/msg/Twist              | ignition::msgs::Twist                  |
+| geometry_msgs/msg/TwistWithCovariance| ignition::msgs::TwistWithCovariance    |
+| mav_msgs/msg/Actuators (TODO)        | ignition::msgs::Actuators (TODO)       |
+| nav_msgs/msg/Odometry                | ignition::msgs::Odometry               |
+| nav_msgs/msg/Odometry                | ignition::msgs::OdometryWithCovariance |
+| ros_ign_interfaces/msg/Contact       | ignition::msgs::Contact                |
+| ros_ign_interfaces/msg/Contacts      | ignition::msgs::Contacts               |
+| ros_ign_interfaces/msg/Entity        | ignition::msgs::Entity                 |
+| ros_ign_interfaces/msg/GuiCamera     | ignition::msgs::GUICamera              |
+| ros_ign_interfaces/msg/JointWrench   | ignition::msgs::JointWrench            |
+| ros_ign_interfaces/msg/Light         | ignition::msgs::Light                  |
+| ros_ign_interfaces/msg/StringVec     | ignition::msgs::StringMsg_V            |
+| ros_ign_interfaces/msg/TrackVisual   | ignition::msgs::TrackVisual            |
+| ros_ign_interfaces/msg/VideoRecord   | ignition::msgs::VideoRecord            |
+| ros_ign_interfaces/msg/WorldControl  | ignition::msgs::WorldControl           |
+| rosgraph_msgs/msg/Clock              | ignition::msgs::Clock                  |
+| sensor_msgs/msg/BatteryState         | ignition::msgs::BatteryState           |
+| sensor_msgs/msg/CameraInfo           | ignition::msgs::CameraInfo             |
+| sensor_msgs/msg/FluidPressure        | ignition::msgs::FluidPressure          |
+| sensor_msgs/msg/Imu                  | ignition::msgs::IMU                    |
+| sensor_msgs/msg/Image                | ignition::msgs::Image                  |
+| sensor_msgs/msg/JointState           | ignition::msgs::Model                  |
+| sensor_msgs/msg/LaserScan            | ignition::msgs::LaserScan              |
+| sensor_msgs/msg/MagneticField        | ignition::msgs::Magnetometer           |
+| sensor_msgs/msg/PointCloud2          | ignition::msgs::PointCloudPacked       |
+| tf2_msgs/msg/TFMessage               | ignition::msgs::Pose_V                 |
+| trajectory_msgs/msg/JointTrajectory  | ignition::msgs::JointTrajectory        |
 
 Run `ros2 run ros_ign_bridge parameter_bridge -h` for instructions.
 

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/geometry_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/geometry_msgs.hpp
@@ -19,6 +19,7 @@
 #include <ignition/msgs/quaternion.pb.h>
 #include <ignition/msgs/vector3d.pb.h>
 #include <ignition/msgs/pose.pb.h>
+#include <ignition/msgs/pose_with_covariance.pb.h>
 #include <ignition/msgs/pose_v.pb.h>
 #include <ignition/msgs/twist.pb.h>
 #include <ignition/msgs/wrench.pb.h>
@@ -26,6 +27,7 @@
 // ROS 2 messages
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_with_covariance.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -85,6 +87,18 @@ void
 convert_ign_to_ros(
   const ignition::msgs::Pose & ign_msg,
   geometry_msgs::msg::Pose & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const geometry_msgs::msg::PoseWithCovariance & ros_msg,
+  ignition::msgs::PoseWithCovariance & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::PoseWithCovariance & ign_msg,
+  geometry_msgs::msg::PoseWithCovariance & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/geometry_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/geometry_msgs.hpp
@@ -22,6 +22,7 @@
 #include <ignition/msgs/pose_with_covariance.pb.h>
 #include <ignition/msgs/pose_v.pb.h>
 #include <ignition/msgs/twist.pb.h>
+#include <ignition/msgs/twist_with_covariance.pb.h>
 #include <ignition/msgs/wrench.pb.h>
 
 // ROS 2 messages
@@ -32,6 +33,7 @@
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_with_covariance.hpp>
 #include <geometry_msgs/msg/wrench.hpp>
 
 #include <ros_ign_bridge/convert_decl.hpp>
@@ -147,6 +149,18 @@ void
 convert_ign_to_ros(
   const ignition::msgs::Twist & ign_msg,
   geometry_msgs::msg::Twist & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const geometry_msgs::msg::TwistWithCovariance & ros_msg,
+  ignition::msgs::TwistWithCovariance & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::TwistWithCovariance & ign_msg,
+  geometry_msgs::msg::TwistWithCovariance & ros_msg);
 
 template<>
 void

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/nav_msgs.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/nav_msgs.hpp
@@ -17,6 +17,7 @@
 
 // Ignition messages
 #include <ignition/msgs/odometry.pb.h>
+#include <ignition/msgs/odometry_with_covariance.pb.h>
 
 // ROS 2 messages
 #include <nav_msgs/msg/odometry.hpp>
@@ -36,6 +37,18 @@ template<>
 void
 convert_ign_to_ros(
   const ignition::msgs::Odometry & ign_msg,
+  nav_msgs::msg::Odometry & ros_msg);
+
+template<>
+void
+convert_ros_to_ign(
+  const nav_msgs::msg::Odometry & ros_msg,
+  ignition::msgs::OdometryWithCovariance & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::OdometryWithCovariance & ign_msg,
   nav_msgs::msg::Odometry & ros_msg);
 
 }  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/convert/geometry_msgs.cpp
@@ -220,6 +220,26 @@ convert_ign_to_ros(
 template<>
 void
 convert_ros_to_ign(
+  const geometry_msgs::msg::TwistWithCovariance & ros_msg,
+  ignition::msgs::TwistWithCovariance & ign_msg)
+{
+  convert_ros_to_ign(ros_msg.twist.linear, (*ign_msg.mutable_twist()->mutable_linear()));
+  convert_ros_to_ign(ros_msg.twist.angular, (*ign_msg.mutable_twist()->mutable_angular()));
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::TwistWithCovariance & ign_msg,
+  geometry_msgs::msg::TwistWithCovariance & ros_msg)
+{
+  convert_ign_to_ros(ign_msg.twist().linear(), ros_msg.twist.linear);
+  convert_ign_to_ros(ign_msg.twist().angular(), ros_msg.twist.angular);
+}
+
+template<>
+void
+convert_ros_to_ign(
   const geometry_msgs::msg::Wrench & ros_msg,
   ignition::msgs::Wrench & ign_msg)
 {

--- a/ros_ign_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/convert/geometry_msgs.cpp
@@ -112,7 +112,7 @@ convert_ros_to_ign(
   const geometry_msgs::msg::PoseWithCovariance & ros_msg,
   ignition::msgs::PoseWithCovariance & ign_msg)
 {
-  convert_ros_to_ign(ros_msg.pose.position, *ign_msg.mutable_pose()->mutable_position());  
+  convert_ros_to_ign(ros_msg.pose.position, *ign_msg.mutable_pose()->mutable_position());
   convert_ros_to_ign(ros_msg.pose.orientation, *ign_msg.mutable_pose()->mutable_orientation());
   for (const auto & elem : ros_msg.covariance) {
     ign_msg.mutable_covariance()->add_data(elem);

--- a/ros_ign_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/convert/geometry_msgs.cpp
@@ -128,9 +128,11 @@ convert_ign_to_ros(
   convert_ign_to_ros(ign_msg.pose().position(), ros_msg.pose.position);
   convert_ign_to_ros(ign_msg.pose().orientation(), ros_msg.pose.orientation);
   int data_size = ign_msg.covariance().data_size();
-  for (int i = 0 ; i < data_size ; i++) {
-    auto data = ign_msg.covariance().data()[i];
-    ros_msg.covariance[i] = data;
+  if (data_size == 36) {
+    for (int i = 0 ; i < data_size ; i++) {
+      auto data = ign_msg.covariance().data()[i];
+      ros_msg.covariance[i] = data;
+    }
   }
 }
 
@@ -247,9 +249,11 @@ convert_ign_to_ros(
   convert_ign_to_ros(ign_msg.twist().linear(), ros_msg.twist.linear);
   convert_ign_to_ros(ign_msg.twist().angular(), ros_msg.twist.angular);
   int data_size = ign_msg.covariance().data_size();
-  for (int i = 0 ; i < data_size ; i++) {
-    auto data = ign_msg.covariance().data()[i];
-    ros_msg.covariance[i] = data;
+  if (data_size == 36){
+    for (int i = 0 ; i < data_size ; i++) {
+      auto data = ign_msg.covariance().data()[i];
+      ros_msg.covariance[i] = data;
+    }
   }
 }
 

--- a/ros_ign_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/convert/geometry_msgs.cpp
@@ -109,6 +109,28 @@ convert_ign_to_ros(
 template<>
 void
 convert_ros_to_ign(
+  const geometry_msgs::msg::PoseWithCovariance & ros_msg,
+  ignition::msgs::PoseWithCovariance & ign_msg)
+{
+  std::cout << "dbg 1" << std::endl;
+  convert_ros_to_ign(ros_msg.pose.position, *ign_msg.mutable_pose()->mutable_position());  
+  convert_ros_to_ign(ros_msg.pose.orientation, *ign_msg.mutable_pose()->mutable_orientation());
+  std::cout << "dbg 2" << std::endl;
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::PoseWithCovariance & ign_msg,
+  geometry_msgs::msg::PoseWithCovariance & ros_msg)
+{
+  convert_ign_to_ros(ign_msg.pose().position(), ros_msg.pose.position);
+  convert_ign_to_ros(ign_msg.pose().orientation(), ros_msg.pose.orientation);
+}
+
+template<>
+void
+convert_ros_to_ign(
   const geometry_msgs::msg::PoseStamped & ros_msg,
   ignition::msgs::Pose & ign_msg)
 {

--- a/ros_ign_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/convert/geometry_msgs.cpp
@@ -112,10 +112,8 @@ convert_ros_to_ign(
   const geometry_msgs::msg::PoseWithCovariance & ros_msg,
   ignition::msgs::PoseWithCovariance & ign_msg)
 {
-  std::cout << "dbg 1" << std::endl;
   convert_ros_to_ign(ros_msg.pose.position, *ign_msg.mutable_pose()->mutable_position());  
   convert_ros_to_ign(ros_msg.pose.orientation, *ign_msg.mutable_pose()->mutable_orientation());
-  std::cout << "dbg 2" << std::endl;
 }
 
 template<>

--- a/ros_ign_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/convert/geometry_msgs.cpp
@@ -129,7 +129,7 @@ convert_ign_to_ros(
   convert_ign_to_ros(ign_msg.pose().orientation(), ros_msg.pose.orientation);
   int data_size = ign_msg.covariance().data_size();
   if (data_size == 36) {
-    for (int i = 0 ; i < data_size ; i++) {
+    for (int i = 0; i < data_size; i++) {
       auto data = ign_msg.covariance().data()[i];
       ros_msg.covariance[i] = data;
     }
@@ -250,7 +250,7 @@ convert_ign_to_ros(
   convert_ign_to_ros(ign_msg.twist().angular(), ros_msg.twist.angular);
   int data_size = ign_msg.covariance().data_size();
   if (data_size == 36) {
-    for (int i = 0 ; i < data_size ; i++) {
+    for (int i = 0; i < data_size; i++) {
       auto data = ign_msg.covariance().data()[i];
       ros_msg.covariance[i] = data;
     }

--- a/ros_ign_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/convert/geometry_msgs.cpp
@@ -249,7 +249,7 @@ convert_ign_to_ros(
   convert_ign_to_ros(ign_msg.twist().linear(), ros_msg.twist.linear);
   convert_ign_to_ros(ign_msg.twist().angular(), ros_msg.twist.angular);
   int data_size = ign_msg.covariance().data_size();
-  if (data_size == 36){
+  if (data_size == 36) {
     for (int i = 0 ; i < data_size ; i++) {
       auto data = ign_msg.covariance().data()[i];
       ros_msg.covariance[i] = data;

--- a/ros_ign_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/convert/geometry_msgs.cpp
@@ -114,6 +114,9 @@ convert_ros_to_ign(
 {
   convert_ros_to_ign(ros_msg.pose.position, *ign_msg.mutable_pose()->mutable_position());  
   convert_ros_to_ign(ros_msg.pose.orientation, *ign_msg.mutable_pose()->mutable_orientation());
+  for (const auto & elem : ros_msg.covariance) {
+    ign_msg.mutable_covariance()->add_data(elem);
+  }
 }
 
 template<>
@@ -124,6 +127,11 @@ convert_ign_to_ros(
 {
   convert_ign_to_ros(ign_msg.pose().position(), ros_msg.pose.position);
   convert_ign_to_ros(ign_msg.pose().orientation(), ros_msg.pose.orientation);
+  int data_size = ign_msg.covariance().data_size();
+  for (int i = 0 ; i < data_size ; i++) {
+    auto data = ign_msg.covariance().data()[i];
+    ros_msg.covariance[i] = data;
+  }
 }
 
 template<>
@@ -225,6 +233,9 @@ convert_ros_to_ign(
 {
   convert_ros_to_ign(ros_msg.twist.linear, (*ign_msg.mutable_twist()->mutable_linear()));
   convert_ros_to_ign(ros_msg.twist.angular, (*ign_msg.mutable_twist()->mutable_angular()));
+  for (const auto & elem : ros_msg.covariance) {
+    ign_msg.mutable_covariance()->add_data(elem);
+  }
 }
 
 template<>
@@ -235,6 +246,11 @@ convert_ign_to_ros(
 {
   convert_ign_to_ros(ign_msg.twist().linear(), ros_msg.twist.linear);
   convert_ign_to_ros(ign_msg.twist().angular(), ros_msg.twist.angular);
+  int data_size = ign_msg.covariance().data_size();
+  for (int i = 0 ; i < data_size ; i++) {
+    auto data = ign_msg.covariance().data()[i];
+    ros_msg.covariance[i] = data;
+  }
 }
 
 template<>

--- a/ros_ign_bridge/src/convert/nav_msgs.cpp
+++ b/ros_ign_bridge/src/convert/nav_msgs.cpp
@@ -44,9 +44,9 @@ convert_ign_to_ros(
   convert_ign_to_ros(ign_msg.twist(), ros_msg.twist.twist);
 
   for (auto i = 0; i < ign_msg.header().data_size(); ++i) {
-    auto aPair = ign_msg.header().data(i);
-    if (aPair.key() == "child_frame_id" && aPair.value_size() > 0) {
-      ros_msg.child_frame_id = frame_id_ign_to_ros(aPair.value(0));
+    auto a_pair = ign_msg.header().data(i);
+    if (a_pair.key() == "child_frame_id" && a_pair.value_size() > 0) {
+      ros_msg.child_frame_id = frame_id_ign_to_ros(a_pair.value(0));
       break;
     }
   }
@@ -78,9 +78,9 @@ convert_ign_to_ros(
   convert_ign_to_ros(ign_msg.twist_with_covariance(), ros_msg.twist);
 
   for (auto i = 0; i < ign_msg.header().data_size(); ++i) {
-    auto aPair = ign_msg.header().data(i);
-    if (aPair.key() == "child_frame_id" && aPair.value_size() > 0) {
-      ros_msg.child_frame_id = frame_id_ign_to_ros(aPair.value(0));
+    auto a_pair = ign_msg.header().data(i);
+    if (a_pair.key() == "child_frame_id" && a_pair.value_size() > 0) {
+      ros_msg.child_frame_id = frame_id_ign_to_ros(a_pair.value(0));
       break;
     }
   }

--- a/ros_ign_bridge/src/convert/nav_msgs.cpp
+++ b/ros_ign_bridge/src/convert/nav_msgs.cpp
@@ -52,4 +52,38 @@ convert_ign_to_ros(
   }
 }
 
+template<>
+void
+convert_ros_to_ign(
+  const nav_msgs::msg::Odometry & ros_msg,
+  ignition::msgs::OdometryWithCovariance & ign_msg)
+{
+  convert_ros_to_ign(ros_msg.header, (*ign_msg.mutable_header()));
+  convert_ros_to_ign(ros_msg.pose, (*ign_msg.mutable_pose_with_covariance()));
+  convert_ros_to_ign(ros_msg.twist, (*ign_msg.mutable_twist_with_covariance()));
+
+  auto childFrame = ign_msg.mutable_header()->add_data();
+  childFrame->set_key("child_frame_id");
+  childFrame->add_value(ros_msg.child_frame_id);
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::OdometryWithCovariance & ign_msg,
+  nav_msgs::msg::Odometry & ros_msg)
+{
+  convert_ign_to_ros(ign_msg.header(), ros_msg.header);
+  convert_ign_to_ros(ign_msg.pose_with_covariance(), ros_msg.pose);
+  convert_ign_to_ros(ign_msg.twist_with_covariance(), ros_msg.twist);
+
+  for (auto i = 0; i < ign_msg.header().data_size(); ++i) {
+    auto aPair = ign_msg.header().data(i);
+    if (aPair.key() == "child_frame_id" && aPair.value_size() > 0) {
+      ros_msg.child_frame_id = frame_id_ign_to_ros(aPair.value(0));
+      break;
+    }
+  }
+}
+
 }  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/factories/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/factories/geometry_msgs.cpp
@@ -76,7 +76,7 @@ get_factory__geometry_msgs(
         geometry_msgs::msg::PoseWithCovariance,
         ignition::msgs::PoseWithCovariance
       >
-    >("geometry_msgs/msg/Pose", ign_type_name);
+    >("geometry_msgs/msg/PoseWithCovariance", ign_type_name);
   }
   if ((ros_type_name == "geometry_msgs/msg/PoseStamped" || ros_type_name.empty()) &&
     ign_type_name == "ignition.msgs.Pose")

--- a/ros_ign_bridge/src/factories/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/factories/geometry_msgs.cpp
@@ -120,6 +120,17 @@ get_factory__geometry_msgs(
     >("geometry_msgs/msg/Twist", ign_type_name);
   }
   if (
+    (ros_type_name == "geometry_msgs/msg/TwistWithCovariance" || ros_type_name.empty()) &&
+    ign_type_name == "ignition.msgs.TwistWithCovariance")
+  {
+    return std::make_shared<
+      Factory<
+        geometry_msgs::msg::TwistWithCovariance,
+        ignition::msgs::TwistWithCovariance
+      >
+    >("geometry_msgs/msg/TwistWithCovariance", ign_type_name);
+  }
+  if (
     (ros_type_name == "geometry_msgs/msg/Wrench" || ros_type_name.empty()) &&
     ign_type_name == "ignition.msgs.Wrench")
   {
@@ -345,6 +356,30 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Twist & ign_msg,
   geometry_msgs::msg::Twist & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::msg::TwistWithCovariance,
+  ignition::msgs::TwistWithCovariance
+>::convert_ros_to_ign(
+  const geometry_msgs::msg::TwistWithCovariance & ros_msg,
+  ignition::msgs::TwistWithCovariance & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::msg::TwistWithCovariance,
+  ignition::msgs::TwistWithCovariance
+>::convert_ign_to_ros(
+  const ignition::msgs::TwistWithCovariance & ign_msg,
+  geometry_msgs::msg::TwistWithCovariance & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
 }

--- a/ros_ign_bridge/src/factories/geometry_msgs.cpp
+++ b/ros_ign_bridge/src/factories/geometry_msgs.cpp
@@ -68,6 +68,16 @@ get_factory__geometry_msgs(
       >
     >("geometry_msgs/msg/Pose", ign_type_name);
   }
+  if ((ros_type_name == "geometry_msgs/msg/PoseWithCovariance" || ros_type_name.empty()) &&
+    ign_type_name == "ignition.msgs.PoseWithCovariance")
+  {
+    return std::make_shared<
+      Factory<
+        geometry_msgs::msg::PoseWithCovariance,
+        ignition::msgs::PoseWithCovariance
+      >
+    >("geometry_msgs/msg/Pose", ign_type_name);
+  }
   if ((ros_type_name == "geometry_msgs/msg/PoseStamped" || ros_type_name.empty()) &&
     ign_type_name == "ignition.msgs.Pose")
   {
@@ -215,6 +225,30 @@ Factory<
 >::convert_ign_to_ros(
   const ignition::msgs::Pose & ign_msg,
   geometry_msgs::msg::Pose & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::msg::PoseWithCovariance,
+  ignition::msgs::PoseWithCovariance
+>::convert_ros_to_ign(
+  const geometry_msgs::msg::PoseWithCovariance & ros_msg,
+  ignition::msgs::PoseWithCovariance & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::msg::PoseWithCovariance,
+  ignition::msgs::PoseWithCovariance
+>::convert_ign_to_ros(
+  const ignition::msgs::PoseWithCovariance & ign_msg,
+  geometry_msgs::msg::PoseWithCovariance & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
 }

--- a/ros_ign_bridge/src/factories/nav_msgs.cpp
+++ b/ros_ign_bridge/src/factories/nav_msgs.cpp
@@ -38,6 +38,16 @@ get_factory__nav_msgs(
       >
     >("nav_msgs/msg/Odometry", ign_type_name);
   }
+  if ((ros_type_name == "nav_msgs/msg/Odometry" || ros_type_name.empty()) &&
+    ign_type_name == "ignition.msgs.OdometryWithCovariance")
+  {
+    return std::make_shared<
+      Factory<
+        nav_msgs::msg::Odometry,
+        ignition::msgs::OdometryWithCovariance
+      >
+    >("nav_msgs/msg/Odometry", ign_type_name);
+  }
   return nullptr;
 }
 
@@ -60,6 +70,30 @@ Factory<
   ignition::msgs::Odometry
 >::convert_ign_to_ros(
   const ignition::msgs::Odometry & ign_msg,
+  nav_msgs::msg::Odometry & ros_msg)
+{
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+}
+
+template<>
+void
+Factory<
+  nav_msgs::msg::Odometry,
+  ignition::msgs::OdometryWithCovariance
+>::convert_ros_to_ign(
+  const nav_msgs::msg::Odometry & ros_msg,
+  ignition::msgs::OdometryWithCovariance & ign_msg)
+{
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  nav_msgs::msg::Odometry,
+  ignition::msgs::OdometryWithCovariance
+>::convert_ign_to_ros(
+  const ignition::msgs::OdometryWithCovariance & ign_msg,
   nav_msgs::msg::Odometry & ros_msg)
 {
   ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);

--- a/ros_ign_bridge/src/parameter_bridge.cpp
+++ b/ros_ign_bridge/src/parameter_bridge.cpp
@@ -170,6 +170,7 @@ int main(int argc, char * argv[])
           break;
       }
     } catch (std::runtime_error & _e) {
+      std::cout << _e.what() << std::endl;
       std::cerr << "Failed to create a bridge for topic [" << topic_name << "] " <<
         "with ROS2 type [" << ros_type_name << "] and " <<
         "Ignition Transport type [" << ign_type_name << "]" << std::endl;

--- a/ros_ign_bridge/src/parameter_bridge.cpp
+++ b/ros_ign_bridge/src/parameter_bridge.cpp
@@ -170,7 +170,6 @@ int main(int argc, char * argv[])
           break;
       }
     } catch (std::runtime_error & _e) {
-      std::cout << _e.what() << std::endl;
       std::cerr << "Failed to create a bridge for topic [" << topic_name << "] " <<
         "with ROS2 type [" << ros_type_name << "] and " <<
         "Ignition Transport type [" << ign_type_name << "]" << std::endl;

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
@@ -54,14 +54,14 @@ def generate_test_description():
           '/point@geometry_msgs/msg/Point@ignition.msgs.Vector3d',
           '/pose@geometry_msgs/msg/Pose@ignition.msgs.Pose',
           '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@'
-                  'ignition.msgs.PoseWithCovariance',
+          'ignition.msgs.PoseWithCovariance',
           '/pose_stamped@geometry_msgs/msg/PoseStamped@ignition.msgs.Pose',
           '/transform@geometry_msgs/msg/Transform@ignition.msgs.Pose',
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',
           '/transform_stamped@geometry_msgs/msg/TransformStamped@ignition.msgs.Pose',
           '/twist@geometry_msgs/msg/Twist@ignition.msgs.Twist',
           '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@'
-                  'ignition.msgs.TwistWithCovariance',
+          'ignition.msgs.TwistWithCovariance',
           '/wrench@geometry_msgs/msg/Wrench@ignition.msgs.Wrench',
           '/joint_wrench@ros_ign_interfaces/msg/JointWrench@ignition.msgs.JointWrench',
           '/entity@ros_ign_interfaces/msg/Entity@ignition.msgs.Entity',
@@ -81,7 +81,7 @@ def generate_test_description():
           # '/actuators@mav_msgs/msg/Actuators@ignition.msgs.Actuators',
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
           '/odometry_with_covariance@nav_msgs/msg/Odometry@'
-                  'ignition.msgs.OdometryWithCovariance',
+          'ignition.msgs.OdometryWithCovariance',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
           '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
@@ -53,13 +53,15 @@ def generate_test_description():
           '/clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock',
           '/point@geometry_msgs/msg/Point@ignition.msgs.Vector3d',
           '/pose@geometry_msgs/msg/Pose@ignition.msgs.Pose',
-          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@ignition.msgs.PoseWithCovariance',
+          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@\
+                  ignition.msgs.PoseWithCovariance',
           '/pose_stamped@geometry_msgs/msg/PoseStamped@ignition.msgs.Pose',
           '/transform@geometry_msgs/msg/Transform@ignition.msgs.Pose',
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',
           '/transform_stamped@geometry_msgs/msg/TransformStamped@ignition.msgs.Pose',
           '/twist@geometry_msgs/msg/Twist@ignition.msgs.Twist',
-          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@ignition.msgs.TwistWithCovariance',
+          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@\
+                  ignition.msgs.TwistWithCovariance',
           '/wrench@geometry_msgs/msg/Wrench@ignition.msgs.Wrench',
           '/joint_wrench@ros_ign_interfaces/msg/JointWrench@ignition.msgs.JointWrench',
           '/entity@ros_ign_interfaces/msg/Entity@ignition.msgs.Entity',
@@ -78,7 +80,8 @@ def generate_test_description():
           '/magnetic@sensor_msgs/msg/MagneticField@ignition.msgs.Magnetometer',
           # '/actuators@mav_msgs/msg/Actuators@ignition.msgs.Actuators',
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
-          '/odometry_with_covariance@nav_msgs/msg/Odometry@ignition.msgs.OdometryWithCovariance',
+          '/odometry_with_covariance@nav_msgs/msg/Odometry@\
+                  ignition.msgs.OdometryWithCovariance',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
           '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
@@ -53,6 +53,7 @@ def generate_test_description():
           '/clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock',
           '/point@geometry_msgs/msg/Point@ignition.msgs.Vector3d',
           '/pose@geometry_msgs/msg/Pose@ignition.msgs.Pose',
+          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@ignition.msgs.PoseWithCovariance',
           '/pose_stamped@geometry_msgs/msg/PoseStamped@ignition.msgs.Pose',
           '/transform@geometry_msgs/msg/Transform@ignition.msgs.Pose',
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
@@ -59,6 +59,7 @@ def generate_test_description():
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',
           '/transform_stamped@geometry_msgs/msg/TransformStamped@ignition.msgs.Pose',
           '/twist@geometry_msgs/msg/Twist@ignition.msgs.Twist',
+          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@ignition.msgs.TwistWithCovariance',
           '/wrench@geometry_msgs/msg/Wrench@ignition.msgs.Wrench',
           '/joint_wrench@ros_ign_interfaces/msg/JointWrench@ignition.msgs.JointWrench',
           '/entity@ros_ign_interfaces/msg/Entity@ignition.msgs.Entity',

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
@@ -78,6 +78,7 @@ def generate_test_description():
           '/magnetic@sensor_msgs/msg/MagneticField@ignition.msgs.Magnetometer',
           # '/actuators@mav_msgs/msg/Actuators@ignition.msgs.Actuators',
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
+          '/odometry_with_covariance@nav_msgs/msg/Odometry@ignition.msgs.OdometryWithCovariance',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
           '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',

--- a/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ign_subscriber.launch.py
@@ -53,15 +53,15 @@ def generate_test_description():
           '/clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock',
           '/point@geometry_msgs/msg/Point@ignition.msgs.Vector3d',
           '/pose@geometry_msgs/msg/Pose@ignition.msgs.Pose',
-          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@\
-                  ignition.msgs.PoseWithCovariance',
+          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@'
+                  'ignition.msgs.PoseWithCovariance',
           '/pose_stamped@geometry_msgs/msg/PoseStamped@ignition.msgs.Pose',
           '/transform@geometry_msgs/msg/Transform@ignition.msgs.Pose',
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',
           '/transform_stamped@geometry_msgs/msg/TransformStamped@ignition.msgs.Pose',
           '/twist@geometry_msgs/msg/Twist@ignition.msgs.Twist',
-          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@\
-                  ignition.msgs.TwistWithCovariance',
+          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@'
+                  'ignition.msgs.TwistWithCovariance',
           '/wrench@geometry_msgs/msg/Wrench@ignition.msgs.Wrench',
           '/joint_wrench@ros_ign_interfaces/msg/JointWrench@ignition.msgs.JointWrench',
           '/entity@ros_ign_interfaces/msg/Entity@ignition.msgs.Entity',
@@ -80,8 +80,8 @@ def generate_test_description():
           '/magnetic@sensor_msgs/msg/MagneticField@ignition.msgs.Magnetometer',
           # '/actuators@mav_msgs/msg/Actuators@ignition.msgs.Actuators',
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
-          '/odometry_with_covariance@nav_msgs/msg/Odometry@\
-                  ignition.msgs.OdometryWithCovariance',
+          '/odometry_with_covariance@nav_msgs/msg/Odometry@'
+                  'ignition.msgs.OdometryWithCovariance',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
           '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
@@ -54,14 +54,14 @@ def generate_test_description():
           '/point@geometry_msgs/msg/Point@ignition.msgs.Vector3d',
           '/pose@geometry_msgs/msg/Pose@ignition.msgs.Pose',
           '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@'
-                  'ignition.msgs.PoseWithCovariance',
+          'ignition.msgs.PoseWithCovariance',
           '/pose_stamped@geometry_msgs/msg/PoseStamped@ignition.msgs.Pose',
           '/transform@geometry_msgs/msg/Transform@ignition.msgs.Pose',
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',
           '/transform_stamped@geometry_msgs/msg/TransformStamped@ignition.msgs.Pose',
           '/twist@geometry_msgs/msg/Twist@ignition.msgs.Twist',
           '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@'
-                  'ignition.msgs.TwistWithCovariance',
+          'ignition.msgs.TwistWithCovariance',
           '/wrench@geometry_msgs/msg/Wrench@ignition.msgs.Wrench',
           '/joint_wrench@ros_ign_interfaces/msg/JointWrench@ignition.msgs.JointWrench',
           '/entity@ros_ign_interfaces/msg/Entity@ignition.msgs.Entity',
@@ -81,7 +81,7 @@ def generate_test_description():
           # '/actuators@mav_msgs/msg/Actuators@ignition.msgs.Actuators',
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
           '/odometry_with_covariance@nav_msgs/msg/Odometry@'
-                  'ignition.msgs.OdometryWithCovariance',
+          'ignition.msgs.OdometryWithCovariance',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
           '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
@@ -53,13 +53,15 @@ def generate_test_description():
           '/clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock',
           '/point@geometry_msgs/msg/Point@ignition.msgs.Vector3d',
           '/pose@geometry_msgs/msg/Pose@ignition.msgs.Pose',
-          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@ignition.msgs.PoseWithCovariance',
+          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@\
+                  ignition.msgs.PoseWithCovariance',
           '/pose_stamped@geometry_msgs/msg/PoseStamped@ignition.msgs.Pose',
           '/transform@geometry_msgs/msg/Transform@ignition.msgs.Pose',
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',
           '/transform_stamped@geometry_msgs/msg/TransformStamped@ignition.msgs.Pose',
           '/twist@geometry_msgs/msg/Twist@ignition.msgs.Twist',
-          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@ignition.msgs.TwistWithCovariance',
+          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@\
+                  ignition.msgs.TwistWithCovariance',
           '/wrench@geometry_msgs/msg/Wrench@ignition.msgs.Wrench',
           '/joint_wrench@ros_ign_interfaces/msg/JointWrench@ignition.msgs.JointWrench',
           '/entity@ros_ign_interfaces/msg/Entity@ignition.msgs.Entity',
@@ -78,7 +80,8 @@ def generate_test_description():
           '/magnetic@sensor_msgs/msg/MagneticField@ignition.msgs.Magnetometer',
           # '/actuators@mav_msgs/msg/Actuators@ignition.msgs.Actuators',
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
-          '/odometry_with_covariance@nav_msgs/msg/Odometry@ignition.msgs.OdometryWithCovariance',
+          '/odometry_with_covariance@nav_msgs/msg/Odometry@\
+                  ignition.msgs.OdometryWithCovariance',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
           '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
@@ -53,6 +53,7 @@ def generate_test_description():
           '/clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock',
           '/point@geometry_msgs/msg/Point@ignition.msgs.Vector3d',
           '/pose@geometry_msgs/msg/Pose@ignition.msgs.Pose',
+          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@ignition.msgs.PoseWithCovariance',
           '/pose_stamped@geometry_msgs/msg/PoseStamped@ignition.msgs.Pose',
           '/transform@geometry_msgs/msg/Transform@ignition.msgs.Pose',
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
@@ -59,6 +59,7 @@ def generate_test_description():
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',
           '/transform_stamped@geometry_msgs/msg/TransformStamped@ignition.msgs.Pose',
           '/twist@geometry_msgs/msg/Twist@ignition.msgs.Twist',
+          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@ignition.msgs.TwistWithCovariance',
           '/wrench@geometry_msgs/msg/Wrench@ignition.msgs.Wrench',
           '/joint_wrench@ros_ign_interfaces/msg/JointWrench@ignition.msgs.JointWrench',
           '/entity@ros_ign_interfaces/msg/Entity@ignition.msgs.Entity',

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
@@ -78,6 +78,7 @@ def generate_test_description():
           '/magnetic@sensor_msgs/msg/MagneticField@ignition.msgs.Magnetometer',
           # '/actuators@mav_msgs/msg/Actuators@ignition.msgs.Actuators',
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
+          '/odometry_with_covariance@nav_msgs/msg/Odometry@ignition.msgs.OdometryWithCovariance',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
           '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',

--- a/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
+++ b/ros_ign_bridge/test/launch/test_ros_subscriber.launch.py
@@ -53,15 +53,15 @@ def generate_test_description():
           '/clock@rosgraph_msgs/msg/Clock@ignition.msgs.Clock',
           '/point@geometry_msgs/msg/Point@ignition.msgs.Vector3d',
           '/pose@geometry_msgs/msg/Pose@ignition.msgs.Pose',
-          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@\
-                  ignition.msgs.PoseWithCovariance',
+          '/pose_with_covariance@geometry_msgs/msg/PoseWithCovariance@'
+                  'ignition.msgs.PoseWithCovariance',
           '/pose_stamped@geometry_msgs/msg/PoseStamped@ignition.msgs.Pose',
           '/transform@geometry_msgs/msg/Transform@ignition.msgs.Pose',
           '/tf2_message@tf2_msgs/msg/TFMessage@ignition.msgs.Pose_V',
           '/transform_stamped@geometry_msgs/msg/TransformStamped@ignition.msgs.Pose',
           '/twist@geometry_msgs/msg/Twist@ignition.msgs.Twist',
-          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@\
-                  ignition.msgs.TwistWithCovariance',
+          '/twist_with_covariance@geometry_msgs/msg/TwistWithCovariance@'
+                  'ignition.msgs.TwistWithCovariance',
           '/wrench@geometry_msgs/msg/Wrench@ignition.msgs.Wrench',
           '/joint_wrench@ros_ign_interfaces/msg/JointWrench@ignition.msgs.JointWrench',
           '/entity@ros_ign_interfaces/msg/Entity@ignition.msgs.Entity',
@@ -80,8 +80,8 @@ def generate_test_description():
           '/magnetic@sensor_msgs/msg/MagneticField@ignition.msgs.Magnetometer',
           # '/actuators@mav_msgs/msg/Actuators@ignition.msgs.Actuators',
           '/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry',
-          '/odometry_with_covariance@nav_msgs/msg/Odometry@\
-                  ignition.msgs.OdometryWithCovariance',
+          '/odometry_with_covariance@nav_msgs/msg/Odometry@'
+                  'ignition.msgs.OdometryWithCovariance',
           '/pointcloud2@sensor_msgs/msg/PointCloud2@ignition.msgs.PointCloudPacked',
           '/joint_states@sensor_msgs/msg/JointState@ignition.msgs.Model',
           '/battery_state@sensor_msgs/msg/BatteryState@ignition.msgs.BatteryState',

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -197,6 +197,12 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::Twist twist_msg;
   ros_ign_bridge::testing::createTestMsg(twist_msg);
 
+  // ignition::msgs::TwistWithCovariance.
+  auto twist_cov_pub = node.Advertise<ignition::msgs::TwistWithCovariance>(
+    "twist_with_covariance");
+  ignition::msgs::TwistWithCovariance twist_cov_msg;
+  ros_ign_bridge::testing::createTestMsg(twist_cov_msg);
+
   // ignition::msgs::Wrench.
   auto wrench_pub = node.Advertise<ignition::msgs::Wrench>("wrench");
   ignition::msgs::Wrench wrench_msg;
@@ -299,6 +305,7 @@ int main(int /*argc*/, char **/*argv*/)
     odometry_pub.Publish(odometry_msg);
     joint_states_pub.Publish(joint_states_msg);
     twist_pub.Publish(twist_msg);
+    twist_cov_pub.Publish(twist_cov_msg);
     pointcloudpacked_pub.Publish(pointcloudpacked_msg);
     battery_state_pub.Publish(battery_state_msg);
     joint_trajectory_pub.Publish(joint_trajectory_msg);

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -119,6 +119,11 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::Pose pose_msg;
   ros_ign_bridge::testing::createTestMsg(pose_msg);
 
+  // ignition::msgs::PoseWithCovariance.
+  auto pose_cov_pub = node.Advertise<ignition::msgs::PoseWithCovariance>("pose_with_covariance");
+  ignition::msgs::PoseWithCovariance pose_cov_msg;
+  ros_ign_bridge::testing::createTestMsg(pose_cov_msg);
+
   // ignition::msgs::PoseStamped.
   auto pose_stamped_pub = node.Advertise<ignition::msgs::Pose>("pose_stamped");
   ignition::msgs::Pose pose_stamped_msg;
@@ -274,6 +279,7 @@ int main(int /*argc*/, char **/*argv*/)
     clock_pub.Publish(clock_msg);
     point_pub.Publish(point_msg);
     pose_pub.Publish(pose_msg);
+    pose_cov_pub.Publish(pose_cov_msg);
     pose_stamped_pub.Publish(pose_stamped_msg);
     transform_pub.Publish(transform_msg);
     transform_stamped_pub.Publish(transform_stamped_msg);

--- a/ros_ign_bridge/test/publishers/ign_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ign_publisher.cpp
@@ -187,6 +187,12 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::Odometry odometry_msg;
   ros_ign_bridge::testing::createTestMsg(odometry_msg);
 
+  // ignition::msgs::OdometryWithCovariance.
+  auto odometry_cov_pub = node.Advertise<ignition::msgs::OdometryWithCovariance>(
+    "odometry_with_covariance");
+  ignition::msgs::OdometryWithCovariance odometry_cov_msg;
+  ros_ign_bridge::testing::createTestMsg(odometry_cov_msg);
+
   // ignition::msgs::Model.
   auto joint_states_pub = node.Advertise<ignition::msgs::Model>("joint_states");
   ignition::msgs::Model joint_states_msg;
@@ -303,6 +309,7 @@ int main(int /*argc*/, char **/*argv*/)
     magnetic_pub.Publish(magnetometer_msg);
     actuators_pub.Publish(actuators_msg);
     odometry_pub.Publish(odometry_msg);
+    odometry_cov_pub.Publish(odometry_cov_msg);
     joint_states_pub.Publish(joint_states_msg);
     twist_pub.Publish(twist_msg);
     twist_cov_pub.Publish(twist_cov_msg);

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -100,7 +100,7 @@ int main(int argc, char ** argv)
   // geometry_msgs::msg::PoseWithCovariance.
   auto pose_cov_pub =
     node->create_publisher<geometry_msgs::msg::PoseWithCovariance>(
-      "pose_with_covariance", 1000);
+    "pose_with_covariance", 1000);
   geometry_msgs::msg::PoseWithCovariance pose_cov_msg;
   ros_ign_bridge::testing::createTestMsg(pose_cov_msg);
 
@@ -131,7 +131,7 @@ int main(int argc, char ** argv)
   // geometry_msgs::msg::TwistWithCovariance.
   auto twist_cov_pub =
     node->create_publisher<geometry_msgs::msg::TwistWithCovariance>(
-      "twist_with_covariance", 1000);
+    "twist_with_covariance", 1000);
   geometry_msgs::msg::TwistWithCovariance twist_cov_msg;
   ros_ign_bridge::testing::createTestMsg(twist_cov_msg);
 

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -97,6 +97,13 @@ int main(int argc, char ** argv)
   geometry_msgs::msg::Pose pose_msg;
   ros_ign_bridge::testing::createTestMsg(pose_msg);
 
+  // geometry_msgs::msg::PoseWithCovariance.
+  auto pose_cov_pub =
+    node->create_publisher<geometry_msgs::msg::PoseWithCovariance>(
+      "pose_with_covariance", 1000);
+  geometry_msgs::msg::PoseWithCovariance pose_cov_msg;
+  ros_ign_bridge::testing::createTestMsg(pose_cov_msg);
+
   // geometry_msgs::msg::PoseStamped.
   auto pose_stamped_pub =
     node->create_publisher<geometry_msgs::msg::PoseStamped>("pose_stamped", 1000);
@@ -274,6 +281,7 @@ int main(int argc, char ** argv)
     clock_pub->publish(clock_msg);
     point_pub->publish(point_msg);
     pose_pub->publish(pose_msg);
+    pose_cov_pub->publish(pose_cov_msg);
     pose_stamped_pub->publish(pose_stamped_msg);
     transform_pub->publish(transform_msg);
     transform_stamped_pub->publish(transform_stamped_msg);

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -212,6 +212,12 @@ int main(int argc, char ** argv)
   nav_msgs::msg::Odometry odometry_msg;
   ros_ign_bridge::testing::createTestMsg(odometry_msg);
 
+  // nav_msgs::msg::Odometry.
+  auto odometry_cov_pub =
+    node->create_publisher<nav_msgs::msg::Odometry>("odometry_with_covariance", 1000);
+  nav_msgs::msg::Odometry odometry_cov_msg;
+  ros_ign_bridge::testing::createTestMsg(odometry_cov_msg);
+
   // sensor_msgs::msg::Image.
   auto image_pub =
     node->create_publisher<sensor_msgs::msg::Image>("image", 1000);
@@ -303,6 +309,7 @@ int main(int argc, char ** argv)
     contacts_pub->publish(contacts_msg);
     // actuators_pub->publish(actuators_msg);
     odometry_pub->publish(odometry_msg);
+    odometry_cov_pub->publish(odometry_cov_msg);
     image_pub->publish(image_msg);
     camera_info_pub->publish(camera_info_msg);
     fluid_pressure_pub->publish(fluid_pressure_msg);

--- a/ros_ign_bridge/test/publishers/ros_publisher.cpp
+++ b/ros_ign_bridge/test/publishers/ros_publisher.cpp
@@ -128,6 +128,13 @@ int main(int argc, char ** argv)
   geometry_msgs::msg::Twist twist_msg;
   ros_ign_bridge::testing::createTestMsg(twist_msg);
 
+  // geometry_msgs::msg::TwistWithCovariance.
+  auto twist_cov_pub =
+    node->create_publisher<geometry_msgs::msg::TwistWithCovariance>(
+      "twist_with_covariance", 1000);
+  geometry_msgs::msg::TwistWithCovariance twist_cov_msg;
+  ros_ign_bridge::testing::createTestMsg(twist_cov_msg);
+
   auto tf2_message_pub =
     node->create_publisher<tf2_msgs::msg::TFMessage>("tf2_message", 1000);
   tf2_msgs::msg::TFMessage tf2_msg;
@@ -287,6 +294,7 @@ int main(int argc, char ** argv)
     transform_stamped_pub->publish(transform_stamped_msg);
     tf2_message_pub->publish(tf2_msg);
     twist_pub->publish(twist_msg);
+    twist_cov_pub->publish(twist_cov_msg);
     wrench_pub->publish(wrench_msg);
     light_pub->publish(light_msg);
     joint_wrench_pub->publish(joint_wrench_msg);

--- a/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
@@ -442,6 +442,18 @@ TEST(IgnSubscriberTest, Odometry)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, OdometryWithCovariance)
+{
+  MyTestClass<ignition::msgs::OdometryWithCovariance> client("odometry_with_covariance");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 100ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(IgnSubscriberTest, JointStates)
 {
   MyTestClass<ignition::msgs::Model> client("joint_states");

--- a/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
@@ -202,6 +202,18 @@ TEST(IgnSubscriberTest, Pose)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, PoseWithCovariance)
+{
+  MyTestClass<ignition::msgs::PoseWithCovariance> client("pose_with_covariance");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 100ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(IgnSubscriberTest, PoseStamped)
 {
   MyTestClass<ignition::msgs::Pose> client("pose_stamped");

--- a/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ign_subscriber.cpp
@@ -274,6 +274,18 @@ TEST(IgnSubscriberTest, Twist)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, TwistWithCovariance)
+{
+  MyTestClass<ignition::msgs::TwistWithCovariance> client("twist_with_covariance");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 100ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(IgnSubscriberTest, Wrench)
 {
   MyTestClass<ignition::msgs::Wrench> client("wrench");

--- a/ros_ign_bridge/test/subscribers/ros_subscriber/geometry_msgs_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber/geometry_msgs_subscriber.cpp
@@ -142,6 +142,18 @@ TEST(ROSSubscriberTest, Twist)
 }
 
 /////////////////////////////////////////////////
+TEST(ROSSubscriberTest, TwistWithCovariance)
+{
+  MyTestClass<geometry_msgs::msg::TwistWithCovariance> client("twist_with_covariance");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    ros_subscriber::TestNode(), client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(ROSSubscriberTest, Wrench)
 {
   MyTestClass<geometry_msgs::msg::Wrench> client("wrench");

--- a/ros_ign_bridge/test/subscribers/ros_subscriber/geometry_msgs_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber/geometry_msgs_subscriber.cpp
@@ -70,6 +70,18 @@ TEST(ROSSubscriberTest, Pose)
 }
 
 /////////////////////////////////////////////////
+TEST(ROSSubscriberTest, PoseWithCovariance)
+{
+  MyTestClass<geometry_msgs::msg::PoseWithCovariance> client("pose_with_covariance");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    ros_subscriber::TestNode(), client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(ROSSubscriberTest, PoseStamped)
 {
   MyTestClass<geometry_msgs::msg::PoseStamped> client("pose_stamped");

--- a/ros_ign_bridge/test/subscribers/ros_subscriber/nav_msgs_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber/nav_msgs_subscriber.cpp
@@ -32,3 +32,15 @@ TEST(ROSSubscriberTest, Odometry)
 
   EXPECT_TRUE(client.callbackExecuted);
 }
+
+/////////////////////////////////////////////////
+TEST(ROSSubscriberTest, OdometryWithCovariance)
+{
+  MyTestClass<nav_msgs::msg::Odometry> client("odometry_with_covariance");
+
+  using namespace std::chrono_literals;
+  ros_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    ros_subscriber::TestNode(), client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -834,8 +834,10 @@ void createTestMsg(ignition::msgs::OdometryWithCovariance & _msg)
 void compareTestMsg(const std::shared_ptr<ignition::msgs::OdometryWithCovariance> & _msg)
 {
   compareTestMsg(std::make_shared<ignition::msgs::Header>(_msg->header()));
-  compareTestMsg(std::make_shared<ignition::msgs::PoseWithCovariance>(_msg->pose_with_covariance()));
-  compareTestMsg(std::make_shared<ignition::msgs::TwistWithCovariance>(_msg->twist_with_covariance()));
+  compareTestMsg(std::make_shared<ignition::msgs::PoseWithCovariance>(_msg->
+    pose_with_covariance()));
+  compareTestMsg(std::make_shared<ignition::msgs::TwistWithCovariance>(_msg->
+    twist_with_covariance()));
 }
 
 void createTestMsg(ignition::msgs::PointCloudPacked & _msg)

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -299,7 +299,7 @@ void createTestMsg(ignition::msgs::TwistWithCovariance & _msg)
 
   _msg.mutable_twist()->mutable_linear()->CopyFrom(linear_msg);
   _msg.mutable_twist()->mutable_angular()->CopyFrom(angular_msg);
-  for (int i = 0 ; i < 36 ; i++) {
+  for (int i = 0; i < 36; i++) {
     _msg.mutable_covariance()->add_data(i);
   }
 }
@@ -834,10 +834,14 @@ void createTestMsg(ignition::msgs::OdometryWithCovariance & _msg)
 void compareTestMsg(const std::shared_ptr<ignition::msgs::OdometryWithCovariance> & _msg)
 {
   compareTestMsg(std::make_shared<ignition::msgs::Header>(_msg->header()));
-  compareTestMsg(std::make_shared<ignition::msgs::PoseWithCovariance>(_msg->
-    pose_with_covariance()));
-  compareTestMsg(std::make_shared<ignition::msgs::TwistWithCovariance>(_msg->
-    twist_with_covariance()));
+  compareTestMsg(
+    std::make_shared<ignition::msgs::PoseWithCovariance>(
+      _msg->
+      pose_with_covariance()));
+  compareTestMsg(
+    std::make_shared<ignition::msgs::TwistWithCovariance>(
+      _msg->
+      twist_with_covariance()));
 }
 
 void createTestMsg(ignition::msgs::PointCloudPacked & _msg)

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -239,6 +239,9 @@ void createTestMsg(ignition::msgs::PoseWithCovariance & _msg)
 {
   createTestMsg(*_msg.mutable_pose()->mutable_position());
   createTestMsg(*_msg.mutable_pose()->mutable_orientation());
+  for (int i = 0; i < 36; i++) {
+    _msg.mutable_covariance()->add_data(i);
+  }
 }
 
 void compareTestMsg(const std::shared_ptr<ignition::msgs::PoseWithCovariance> & _msg)
@@ -293,6 +296,9 @@ void createTestMsg(ignition::msgs::TwistWithCovariance & _msg)
 
   _msg.mutable_twist()->mutable_linear()->CopyFrom(linear_msg);
   _msg.mutable_twist()->mutable_angular()->CopyFrom(angular_msg);
+  for (int i = 0 ; i < 36 ; i++) {
+    _msg.mutable_covariance()->add_data(i);
+  }
 }
 
 void compareTestMsg(const std::shared_ptr<ignition::msgs::TwistWithCovariance> & _msg)

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -235,6 +235,18 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Pose> & _msg)
   compareTestMsg(std::make_shared<ignition::msgs::Quaternion>(_msg->orientation()));
 }
 
+void createTestMsg(ignition::msgs::PoseWithCovariance & _msg)
+{
+  createTestMsg(*_msg.mutable_pose()->mutable_position());
+  createTestMsg(*_msg.mutable_pose()->mutable_orientation());
+}
+
+void compareTestMsg(const std::shared_ptr<ignition::msgs::PoseWithCovariance> & _msg)
+{
+  compareTestMsg(std::make_shared<ignition::msgs::Vector3d>(_msg->pose().position()));
+  compareTestMsg(std::make_shared<ignition::msgs::Quaternion>(_msg->pose().orientation()));
+}
+
 void createTestMsg(ignition::msgs::Pose_V & _msg)
 {
   createTestMsg(*(_msg.mutable_header()));

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -283,6 +283,24 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Twist> & _msg)
   compareTestMsg(std::make_shared<ignition::msgs::Vector3d>(_msg->angular()));
 }
 
+void createTestMsg(ignition::msgs::TwistWithCovariance & _msg)
+{
+  ignition::msgs::Vector3d linear_msg;
+  ignition::msgs::Vector3d angular_msg;
+
+  createTestMsg(linear_msg);
+  createTestMsg(angular_msg);
+
+  _msg.mutable_twist()->mutable_linear()->CopyFrom(linear_msg);
+  _msg.mutable_twist()->mutable_angular()->CopyFrom(angular_msg);
+}
+
+void compareTestMsg(const std::shared_ptr<ignition::msgs::TwistWithCovariance> & _msg)
+{
+  compareTestMsg(std::make_shared<ignition::msgs::Vector3d>(_msg->twist().linear()));
+  compareTestMsg(std::make_shared<ignition::msgs::Vector3d>(_msg->twist().angular()));
+}
+
 void createTestMsg(ignition::msgs::Wrench & _msg)
 {
   ignition::msgs::Header header_msg;

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -248,6 +248,9 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::PoseWithCovariance> & 
 {
   compareTestMsg(std::make_shared<ignition::msgs::Vector3d>(_msg->pose().position()));
   compareTestMsg(std::make_shared<ignition::msgs::Quaternion>(_msg->pose().orientation()));
+  for (int i = 0; i < 36; i++) {
+    EXPECT_EQ(_msg->covariance().data(i), i);
+  }
 }
 
 void createTestMsg(ignition::msgs::Pose_V & _msg)
@@ -305,6 +308,9 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::TwistWithCovariance> &
 {
   compareTestMsg(std::make_shared<ignition::msgs::Vector3d>(_msg->twist().linear()));
   compareTestMsg(std::make_shared<ignition::msgs::Vector3d>(_msg->twist().angular()));
+  for (int i = 0; i < 36; i++) {
+    EXPECT_EQ(_msg->covariance().data()[i], i);
+  }
 }
 
 void createTestMsg(ignition::msgs::Wrench & _msg)

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -804,6 +804,28 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Odometry> & _msg)
   compareTestMsg(std::make_shared<ignition::msgs::Twist>(_msg->twist()));
 }
 
+void createTestMsg(ignition::msgs::OdometryWithCovariance & _msg)
+{
+  ignition::msgs::Header header_msg;
+  ignition::msgs::PoseWithCovariance pose_cov_msg;
+  ignition::msgs::TwistWithCovariance twist_cov_msg;
+
+  createTestMsg(header_msg);
+  createTestMsg(pose_cov_msg);
+  createTestMsg(twist_cov_msg);
+
+  _msg.mutable_header()->CopyFrom(header_msg);
+  _msg.mutable_pose_with_covariance()->CopyFrom(pose_cov_msg);
+  _msg.mutable_twist_with_covariance()->CopyFrom(twist_cov_msg);
+}
+
+void compareTestMsg(const std::shared_ptr<ignition::msgs::OdometryWithCovariance> & _msg)
+{
+  compareTestMsg(std::make_shared<ignition::msgs::Header>(_msg->header()));
+  compareTestMsg(std::make_shared<ignition::msgs::PoseWithCovariance>(_msg->pose_with_covariance()));
+  compareTestMsg(std::make_shared<ignition::msgs::TwistWithCovariance>(_msg->twist_with_covariance()));
+}
+
 void createTestMsg(ignition::msgs::PointCloudPacked & _msg)
 {
   ignition::msgs::Header header_msg;

--- a/ros_ign_bridge/test/utils/ign_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.hpp
@@ -308,6 +308,14 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Odometry> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.
+void createTestMsg(ignition::msgs::OdometryWithCovariance & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ignition::msgs::OdometryWithCovariance> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
 void createTestMsg(ignition::msgs::PointCloudPacked & _msg);
 
 /// \brief Compare a message with the populated for testing.

--- a/ros_ign_bridge/test/utils/ign_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.hpp
@@ -40,14 +40,17 @@
 #include <ignition/msgs/magnetometer.pb.h>
 #include <ignition/msgs/model.pb.h>
 #include <ignition/msgs/odometry.pb.h>
+#include <ignition/msgs/odometry_with_covariance.pb.h>
 #include <ignition/msgs/pointcloud_packed.pb.h>
 #include <ignition/msgs/pose.pb.h>
+#include <ignition/msgs/pose_with_covariance.pb.h>
 #include <ignition/msgs/pose_v.pb.h>
 #include <ignition/msgs/quaternion.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 #include <ignition/msgs/stringmsg_v.pb.h>
 #include <ignition/msgs/track_visual.pb.h>
 #include <ignition/msgs/twist.pb.h>
+#include <ignition/msgs/twist_with_covariance.pb.h>
 #include <ignition/msgs/uint32.pb.h>
 #include <ignition/msgs/vector3d.pb.h>
 #include <ignition/msgs/video_record.pb.h>
@@ -150,6 +153,14 @@ void createTestMsg(ignition::msgs::Pose & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<ignition::msgs::Pose> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ignition::msgs::PoseWithCovariance & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ignition::msgs::PoseWithCovariance> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_ign_bridge/test/utils/ign_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.hpp
@@ -180,6 +180,14 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Twist> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.
+void createTestMsg(ignition::msgs::TwistWithCovariance & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ignition::msgs::TwistWithCovariance> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
 void createTestMsg(ignition::msgs::Wrench & _msg);
 
 /// \brief Compare a message with the populated for testing.

--- a/ros_ign_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.cpp
@@ -264,6 +264,24 @@ void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::Pose> & _msg)
   compareTestMsg(_msg->orientation);
 }
 
+void compareTestMsg(const geometry_msgs::msg::PoseWithCovariance & _msg)
+{
+  compareTestMsg(_msg.pose.position);
+  compareTestMsg(_msg.pose.orientation);
+}
+
+void createTestMsg(geometry_msgs::msg::PoseWithCovariance & _msg)
+{
+  createTestMsg(_msg.pose.position);
+  createTestMsg(_msg.pose.orientation);
+}
+
+void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::PoseWithCovariance> & _msg)
+{
+  compareTestMsg(_msg->pose.position);
+  compareTestMsg(_msg->pose.orientation);
+}
+
 void createTestMsg(geometry_msgs::msg::PoseStamped & _msg)
 {
   createTestMsg(_msg.header);

--- a/ros_ign_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.cpp
@@ -355,6 +355,18 @@ void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::Twist> & _msg)
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->angular));
 }
 
+void createTestMsg(geometry_msgs::msg::TwistWithCovariance & _msg)
+{
+  createTestMsg(_msg.twist.linear);
+  createTestMsg(_msg.twist.angular);
+}
+
+void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::TwistWithCovariance> & _msg)
+{
+  compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->twist.linear));
+  compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->twist.angular));
+}
+
 void createTestMsg(geometry_msgs::msg::Wrench & _msg)
 {
   createTestMsg(_msg.force);

--- a/ros_ign_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.cpp
@@ -268,6 +268,9 @@ void compareTestMsg(const geometry_msgs::msg::PoseWithCovariance & _msg)
 {
   compareTestMsg(_msg.pose.position);
   compareTestMsg(_msg.pose.orientation);
+  for (int i = 0; i < 36; i++) {
+    EXPECT_EQ(_msg.covariance[i], i);
+  }
 }
 
 void createTestMsg(geometry_msgs::msg::PoseWithCovariance & _msg)
@@ -283,6 +286,9 @@ void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::PoseWithCovariance
 {
   compareTestMsg(_msg->pose.position);
   compareTestMsg(_msg->pose.orientation);
+  for (int i = 0; i < 36; i++) {
+    EXPECT_EQ(_msg->covariance[i], i);
+  }
 }
 
 void createTestMsg(geometry_msgs::msg::PoseStamped & _msg)
@@ -371,6 +377,9 @@ void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::TwistWithCovarianc
 {
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->twist.linear));
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->twist.angular));
+  for (int i = 0; i < 36; i++) {
+    EXPECT_EQ(_msg->covariance[i], i);
+  }
 }
 
 void createTestMsg(geometry_msgs::msg::Wrench & _msg)

--- a/ros_ign_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.cpp
@@ -277,7 +277,7 @@ void createTestMsg(geometry_msgs::msg::PoseWithCovariance & _msg)
 {
   createTestMsg(_msg.pose.position);
   createTestMsg(_msg.pose.orientation);
-  for (int i = 0 ; i < 36; i++){
+  for (int i = 0; i < 36; i++) {
     _msg.covariance[i] = i;
   }
 }
@@ -368,7 +368,7 @@ void createTestMsg(geometry_msgs::msg::TwistWithCovariance & _msg)
 {
   createTestMsg(_msg.twist.linear);
   createTestMsg(_msg.twist.angular);
-  for (int i = 0 ; i < 36; i++){
+  for (int i = 0; i < 36; i++) {
     _msg.covariance[i] = i;
   }
 }

--- a/ros_ign_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.cpp
@@ -274,6 +274,9 @@ void createTestMsg(geometry_msgs::msg::PoseWithCovariance & _msg)
 {
   createTestMsg(_msg.pose.position);
   createTestMsg(_msg.pose.orientation);
+  for (int i = 0 ; i < 36; i++){
+    _msg.covariance[i] = i;
+  }
 }
 
 void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::PoseWithCovariance> & _msg)
@@ -359,6 +362,9 @@ void createTestMsg(geometry_msgs::msg::TwistWithCovariance & _msg)
 {
   createTestMsg(_msg.twist.linear);
   createTestMsg(_msg.twist.angular);
+  for (int i = 0 ; i < 36; i++){
+    _msg.covariance[i] = i;
+  }
 }
 
 void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::TwistWithCovariance> & _msg)
@@ -643,6 +649,10 @@ void createTestMsg(nav_msgs::msg::Odometry & _msg)
   createTestMsg(_msg.header);
   createTestMsg(_msg.pose.pose);
   createTestMsg(_msg.twist.twist);
+  for (int i = 0; i < 36; i++) {
+    _msg.pose.covariance[i] = i;
+    _msg.twist.covariance[i] = i;
+  }
 }
 
 void compareTestMsg(const std::shared_ptr<nav_msgs::msg::Odometry> & _msg)

--- a/ros_ign_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.hpp
@@ -28,10 +28,12 @@
 #include <std_msgs/msg/string.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_with_covariance.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/transform.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_with_covariance.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <geometry_msgs/msg/wrench.hpp>
@@ -199,6 +201,18 @@ void createTestMsg(geometry_msgs::msg::Pose & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::Pose> & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const geometry_msgs::msg::PoseWithCovariance & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(geometry_msgs::msg::PoseWithCovariance & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::PoseWithCovariance> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_ign_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.hpp
@@ -252,6 +252,14 @@ void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::Twist> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.
+void createTestMsg(geometry_msgs::msg::TwistWithCovariance & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<geometry_msgs::msg::TwistWithCovariance> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
 void createTestMsg(geometry_msgs::msg::Wrench & _msg);
 
 /// \brief Compare a message with the populated for testing.


### PR DESCRIPTION
🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

## Summary
This PR aims to interface the following message types : 
* ``ignition::msgs::PoseWithCovariance`` <--> ``geometry_msgs/msg/PoseWithCovariance``
* ``ignition::msgs::TwistWithCovariance`` <--> ``geometry_msgs/msg/TwistWithCovariance``
* ``ignition::msgs::OdometryWithCovariance`` <--> ``nav_msgs/msg/Odometry``

This is a follow up PR to the message types added here : https://github.com/ignitionrobotics/ign-msgs/pull/224

## Test it
TODO

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸