### PR TITLE
Add rssi to Dataframe.msg

### DIFF
--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -230,7 +230,7 @@ convert_ign_to_ros(
   ros_msg.src_address = ign_msg.src_address();
   ros_msg.dst_address = ign_msg.dst_address();
 
-  const auto &header = ign_msg.header();
+  const auto & header = ign_msg.header();
   for (auto i = 0; i < header.data_size(); ++i) {
     if (header.data(i).key() == "rssi" && header.data(i).value_size() > 0) {
       try {

--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -235,12 +235,10 @@ convert_ign_to_ros(
     if (header.data(i).key() == "rssi" && header.data(i).value_size() > 0) {
       try {
         ros_msg.rssi = std::stod(header.data(i).value(0));
-      }
-      catch (const std::invalid_argument&) {
+      } catch (const std::invalid_argument&) {
         std::cerr << "RSSI value is invalid ("
                   << header.data(i).value(0) << ")" << std::endl;
-      }
-      catch (const std::out_of_range&) {
+      } catch (const std::out_of_range&) {
         std::cerr << "RSSI value is out of range ("
                   << header.data(i).value(0) << ")" << std::endl;
       }

--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -239,7 +239,8 @@ convert_ign_to_ros(
       catch (const std::invalid_argument&) {
         std::cerr << "RSSI value is invalid ("
                   << header.data(i).value(0) << ")" << std::endl;
-      } catch (const std::out_of_range&) {
+      }
+      catch (const std::out_of_range&) {
         std::cerr << "RSSI value is out of range ("
                   << header.data(i).value(0) << ")" << std::endl;
       }

--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -235,10 +235,10 @@ convert_ign_to_ros(
     if (header.data(i).key() == "rssi" && header.data(i).value_size() > 0) {
       try {
         ros_msg.rssi = std::stod(header.data(i).value(0));
-      } catch (const std::invalid_argument&) {
+      } catch (const std::invalid_argument &) {
         std::cerr << "RSSI value is invalid ("
                   << header.data(i).value(0) << ")" << std::endl;
-      } catch (const std::out_of_range&) {
+      } catch (const std::out_of_range &) {
         std::cerr << "RSSI value is out of range ("
                   << header.data(i).value(0) << ")" << std::endl;
       }

--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -209,7 +209,7 @@ convert_ros_to_ign(
   ignition::msgs::Dataframe & ign_msg)
 {
   convert_ros_to_ign(ros_msg.header, (*ign_msg.mutable_header()));
-  auto *rssiPtr = ign_msg.mutable_header()->add_data();
+  auto * rssiPtr = ign_msg.mutable_header()->add_data();
   rssiPtr->set_key("rssi");
   rssiPtr->add_value(std::to_string(ros_msg.rssi));
 
@@ -231,20 +231,15 @@ convert_ign_to_ros(
   ros_msg.dst_address = ign_msg.dst_address();
 
   const auto &header = ign_msg.header();
-  for (auto i = 0; i < header.data_size(); ++i)
-  {
-    if (header.data(i).key() == "rssi" && header.data(i).value_size() > 0)
-    {
-      try
-      {
+  for (auto i = 0; i < header.data_size(); ++i) {
+    if (header.data(i).key() == "rssi" && header.data(i).value_size() > 0) {
+      try {
         ros_msg.rssi = std::stod(header.data(i).value(0));
       }
-      catch (const std::invalid_argument&)
-      {
+      catch (const std::invalid_argument&) {
         std::cerr << "RSSI value is invalid ("
                   << header.data(i).value(0) << ")" << std::endl;
-      } catch (const std::out_of_range&)
-      {
+      } catch (const std::out_of_range&) {
         std::cerr << "RSSI value is out of range ("
                   << header.data(i).value(0) << ")" << std::endl;
       }

--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -236,11 +236,11 @@ convert_ign_to_ros(
       try {
         ros_msg.rssi = std::stod(header.data(i).value(0));
       } catch (const std::invalid_argument &) {
-        std::cerr << "RSSI value is invalid ("
-                  << header.data(i).value(0) << ")" << std::endl;
+        std::cerr << "RSSI value is invalid (" <<
+          header.data(i).value(0) << ")" << std::endl;
       } catch (const std::out_of_range &) {
-        std::cerr << "RSSI value is out of range ("
-                  << header.data(i).value(0) << ")" << std::endl;
+        std::cerr << "RSSI value is out of range (" <<
+          header.data(i).value(0) << ")" << std::endl;
       }
     }
   }

--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -234,7 +234,21 @@ convert_ign_to_ros(
   for (auto i = 0; i < header.data_size(); ++i)
   {
     if (header.data(i).key() == "rssi" && header.data(i).value_size() > 0)
-      ros_msg.rssi = std::stod(header.data(i).value(0));
+    {
+      try
+      {
+        ros_msg.rssi = std::stod(header.data(i).value(0));
+      }
+      catch (const std::invalid_argument&)
+      {
+        std::cerr << "RSSI value is invalid ("
+                  << header.data(i).value(0) << ")" << std::endl;
+      } catch (const std::out_of_range&)
+      {
+        std::cerr << "RSSI value is out of range ("
+                  << header.data(i).value(0) << ")" << std::endl;
+      }
+    }
   }
 
   ros_msg.data.resize(ign_msg.data().size());

--- a/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/ros_ign_interfaces.cpp
@@ -209,6 +209,9 @@ convert_ros_to_ign(
   ignition::msgs::Dataframe & ign_msg)
 {
   convert_ros_to_ign(ros_msg.header, (*ign_msg.mutable_header()));
+  auto *rssiPtr = ign_msg.mutable_header()->add_data();
+  rssiPtr->set_key("rssi");
+  rssiPtr->add_value(std::to_string(ros_msg.rssi));
 
   ign_msg.set_src_address(ros_msg.src_address);
   ign_msg.set_dst_address(ros_msg.dst_address);
@@ -226,6 +229,13 @@ convert_ign_to_ros(
 
   ros_msg.src_address = ign_msg.src_address();
   ros_msg.dst_address = ign_msg.dst_address();
+
+  const auto &header = ign_msg.header();
+  for (auto i = 0; i < header.data_size(); ++i)
+  {
+    if (header.data(i).key() == "rssi" && header.data(i).value_size() > 0)
+      ros_msg.rssi = std::stod(header.data(i).value(0));
+  }
 
   ros_msg.data.resize(ign_msg.data().size());
   std::copy(

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -455,6 +455,10 @@ void createTestMsg(ignition::msgs::Dataframe & _msg)
   createTestMsg(header_msg);
   _msg.mutable_header()->CopyFrom(header_msg);
 
+  auto *rssiPtr = _msg.mutable_header()->add_data();
+  rssiPtr->set_key("rssi");
+  rssiPtr->add_value("-10.3");
+
   _msg.set_src_address("localhost:8080");
   _msg.set_dst_address("localhost:8081");
   _msg.set_data(std::string(150, '1'));
@@ -466,6 +470,19 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Dataframe> & _msg)
   createTestMsg(expected_msg);
   compareTestMsg(std::make_shared<ignition::msgs::Header>(_msg->header()));
 
+  ASSERT_GT(_msg->header().data_size(), 0);
+  bool rssiFound = false;
+  for (auto i = 0; i < _msg->header().data_size(); ++i)
+  {
+    if (_msg->header().data(i).key() == "rssi" &&
+        _msg->header().data(i).value_size() > 0)
+    {
+      EXPECT_EQ(0u, _msg->header().data(i).value(0).find("-10.3"));
+      rssiFound = true;
+    }
+  }
+
+  EXPECT_TRUE(rssiFound);
   EXPECT_EQ(expected_msg.src_address(), _msg->src_address());
   EXPECT_EQ(expected_msg.dst_address(), _msg->dst_address());
   EXPECT_EQ(expected_msg.data(), _msg->data());

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -455,7 +455,7 @@ void createTestMsg(ignition::msgs::Dataframe & _msg)
   createTestMsg(header_msg);
   _msg.mutable_header()->CopyFrom(header_msg);
 
-  auto *rssiPtr = _msg.mutable_header()->add_data();
+  auto * rssiPtr = _msg.mutable_header()->add_data();
   rssiPtr->set_key("rssi");
   rssiPtr->add_value("-10.3");
 
@@ -472,8 +472,7 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Dataframe> & _msg)
 
   ASSERT_GT(_msg->header().data_size(), 0);
   bool rssiFound = false;
-  for (auto i = 0; i < _msg->header().data_size(); ++i)
-  {
+  for (auto i = 0; i < _msg->header().data_size(); ++i) {
     if (_msg->header().data(i).key() == "rssi" &&
         _msg->header().data(i).value_size() > 0)
     {

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -474,7 +474,7 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Dataframe> & _msg)
   bool rssiFound = false;
   for (auto i = 0; i < _msg->header().data_size(); ++i) {
     if (_msg->header().data(i).key() == "rssi" &&
-        _msg->header().data(i).value_size() > 0)
+      _msg->header().data(i).value_size() > 0)
     {
       EXPECT_EQ(0u, _msg->header().data(i).value(0).find("-10.3"));
       rssiFound = true;

--- a/ros_ign_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.cpp
@@ -615,6 +615,7 @@ void createTestMsg(ros_ign_interfaces::msg::Dataframe & _msg)
 {
   createTestMsg(_msg.header);
 
+  _msg.rssi = -10.3;
   _msg.src_address = "localhost:8080";
   _msg.dst_address = "localhost:8081";
   _msg.data.resize(150, '1');
@@ -628,6 +629,7 @@ void compareTestMsg(const std::shared_ptr<ros_ign_interfaces::msg::Dataframe> & 
   compareTestMsg(_msg->header);
   EXPECT_EQ(expected_msg.src_address, _msg->src_address);
   EXPECT_EQ(expected_msg.dst_address, _msg->dst_address);
+  EXPECT_EQ(expected_msg.rssi, _msg->rssi);
 
   ASSERT_EQ(expected_msg.data.size(), _msg->data.size());
   for (size_t ii = 0; ii < _msg->data.size(); ++ii) {

--- a/ros_ign_interfaces/msg/Dataframe.msg
+++ b/ros_ign_interfaces/msg/Dataframe.msg
@@ -4,3 +4,4 @@ std_msgs/Header header                  # Time stamp
 string src_address                      # Address of the sender
 string dst_address                      # Address of the destination
 uint8[] data                            # Payload
+float64 rssi                            # Received Signal Strength Indicator


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This patch adds a new `rssi` field to the `ros_ign_interfaces/Dataframe.msg`.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

