### PR TITLE
Added ign_version launch argument to set ignition gazebo version

### DIFF
--- a/ros_ign_gazebo/CMakeLists.txt
+++ b/ros_ign_gazebo/CMakeLists.txt
@@ -34,6 +34,9 @@ else()
   find_package(ignition-msgs5 REQUIRED)
   set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
+  find_package(ignition-gazebo3 REQUIRED)
+  set(IGN_GAZEBO_VER ${ignition-gazebo3_VERSION_MAJOR})
+
   message(STATUS "Compiling against Ignition Citadel")
 endif()
 
@@ -52,8 +55,18 @@ target_link_libraries(create
   ignition-transport${IGN_TRANSPORT_VER}::core
 )
 
-install(DIRECTORY
-  launch
+configure_file(
+  launch/ign_gazebo.launch.py.in
+  launch/ign_gazebo.launch.py.configured
+  @ONLY
+)
+file(GENERATE
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/launch/ign_gazebo.launch.py"
+  INPUT "${CMAKE_CURRENT_BINARY_DIR}/launch/ign_gazebo.launch.py.configured"
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/launch/ign_gazebo.launch.py"
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/ros_ign_gazebo/launch/ign_gazebo.launch.py
+++ b/ros_ign_gazebo/launch/ign_gazebo.launch.py
@@ -30,9 +30,14 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('ign_args', default_value='',
                               description='Arguments to be passed to Ignition Gazebo'),
+        # The default version for Foxy in Citadel (3)
+        DeclareLaunchArgument('ign_version', default_value='3',
+                              description='Ignition version'),
         ExecuteProcess(
             cmd=['ign gazebo',
                  LaunchConfiguration('ign_args'),
+                 '--force-version',
+                 LaunchConfiguration('ign_version'),
                  ],
             output='screen',
             additional_env=env,

--- a/ros_ign_gazebo/launch/ign_gazebo.launch.py.in
+++ b/ros_ign_gazebo/launch/ign_gazebo.launch.py.in
@@ -30,9 +30,9 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('ign_args', default_value='',
                               description='Arguments to be passed to Ignition Gazebo'),
-        # The default version for Foxy in Citadel (3)
-        DeclareLaunchArgument('ign_version', default_value='3',
-                              description='Ignition version'),
+        # Ignition Gazebo's major version
+        DeclareLaunchArgument('ign_version', default_value='@IGN_GAZEBO_VER@',
+                              description='Ignition Gazebo\'s major version'),
         ExecuteProcess(
             cmd=['ign gazebo',
                  LaunchConfiguration('ign_args'),


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

Close this PR https://github.com/ignitionrobotics/ros_ign/issues/133

## Summary

Added a new launch argument called `ign_version`

## Test it

```
sudo apt-get install ignition-citadel ignition-fortress
```

Launch ignition Citadel (by default in Foxy)
```
ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_version:=3
```

Launch ignition Fortress
```
ros2 launch ros_ign_gazebo ign_gazebo.launch.py ign_version:=6
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
