### PR TITLE
Add garden to CI

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -10,7 +10,16 @@ export ROS_PYTHON_VERSION=3
 apt update -qq
 apt install -qq -y lsb-release wget curl build-essential
 
-# Citadel, Edifice and Fortress get Ignition with rosdep for Focal
+# Garden only has nightlies for now
+if [ "$IGNITION_VERSION" == "garden" ]; then
+  echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
+  echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list
+  wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+
+  IGN_DEPS="libignition-gazebo7-dev"
+fi
+
+# Fortress comes through rosdep for Focal and Jammy
 
 # Dependencies.
 echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-testing.list
@@ -22,7 +31,7 @@ apt-get install -y $IGN_DEPS \
 
 rosdep init
 rosdep update
-rosdep install --from-paths ./ -i -y --rosdistro $ROS_DISTRO
+rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO
 
 # Build.
 source /opt/ros/$ROS_DISTRO/setup.bash

--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -15,6 +15,9 @@ jobs:
           - docker-image: "ubuntu:22.04"
             ignition-version: "fortress"
             ros-distro: "rolling"
+          - docker-image: "ubuntu:22.04"
+            ignition-version: "garden"
+            ros-distro: "rolling"
     container:
       image: ${{ matrix.docker-image }}
     steps:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Foxy | Citadel | [foxy](https://github.com/gazebosim/ros_gz/tree/foxy) | https:/
 Foxy | Edifice | [foxy](https://github.com/gazebosim/ros_gz/tree/foxy) | only from source
 Galactic | Edifice | [galactic](https://github.com/gazebosim/ros_gz/tree/galactic) | https://packages.ros.org
 Galactic | Fortress | [galactic](https://github.com/gazebosim/ros_gz/tree/galactic) | only from source
-Humble | Fortress | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | https://packages.ros.org
+Humble | Fortress | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | https://packages.ros.org
 Rolling | Edifice | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source
 Rolling | Fortress | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | https://packages.ros.org
 Rolling | Garden (not released) | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source


### PR DESCRIPTION
* Targeted at #255 

Use nightlies for Garden. The `-r` on `rosdep` allows the missing rosdep keys to fail.