### PR TITLE
Feature: set QoS options to override durability (#250)

### DIFF
--- a/ros_ign_bridge/src/factory.hpp
+++ b/ros_ign_bridge/src/factory.hpp
@@ -50,8 +50,15 @@ public:
   {
     // Allow QoS overriding
     auto options = rclcpp::PublisherOptions();
-    options.qos_overriding_options =
-      rclcpp::QosOverridingOptions::with_default_policies();
+    options.qos_overriding_options = rclcpp::QosOverridingOptions {
+      {
+        rclcpp::QosPolicyKind::Depth,
+        rclcpp::QosPolicyKind::Durability,
+        rclcpp::QosPolicyKind::History,
+        rclcpp::QosPolicyKind::Reliability
+      },
+    };
+
     std::shared_ptr<rclcpp::Publisher<ROS_T>> publisher =
       ros_node->create_publisher<ROS_T>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), options);


### PR DESCRIPTION
# 🎉 New feature

* Backport #250

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

For future reference, this is necessary when bridging `tf_static`, because it expects a `transient_local` durability. We're planning to open a separate PR with a demo for how to do this, but here's an example:

```py
      bridge = Node(
          package='ros_ign_bridge',
          executable='parameter_bridge',
          arguments=[
              # Bridge static poses from PosePublisher
              '/model/' + model_name + '/pose_static@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V',
          ],
          remappings=[
              # Remap to tf_static
              ('/model/' + model_name + '/pose_static', '/tf_static'),
          ],
         # Set correct durability for tf_static
          parameters=[{'qos_overrides./tf_static.publisher.durability' : 'transient_local'}]
      )

```


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
