### PR TITLE
feat: set qos options to override durability

### DIFF
--- a/ros_ign_bridge/src/factory.hpp
+++ b/ros_ign_bridge/src/factory.hpp
@@ -48,8 +48,15 @@ public:
   {
     // Allow QoS overriding
     auto options = rclcpp::PublisherOptions();
-    options.qos_overriding_options =
-      rclcpp::QosOverridingOptions::with_default_policies();
+    options.qos_overriding_options = rclcpp::QosOverridingOptions {
+      {
+        rclcpp::QosPolicyKind::Depth,
+        rclcpp::QosPolicyKind::Durability,
+        rclcpp::QosPolicyKind::History,
+        rclcpp::QosPolicyKind::Reliability
+      },
+    };
+
     std::shared_ptr<rclcpp::Publisher<ROS_T>> publisher =
       ros_node->create_publisher<ROS_T>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), options);


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🎉 New feature

Closes #<NUMBER>

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
The default qos options don't contain durability policy, so we can't override durability via ros parameter.
This PR sets additional qos policy into qos options to override durability policy.

## Test it
`ros2 param dump` shows durability under qos_overrides.
```
❯ ros2 param dump /bridge
/bridge:
  ros__parameters:
    qos_overrides:
      /clock:
        publisher:
          depth: 10
          durability: volatile
          history: keep_last
          reliability: reliable
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
