### PR TITLE
Optional "lazy" bridge subscribers

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -87,6 +87,7 @@ endforeach()
 set(bridge_executables
   parameter_bridge
   static_bridge
+  lazy_static_bridge
 )
 
 set(bridge_lib
@@ -95,6 +96,9 @@ set(bridge_lib
 
 add_library(${bridge_lib}
   SHARED
+  src/bridge.cpp
+  src/bridge_ros_to_ign.cpp
+  src/bridge_ign_to_ros.cpp
   src/factories.cpp
 )
 

--- a/ros_ign_bridge/src/bridge.cpp
+++ b/ros_ign_bridge/src/bridge.cpp
@@ -1,0 +1,82 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+#include "bridge.hpp"
+#include "factories.hpp"
+
+namespace ros_ign_bridge
+{
+Bridge::Bridge(
+  rclcpp::Node::SharedPtr ros_node,
+  std::shared_ptr<ignition::transport::Node> ign_node,
+  const std::string & ros_type_name,
+  const std::string & ros_topic_name,
+  const std::string & ign_type_name,
+  const std::string & ign_topic_name,
+  size_t publisher_queue_size,
+  size_t subscriber_queue_size,
+  bool is_lazy)
+: ros_node_(ros_node),
+  ign_node_(ign_node),
+  ros_type_name_(ros_type_name),
+  ros_topic_name_(ros_topic_name),
+  ign_type_name_(ign_type_name),
+  ign_topic_name_(ign_topic_name),
+  subscriber_queue_size_(subscriber_queue_size),
+  publisher_queue_size_(publisher_queue_size),
+  is_lazy_(is_lazy),
+  factory_(get_factory(ros_type_name_, ign_type_name_))
+{
+}
+
+Bridge::~Bridge() = default;
+
+bool Bridge::IsLazy() const
+{
+  return is_lazy_;
+}
+
+void Bridge::Start()
+{
+  if (!this->HasPublisher()) {
+    this->StartPublisher();
+  }
+
+  if (!this->IsLazy() && !this->HasSubscriber()) {
+    this->StartSubscriber();
+  }
+}
+
+void Bridge::Spin()
+{
+  if (!this->IsLazy()) {
+    return;
+  }
+
+  if (this->HasSubscriber() && this->NumSubscriptions() == 0) {
+    RCLCPP_INFO(
+      this->ros_node_->get_logger(),
+      "Lazy Mode Enabled and no subscriptions found, stopping");
+    this->StopSubscriber();
+  } else if (!this->HasSubscriber() && this->NumSubscriptions() > 0) {
+    RCLCPP_INFO(
+      this->ros_node_->get_logger(),
+      "Lazy Mode Enabled and subscriptions found, starting");
+    this->StartSubscriber();
+  }
+}
+}  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/bridge.cpp
+++ b/ros_ign_bridge/src/bridge.cpp
@@ -68,14 +68,16 @@ void Bridge::Spin()
   }
 
   if (this->HasSubscriber() && this->NumSubscriptions() == 0) {
-    RCLCPP_INFO(
+    RCLCPP_DEBUG(
       this->ros_node_->get_logger(),
-      "Lazy Mode Enabled and no subscriptions found, stopping");
+      "Bridge [%s] - No subscriptions found, stopping bridge",
+      ros_topic_name_.c_str());
     this->StopSubscriber();
   } else if (!this->HasSubscriber() && this->NumSubscriptions() > 0) {
-    RCLCPP_INFO(
+    RCLCPP_DEBUG(
       this->ros_node_->get_logger(),
-      "Lazy Mode Enabled and subscriptions found, starting");
+      "Bridge [%s] - Subscriptions found, starting bridge",
+      ros_topic_name_.c_str());
     this->StartSubscriber();
   }
 }

--- a/ros_ign_bridge/src/bridge.hpp
+++ b/ros_ign_bridge/src/bridge.hpp
@@ -15,98 +15,113 @@
 #ifndef BRIDGE_HPP_
 #define BRIDGE_HPP_
 
-// include Ignition Transport
 #include <ignition/transport/Node.hh>
+#include <rclcpp/node.hpp>
 
 #include <memory>
 #include <string>
 
-#include "factories.hpp"
+#include "factory_interface.hpp"
 
 namespace ros_ign_bridge
 {
 
-struct BridgeRosToIgnHandles
+/// \brief Core functionality and data for both bridge directions
+class Bridge
 {
-  rclcpp::SubscriptionBase::SharedPtr ros_subscriber;
-  ignition::transport::Node::Publisher ign_publisher;
+public:
+  /// \brief Default subscriber queue length
+  static constexpr size_t kDefaultSubscriberQueue = 10;
+
+  /// \brief Default publisher queue length
+  static constexpr size_t kDefaultPublisherQueue = 10;
+
+  /// \brief Constructor
+  /// Note, does not actually start the bridge, must be done with Start()
+  ///
+  /// \param[in] ros_node ROS node to create publishers/subscribers on
+  /// \param[in] ign_node IGN node to create publishers/subscribers on
+  /// \param[in] ros_type_name Name of the ROS message type to use
+  /// \param[in] ros_topic Name of the ROS topic to use
+  /// \param[in] ign_type_name Name of the IGN message type to use
+  /// \param[in] ign_topic Name of the IGN topic to use
+  /// \param[in] subscriber_queue_size Depth of the subscriber queue
+  /// \param[in] publisher_queue_size Depth of the publisher queue
+  /// \param[in] is_lazy True for "lazy" subscriptions.
+  Bridge(
+    rclcpp::Node::SharedPtr ros_node,
+    std::shared_ptr<ignition::transport::Node> ign_node,
+    const std::string & ros_type_name,
+    const std::string & ros_topic_name,
+    const std::string & ign_type_name,
+    const std::string & ign_topic_name,
+    size_t subscriber_queue_size = kDefaultSubscriberQueue,
+    size_t publisher_queue_size = kDefaultPublisherQueue,
+    bool is_lazy = false);
+
+  /// \brief Destructor
+  virtual ~Bridge() = 0;
+
+  /// \brief Initiate the bridge
+  ///
+  /// If the bridge is "lazy", then only the publisher (output) side is created.
+  /// The not, both the publisher (output) and subscriber (input) side are
+  /// created.
+  void Start();
+
+  /// \brief Spin the bridge, checking for new subscriptions on the output.
+  ///
+  /// Not necessary if the Bridge isn't lazy
+  void Spin();
+
+  /// \brief Inidicate if this is a "lazy" bridge
+  ///
+  /// A lazy bridge will always create the output side of the bridge, but
+  /// will only create the input side of the bridge when downstream consumers
+  /// are detected on the output side.
+  /// This reduces the amount of overhead in the bridge processing messages
+  /// for non-existent consumers.
+  /// It will also allow for lazy publishers to work on the input side of the
+  /// bridge.
+  /// \return true if lazy
+  bool IsLazy() const;
+
+protected:
+  /// \brief Get the number of subscriptions on the output side of the bridge
+  virtual size_t NumSubscriptions() const = 0;
+
+  /// \brief Indicate if the publisher (output) side has been created
+  virtual bool HasPublisher() const = 0;
+
+  /// \brief Start the publisher (output) side of the bridge
+  virtual void StartPublisher() = 0;
+
+  /// \brief Indicate if the subscriber (input) side has been created
+  virtual bool HasSubscriber() const = 0;
+
+  /// \brief Start the subscriber (input) side of the bridge
+  virtual void StartSubscriber() = 0;
+
+  /// \brief Stop the subscriber (input) side of the bridge
+  virtual void StopSubscriber() = 0;
+
+protected:
+  rclcpp::Node::SharedPtr ros_node_;
+  std::shared_ptr<ignition::transport::Node> ign_node_;
+
+  std::string ros_type_name_;
+  std::string ros_topic_name_;
+  std::string ign_type_name_;
+  std::string ign_topic_name_;
+
+  size_t subscriber_queue_size_;
+  size_t publisher_queue_size_;
+  bool is_lazy_;
+
+  std::shared_ptr<FactoryInterface> factory_;
 };
 
-struct BridgeIgnToRosHandles
-{
-  std::shared_ptr<ignition::transport::Node> ign_subscriber;
-  rclcpp::PublisherBase::SharedPtr ros_publisher;
-};
-
-struct BridgeHandles
-{
-  BridgeRosToIgnHandles bridgeRosToIgn;
-  BridgeIgnToRosHandles bridgeIgnToRos;
-};
-
-BridgeRosToIgnHandles
-create_bridge_from_ros_to_ign(
-  rclcpp::Node::SharedPtr ros_node,
-  std::shared_ptr<ignition::transport::Node> ign_node,
-  const std::string & ros_type_name,
-  const std::string & ros_topic_name,
-  size_t subscriber_queue_size,
-  const std::string & ign_type_name,
-  const std::string & ign_topic_name,
-  size_t publisher_queue_size)
-{
-  auto factory = get_factory(ros_type_name, ign_type_name);
-  auto ign_pub = factory->create_ign_publisher(ign_node, ign_topic_name, publisher_queue_size);
-
-  auto ros_sub = factory->create_ros_subscriber(
-    ros_node, ros_topic_name, subscriber_queue_size, ign_pub);
-
-  BridgeRosToIgnHandles handles;
-  handles.ros_subscriber = ros_sub;
-  handles.ign_publisher = ign_pub;
-  return handles;
-}
-
-BridgeIgnToRosHandles
-create_bridge_from_ign_to_ros(
-  std::shared_ptr<ignition::transport::Node> ign_node,
-  rclcpp::Node::SharedPtr ros_node,
-  const std::string & ign_type_name,
-  const std::string & ign_topic_name,
-  size_t subscriber_queue_size,
-  const std::string & ros_type_name,
-  const std::string & ros_topic_name,
-  size_t publisher_queue_size)
-{
-  auto factory = get_factory(ros_type_name, ign_type_name);
-  auto ros_pub = factory->create_ros_publisher(ros_node, ros_topic_name, publisher_queue_size);
-
-  factory->create_ign_subscriber(ign_node, ign_topic_name, subscriber_queue_size, ros_pub);
-
-  BridgeIgnToRosHandles handles;
-  handles.ign_subscriber = ign_node;
-  handles.ros_publisher = ros_pub;
-  return handles;
-}
-
-BridgeHandles
-create_bidirectional_bridge(
-  rclcpp::Node::SharedPtr ros_node,
-  std::shared_ptr<ignition::transport::Node> ign_node,
-  const std::string & ros_type_name,
-  const std::string & ign_type_name,
-  const std::string & topic_name,
-  size_t queue_size = 10)
-{
-  BridgeHandles handles;
-  handles.bridgeRosToIgn = create_bridge_from_ros_to_ign(
-    ros_node, ign_node,
-    ros_type_name, topic_name, queue_size, ign_type_name, topic_name, queue_size);
-  handles.bridgeIgnToRos = create_bridge_from_ign_to_ros(
-    ign_node, ros_node,
-    ign_type_name, topic_name, queue_size, ros_type_name, topic_name, queue_size);
-  return handles;
-}
+using BridgePtr = std::unique_ptr<Bridge>;
 
 }  // namespace ros_ign_bridge
 

--- a/ros_ign_bridge/src/bridge.hpp
+++ b/ros_ign_bridge/src/bridge.hpp
@@ -47,7 +47,7 @@ public:
   /// \param[in] ign_topic Name of the IGN topic to use
   /// \param[in] subscriber_queue_size Depth of the subscriber queue
   /// \param[in] publisher_queue_size Depth of the publisher queue
-  /// \param[in] is_lazy True for "lazy" subscriptions.
+  /// \param[in] is_lazy True for "lazy" subscriptions. (Default: false)
   Bridge(
     rclcpp::Node::SharedPtr ros_node,
     std::shared_ptr<ignition::transport::Node> ign_node,
@@ -106,18 +106,34 @@ protected:
   virtual void StopSubscriber() = 0;
 
 protected:
+  /// \brief The ROS node used to create publishers/subscriptions
   rclcpp::Node::SharedPtr ros_node_;
+
+  /// \brief The Ignition node used to create publishers/subscriptions
   std::shared_ptr<ignition::transport::Node> ign_node_;
 
+  /// \brief The ROS message type (eg std_msgs/msg/String)
   std::string ros_type_name_;
+
+  /// \brief The ROS topic name to bridge
   std::string ros_topic_name_;
+
+  /// \brief The IGN message type (eg ignition.msgs.String)
   std::string ign_type_name_;
+
+  /// \brief The IGN topic name to bridge
   std::string ign_topic_name_;
 
+  /// \brief Depth of the subscriber queue
   size_t subscriber_queue_size_;
+
+  /// \brief Depth of the publisher queue
   size_t publisher_queue_size_;
+
+  /// \brief Flag to change the "laziness" of the bridge
   bool is_lazy_;
 
+  /// \brief Typed factory used to create publishers/subscribers
   std::shared_ptr<FactoryInterface> factory_;
 };
 

--- a/ros_ign_bridge/src/bridge_ign_to_ros.cpp
+++ b/ros_ign_bridge/src/bridge_ign_to_ros.cpp
@@ -51,10 +51,6 @@ bool BridgeIgnToRos::HasPublisher() const
 void BridgeIgnToRos::StartPublisher()
 {
   // Start ROS publisher
-  RCLCPP_INFO(
-    this->ros_node_->get_logger(),
-    "Created ROS Publisher: %s",
-    this->ros_topic_name_.c_str());
   this->ros_publisher_ = this->factory_->create_ros_publisher(
     this->ros_node_,
     this->ros_topic_name_,
@@ -70,10 +66,6 @@ bool BridgeIgnToRos::HasSubscriber() const
 void BridgeIgnToRos::StartSubscriber()
 {
   // Start Ignition subscriber
-  RCLCPP_INFO(
-    this->ros_node_->get_logger(),
-    "Created IGN Subscriber: %s",
-    this->ign_topic_name_.c_str());
   this->factory_->create_ign_subscriber(
     this->ign_node_,
     this->ign_topic_name_,

--- a/ros_ign_bridge/src/bridge_ign_to_ros.cpp
+++ b/ros_ign_bridge/src/bridge_ign_to_ros.cpp
@@ -1,0 +1,97 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <memory>
+
+#include "bridge_ign_to_ros.hpp"
+
+namespace ros_ign_bridge
+{
+
+BridgeIgnToRos::~BridgeIgnToRos() = default;
+
+size_t BridgeIgnToRos::NumSubscriptions() const
+{
+  // Return number of ROS subscriptions
+  size_t valid_subscriptions = 0;
+
+  if (this->ros_publisher_ != nullptr) {
+    // Use info_by_topic rather than get_subscription_count
+    // to filter out potential bidirectional bridge
+    auto topic_info = this->ros_node_->get_subscriptions_info_by_topic(
+      this->ros_topic_name_);
+
+    for (auto & topic : topic_info) {
+      if (topic.node_name() == this->ros_node_->get_name()) {
+        continue;
+      }
+      valid_subscriptions++;
+    }
+  }
+
+  return valid_subscriptions;
+}
+
+bool BridgeIgnToRos::HasPublisher() const
+{
+  return this->ros_publisher_ != nullptr;
+}
+
+void BridgeIgnToRos::StartPublisher()
+{
+  // Start ROS publisher
+  RCLCPP_INFO(
+    this->ros_node_->get_logger(),
+    "Created ROS Publisher: %s",
+    this->ros_topic_name_.c_str());
+  this->ros_publisher_ = this->factory_->create_ros_publisher(
+    this->ros_node_,
+    this->ros_topic_name_,
+    this->publisher_queue_size_);
+}
+
+bool BridgeIgnToRos::HasSubscriber() const
+{
+  // Return Ignition subscriber status
+  return this->ign_subscriber_ != nullptr;
+}
+
+void BridgeIgnToRos::StartSubscriber()
+{
+  // Start Ignition subscriber
+  RCLCPP_INFO(
+    this->ros_node_->get_logger(),
+    "Created IGN Subscriber: %s",
+    this->ign_topic_name_.c_str());
+  this->factory_->create_ign_subscriber(
+    this->ign_node_,
+    this->ign_topic_name_,
+    this->subscriber_queue_size_,
+    this->ros_publisher_);
+
+  this->ign_subscriber_ = this->ign_node_;
+}
+
+void BridgeIgnToRos::StopSubscriber()
+{
+  // Stop Ignition subscriber
+  if (!this->ign_subscriber_) {
+    return;
+  }
+
+  this->ign_subscriber_->Unsubscribe(this->ign_topic_name_);
+  this->ign_subscriber_.reset();
+}
+
+}  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/bridge_ign_to_ros.hpp
+++ b/ros_ign_bridge/src/bridge_ign_to_ros.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2022 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ros_ign_bridge/src/bridge_ign_to_ros.hpp
+++ b/ros_ign_bridge/src/bridge_ign_to_ros.hpp
@@ -1,0 +1,69 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BRIDGE_IGN_TO_ROS_HPP_
+#define BRIDGE_IGN_TO_ROS_HPP_
+
+#include <ignition/transport/Node.hh>
+#include <rclcpp/subscription_base.hpp>
+
+#include <memory>
+
+#include "bridge.hpp"
+
+namespace ros_ign_bridge
+{
+
+/// \brief Create a IGN to ROS Bridge
+///
+/// Bridge is from IGN Subscription (input) to ROS Publisher (output)
+class BridgeIgnToRos : public Bridge
+{
+public:
+  /// \brief Constructor
+  using Bridge::Bridge;
+
+  /// \brief Destructor
+  ~BridgeIgnToRos() override;
+
+protected:
+  /// \brief Documentation inherited
+  size_t NumSubscriptions() const override;
+
+  /// \brief Documentation inherited
+  bool HasPublisher() const override;
+
+  /// \brief Documentation inherited
+  void StartPublisher() override;
+
+  /// \brief Documentation inherited
+  bool HasSubscriber() const override;
+
+  /// \brief Documentation inherited
+  void StartSubscriber() override;
+
+  /// \brief Documentation inherited
+  void StopSubscriber() override;
+
+protected:
+  /// \brief Ignition subscriber, populated when subscriber active
+  std::shared_ptr<ignition::transport::Node> ign_subscriber_ = {nullptr};
+
+  /// \brief ROS publisher, populated when publisher active
+  rclcpp::PublisherBase::SharedPtr ros_publisher_ = {nullptr};
+};
+
+}  // namespace ros_ign_bridge
+
+#endif  // BRIDGE_IGN_TO_ROS_HPP_

--- a/ros_ign_bridge/src/bridge_ros_to_ign.cpp
+++ b/ros_ign_bridge/src/bridge_ros_to_ign.cpp
@@ -1,0 +1,84 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bridge_ros_to_ign.hpp"
+
+#include <ignition/transport/TopicUtils.hh>
+
+namespace ros_ign_bridge
+{
+
+BridgeRosToIgn::~BridgeRosToIgn() = default;
+
+size_t BridgeRosToIgn::NumSubscriptions() const
+{
+  // Return number of ignition subscriptions
+  // Ignition publishers can only detect presence of connections, and not
+  // get the actual count.
+  // Ignition transport also cannot differentiate connections locally and
+  // remotely, so a bidirectional bridge will always subscribe.
+  // \TODO(mjcarroll) Add transport APIs for correctly querying number
+  // of remote subscriptions
+  if (this->ign_publisher_.Valid() && this->ign_publisher_.HasConnections()) {
+    return 1;
+  }
+  return 0;
+}
+
+bool BridgeRosToIgn::HasPublisher() const
+{
+  // Return Ignition publisher status
+  return this->ign_publisher_.Valid();
+}
+
+void BridgeRosToIgn::StartPublisher()
+{
+  // Start Ignition publisher
+  RCLCPP_INFO(
+    this->ros_node_->get_logger(),
+    "Created IGN Publisher: %s",
+    this->ign_topic_name_.c_str());
+  this->ign_publisher_ = this->factory_->create_ign_publisher(
+    this->ign_node_,
+    this->ign_topic_name_,
+    this->publisher_queue_size_);
+}
+
+bool BridgeRosToIgn::HasSubscriber() const
+{
+  // Return ROS subscriber status
+  return this->ros_subscriber_ != nullptr;
+}
+
+void BridgeRosToIgn::StartSubscriber()
+{
+  // Start ROS subscriber
+  RCLCPP_INFO(
+    this->ros_node_->get_logger(),
+    "Created ROS Subscriber: %s",
+    this->ros_topic_name_.c_str());
+  this->ros_subscriber_ = this->factory_->create_ros_subscriber(
+    this->ros_node_,
+    this->ros_topic_name_,
+    this->subscriber_queue_size_,
+    this->ign_publisher_);
+}
+
+void BridgeRosToIgn::StopSubscriber()
+{
+  // Stop ROS subscriber
+  this->ros_subscriber_.reset();
+}
+
+}  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/bridge_ros_to_ign.cpp
+++ b/ros_ign_bridge/src/bridge_ros_to_ign.cpp
@@ -45,10 +45,6 @@ bool BridgeRosToIgn::HasPublisher() const
 void BridgeRosToIgn::StartPublisher()
 {
   // Start Ignition publisher
-  RCLCPP_INFO(
-    this->ros_node_->get_logger(),
-    "Created IGN Publisher: %s",
-    this->ign_topic_name_.c_str());
   this->ign_publisher_ = this->factory_->create_ign_publisher(
     this->ign_node_,
     this->ign_topic_name_,
@@ -64,10 +60,6 @@ bool BridgeRosToIgn::HasSubscriber() const
 void BridgeRosToIgn::StartSubscriber()
 {
   // Start ROS subscriber
-  RCLCPP_INFO(
-    this->ros_node_->get_logger(),
-    "Created ROS Subscriber: %s",
-    this->ros_topic_name_.c_str());
   this->ros_subscriber_ = this->factory_->create_ros_subscriber(
     this->ros_node_,
     this->ros_topic_name_,

--- a/ros_ign_bridge/src/bridge_ros_to_ign.hpp
+++ b/ros_ign_bridge/src/bridge_ros_to_ign.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2022 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ros_ign_bridge/src/bridge_ros_to_ign.hpp
+++ b/ros_ign_bridge/src/bridge_ros_to_ign.hpp
@@ -1,0 +1,67 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BRIDGE_ROS_TO_IGN_HPP_
+#define BRIDGE_ROS_TO_IGN_HPP_
+
+#include <ignition/transport/Node.hh>
+#include <rclcpp/subscription_base.hpp>
+
+#include "bridge.hpp"
+
+namespace ros_ign_bridge
+{
+
+/// \brief Create a bridge ROS to IGN Bridge
+///
+/// Bridge is from ROS Subscription (input) to IGN Publisher (output)
+class BridgeRosToIgn : public Bridge
+{
+public:
+  /// \brief Constructor
+  using Bridge::Bridge;
+
+  /// \brief Destructor
+  ~BridgeRosToIgn() override;
+
+protected:
+  /// \brief Documentation inherited
+  size_t NumSubscriptions() const override;
+
+  /// \brief Documentation inherited
+  bool HasPublisher() const override;
+
+  /// \brief Documentation inherited
+  void StartPublisher() override;
+
+  /// \brief Documentation inherited
+  bool HasSubscriber() const override;
+
+  /// \brief Documentation inherited
+  void StartSubscriber() override;
+
+  /// \brief Documentation inherited
+  void StopSubscriber() override;
+
+protected:
+  /// \brief ROS subscriber, populated when subscription active
+  rclcpp::SubscriptionBase::SharedPtr ros_subscriber_ = {nullptr};
+
+  /// \brief Ignition publisher, populated when publisher active
+  ignition::transport::Node::Publisher ign_publisher_;
+};
+
+}  // namespace ros_ign_bridge
+
+#endif  // BRIDGE_ROS_TO_IGN_HPP_

--- a/ros_ign_bridge/src/factory.hpp
+++ b/ros_ign_bridge/src/factory.hpp
@@ -40,6 +40,8 @@ public:
     ign_type_name_(ign_type_name)
   {}
 
+  virtual ~Factory() {}
+
   rclcpp::PublisherBase::SharedPtr
   create_ros_publisher(
     rclcpp::Node::SharedPtr ros_node,

--- a/ros_ign_bridge/src/lazy_static_bridge.cpp
+++ b/ros_ign_bridge/src/lazy_static_bridge.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2022 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ros_ign_bridge/src/lazy_static_bridge.cpp
+++ b/ros_ign_bridge/src/lazy_static_bridge.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// include ROS 2
 #include <rclcpp/rclcpp.hpp>
 
 // include Ignition Transport
@@ -45,17 +46,32 @@ int main(int argc, char * argv[])
     std::make_unique<ros_ign_bridge::BridgeRosToIgn>(
       ros_node, ign_node,
       ros_type_name, topic_name,
-      ign_type_name, topic_name));
+      ign_type_name, topic_name,
+      ros_ign_bridge::Bridge::kDefaultSubscriberQueue,
+      ros_ign_bridge::Bridge::kDefaultPublisherQueue,
+      true));
 
   handles.push_back(
     std::make_unique<ros_ign_bridge::BridgeIgnToRos>(
       ros_node, ign_node,
       ros_type_name, topic_name,
-      ign_type_name, topic_name));
+      ign_type_name, topic_name,
+      ros_ign_bridge::Bridge::kDefaultSubscriberQueue,
+      ros_ign_bridge::Bridge::kDefaultPublisherQueue,
+      true));
+
 
   for (auto & bridge : handles) {
     bridge->Start();
   }
+
+  auto timer = ros_node->create_wall_timer(
+    std::chrono::milliseconds(1000),
+    [&handles]() {
+      for (auto & bridge : handles) {
+        bridge->Spin();
+      }
+    });
 
   rclcpp::spin(ros_node);
 

--- a/ros_ign_bridge/src/parameter_bridge.cpp
+++ b/ros_ign_bridge/src/parameter_bridge.cpp
@@ -153,7 +153,7 @@ int main(int argc, char * argv[])
             ros_ign_bridge::Bridge::kDefaultSubscriberQueue,
             ros_ign_bridge::Bridge::kDefaultPublisherQueue,
             lazy_subscription
-            ));
+        ));
       }
       if (ros_to_ign) {
         RCLCPP_INFO(
@@ -169,7 +169,7 @@ int main(int argc, char * argv[])
             ros_ign_bridge::Bridge::kDefaultSubscriberQueue,
             ros_ign_bridge::Bridge::kDefaultPublisherQueue,
             lazy_subscription
-            ));
+        ));
       }
     } catch (std::runtime_error & _e) {
       RCLCPP_WARN(

--- a/ros_ign_bridge/src/parameter_bridge.cpp
+++ b/ros_ign_bridge/src/parameter_bridge.cpp
@@ -85,6 +85,11 @@ int main(int argc, char * argv[])
   // ROS 2 node
   auto ros_node = std::make_shared<rclcpp::Node>("ros_ign_bridge");
 
+  ros_node->declare_parameter<bool>("lazy", false);
+
+  bool lazy_subscription;
+  ros_node->get_parameter("lazy", lazy_subscription);
+
   // Ignition node
   auto ign_node = std::make_shared<ignition::transport::Node>();
 
@@ -137,24 +142,34 @@ int main(int argc, char * argv[])
       if (ign_to_ros) {
         RCLCPP_INFO(
           ros_node->get_logger(),
-          "Creating IGN->ROS Bridge: [%s] (%s -> %s)",
-          topic_name.c_str(), ign_type_name.c_str(), ros_type_name.c_str());
+          "Creating IGN->ROS Bridge: [%s] (%s -> %s) (Lazy %d): ",
+          topic_name.c_str(), ign_type_name.c_str(), ros_type_name.c_str(),
+          lazy_subscription);
         handles.push_back(
           std::make_unique<ros_ign_bridge::BridgeIgnToRos>(
             ros_node, ign_node,
             ros_type_name, topic_name,
-            ign_type_name, topic_name));
+            ign_type_name, topic_name,
+            ros_ign_bridge::Bridge::kDefaultSubscriberQueue,
+            ros_ign_bridge::Bridge::kDefaultPublisherQueue,
+            lazy_subscription
+            ));
       }
       if (ros_to_ign) {
         RCLCPP_INFO(
           ros_node->get_logger(),
-          "Creating ROS->IGN Bridge: [%s] (%s -> %s)",
-          topic_name.c_str(), ros_type_name.c_str(), ign_type_name.c_str());
+          "Creating ROS->IGN Bridge: [%s] (%s -> %s) (Lazy %d): ",
+          topic_name.c_str(), ros_type_name.c_str(), ign_type_name.c_str(),
+          lazy_subscription);
         handles.push_back(
           std::make_unique<ros_ign_bridge::BridgeRosToIgn>(
             ros_node, ign_node,
             ros_type_name, topic_name,
-            ign_type_name, topic_name));
+            ign_type_name, topic_name,
+            ros_ign_bridge::Bridge::kDefaultSubscriberQueue,
+            ros_ign_bridge::Bridge::kDefaultPublisherQueue,
+            lazy_subscription
+            ));
       }
     } catch (std::runtime_error & _e) {
       RCLCPP_WARN(


### PR DESCRIPTION
# Optional "lazy" bridge subscribers

## Summary

This allows for the bridge to be created in such a way that it is "lazy".  In this case "lazy" means:

* The publication (output) side of the bridge is always on and actively looking for subscriptions.
* The subscription (input) side of the bridge is only turned on in the case that there are subscriptions on the output side.

This means that in the case of IGN->ROS2:

* If there are no ROS2 subscribers, the bridge won't subscribe to the IGN topic
* If there are one or more ROS2 subscribers, the bridge will subscribe.
* If all subscriptions go away, the bridge will unsubscribe.

This is especially helpful when interfacing with ign-gazebo, where sensors will be skipped if there are no active subscribers to them.

### Current limitations

* Ignition transport can't tell if a connection is local or not, so in the case of a bidirectional bridge, the output side of the bridge detects the input side of the bridge.  This can be overcome by changing the ignition topic names on both sides of the bridge.
  * This could likely be solved via https://github.com/ignitionrobotics/ign-transport/issues/263
* "laziness" is evaluated in a timer loop from ROS2 at 1 second intervals.  There is a potential data race where a subscriber comes online and misses up to one second of data.  For this reason, laziness is *disabled* by default.

## Test it

### Lazy ros subscriber
```
# In the first window
ros2 run ros_ign_bridge lazy_static_bridge

# In a new window
ign topic -e -t /chatter

# In the first window you should see
[INFO] [1647638695.035819089] [test_node]: Lazy Mode Enabled and subscriptions found, starting
[INFO] [1647638695.035944431] [test_node]: Created ROS Subscriber: chatter

# After Ctrl-C the topic echo
[INFO] [1647638722.035932655] [test_node]: Lazy Mode Enabled and no subscriptions found, stopping
```

### Lazy ign subscriber

```
# In the first window
ros2 run ros_ign_bridge lazy_static_bridge

# In a new window
ros2 topic echo /chatter

# In the first window you should see
[INFO] [1647638483.034489736] [test_node]: Lazy Mode Enabled and subscriptions found, starting
[INFO] [1647638483.034533126] [test_node[INFO] [1647638484.034472832] [test_node]: Lazy Mode Enabled and subscriptions found, starting
[INFO] [1647638484.034615154] [test_node]: Created ROS Subscriber: chatter
]: Created IGN Subscriber: chatter

# Ctrl-c in the second window and you should see
[INFO] [1647638525.034771030] [test_node]: Lazy Mode Enabled and no subscriptions found, stopping
```


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
