### PR TITLE
Adding ign_gazebo_dev package

### DIFF
--- a/ros_ign_dev/ign_gazebo_dev/CMakeLists.txt
+++ b/ros_ign_dev/ign_gazebo_dev/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
+find_package(ament_cmake REQUIRED)
+project(ign_gazebo_dev)
+
+ament_package(
+CONFIG_EXTRAS cmake/ignition_gazebo_dev-extras.cmake)

--- a/ros_ign_dev/ign_gazebo_dev/cmake/ignition_gazebo_dev-extras.cmake
+++ b/ros_ign_dev/ign_gazebo_dev/cmake/ignition_gazebo_dev-extras.cmake
@@ -1,0 +1,17 @@
+# This code here calls and sets required igniton gazebo based on ROS Distribution so,packages can directly go find_package(ign_gazebo_dev) so,that 
+# they don't need to change code with different ros distros
+if(DEFINED ENV{ROS_DISTRO})    
+message(STATUS "Detected ROS Distro is $ENV{ROS_DISTRO}")
+
+if("$ENV{ROS_DISTRO}" MATCHES "foxy")
+  find_package(ignition-gazebo3 REQUIRED)
+  set(IGN_GAZEBO_VER ${ignition-gazebo3_VERSION_MAJOR})
+elseif("$ENV{ROS_DISTRO}" MATCHES "galactic")
+  find_package(ignition-gazebo5 REQUIRED)
+  set(IGN_GAZEBO_VER ${ignition-gazebo5_VERSION_MAJOR})
+elseif("$ENV{ROS_DISTRO}" MATCHES "humble")
+  find_package(ignition-gazebo5 REQUIRED)
+  set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
+else()
+message(STATUS "No ROS Distro detected")
+endif()

--- a/ros_ign_dev/ign_gazebo_dev/cmake/ignition_gazebo_dev-extras.cmake
+++ b/ros_ign_dev/ign_gazebo_dev/cmake/ignition_gazebo_dev-extras.cmake
@@ -1,7 +1,10 @@
 # This code here calls and sets required igniton gazebo based on ROS Distribution so,packages can directly go find_package(ign_gazebo_dev) so,that 
 # they don't need to change code with different ros distros
-if(DEFINED ENV{ROS_DISTRO})    
+set( ENV{OVERRIDE_ROS_GZ_VERSION} 6 )
+
+if(DEFINED ENV{ROS_DISTRO})
 message(STATUS "Detected ROS Distro is $ENV{ROS_DISTRO}")
+endif()
 
 if("$ENV{ROS_DISTRO}" MATCHES "foxy")
   find_package(ignition-gazebo3 REQUIRED)
@@ -10,8 +13,12 @@ elseif("$ENV{ROS_DISTRO}" MATCHES "galactic")
   find_package(ignition-gazebo5 REQUIRED)
   set(IGN_GAZEBO_VER ${ignition-gazebo5_VERSION_MAJOR})
 elseif("$ENV{ROS_DISTRO}" MATCHES "humble")
-  find_package(ignition-gazebo5 REQUIRED)
+  find_package(ignition-gazebo6 REQUIRED)
   set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
 else()
-message(STATUS "No ROS Distro detected")
+  message(STATUS "No ROS Distro detected")
+  message(STATUS "Setting to default gazebo version")
+  find_package(ignition-gazebo$ENV{OVERRIDE_ROS_GZ_VERSION} REQUIRED)
+  set(IGN_GAZEBO_VER ${ignition-gazebo$ENV{OVERRIDE_ROS_GZ_VERSION}_VERSION_MAJOR})
+
 endif()

--- a/ros_ign_dev/ign_gazebo_dev/package.xml
+++ b/ros_ign_dev/ign_gazebo_dev/package.xml
@@ -10,10 +10,16 @@
 
   <author>Harsh Mahesheka</author>
 
+  <build_depend>ros_environment</build_depend>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend condition="$ROS_DISTRO == foxy">ignition-gazebo3</depend>
   <depend condition="$ROS_DISTRO == galactic">ignition-gazebo5</depend>
   <depend condition="$ROS_DISTRO == humble">ignition-gazebo6</depend>
+
+  <!-- If no known ROS DISTRO is found,it will fall back to default a version -->
+
+  <depend condition="$ROS_DISTRO !=humble and $ROS_DISTRO !=galactic and $ROS_DISTRO!=foxy" >ignition-gazebo6</depend>
+
 
 
 

--- a/ros_ign_dev/ign_gazebo_dev/package.xml
+++ b/ros_ign_dev/ign_gazebo_dev/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>ign_gazebo_dev</name>
+  <version>1.0.0</version>
+  <description>Package to pull default ignition gazebo version for each ROS distro</description>
+
+  <maintainer email="harsh.mahesheka.eee20@iitbhu.ac.in">Harsh Mahesheka</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author>Harsh Mahesheka</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend condition="$ROS_DISTRO == foxy">ignition-gazebo3</depend>
+  <depend condition="$ROS_DISTRO == galactic">ignition-gazebo5</depend>
+  <depend condition="$ROS_DISTRO == humble">ignition-gazebo6</depend>
+
+
+
+
+  <!-- The above line makes the package depend on igniton version based on ROS Distribution So, packages can directly depend on it 
+  so that they don't have to change code with different ros distros  -->
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
# 🎉 New feature

Closes #186 

## Summary
First,package.xml has  `<depend condition>` which will make the package depend on the required ign-gazebo version based on Ros distribution and other packages can depend on it.Secondly, ignition_gazebo_dev-extras.cmake under cmake find and set required ign gazebo package so, other packages can simply go  `find_package(ign_gazebo_dev REQUIRED) 
` instead of finding ign-gazebo which will make their packages furthermore compatible with different ROS distros. Currently, I am creating a draft pr for reviews from the community, after that, we can add similar packages for all other ignition libraries.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

## Test it

1. I have created a [test_package](https://github.com/harshmahesheka/test_package/tree/ros_ign_dev), you can clone it or replace find_package and dependencies in any of your own packages. 
2.  Clone this repository in your workspace and do rosdep check to see dependencies change based on your ros distro.
3. Build and source this repository and then build your test package. You can see it and find different gazebo versions based on your ros distro.


