### PR TITLE
Add support for converting Any <-> ParamValue

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -48,6 +48,7 @@ set(GZ_MSGS_VERSION_FULL ${GZ_MSGS_VERSION_MAJOR}.${GZ_MSGS_VERSION_MINOR}.${GZ_
 set(BRIDGE_MESSAGE_TYPES
   geometry_msgs
   nav_msgs
+  rcl_interfaces
   ros_ign_interfaces
   rosgraph_msgs
   sensor_msgs
@@ -173,6 +174,21 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(launch_testing_ament_cmake REQUIRED)
   ament_find_gtest()
+
+  ament_add_gtest(test_rcl_interfaces
+    ${PROJECT_SOURCE_DIR}/src/convert/rcl_interfaces.cpp
+    ${PROJECT_SOURCE_DIR}/src/convert/rcl_interfaces_TEST.cpp
+  )
+  target_link_libraries(test_rcl_interfaces
+    ignition-msgs${GZ_MSGS_VER}::core
+    ${rcl_interfaces_TARGETS}
+    gtest
+    gtest_main
+  )
+  target_include_directories(test_rcl_interfaces
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+  )
 
   add_library(test_utils
     test/utils/ign_test_msg.cpp

--- a/ros_ign_bridge/include/ros_ign_bridge/convert/rcl_interfaces.hpp
+++ b/ros_ign_bridge/include/ros_ign_bridge/convert/rcl_interfaces.hpp
@@ -1,0 +1,44 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS_IGN_BRIDGE__CONVERT__RCL_INTERFACES_HPP_
+#define ROS_IGN_BRIDGE__CONVERT__RCL_INTERFACES_HPP_
+
+// Ignition messages
+#include <ignition/msgs/any.pb.h>
+
+// ROS 2 messages
+#include <rcl_interfaces/msg/parameter.hpp>
+#include <rcl_interfaces/msg/parameter_type.hpp>
+#include <rcl_interfaces/msg/parameter_value.hpp>
+
+#include <ros_ign_bridge/convert_decl.hpp>
+
+namespace ros_ign_bridge
+{
+
+template<>
+void
+convert_ros_to_ign(
+  const rcl_interfaces::msg::ParameterValue & ros_msg,
+  ignition::msgs::Any & ign_msg);
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Any & ign_msg,
+  rcl_interfaces::msg::ParameterValue & ros_msg);
+
+}  // namespace ros_ign_bridge
+#endif  // ROS_IGN_BRIDGE__CONVERT__RCL_INTERFACES_HPP_

--- a/ros_ign_bridge/ros_ign_bridge/mappings.py
+++ b/ros_ign_bridge/ros_ign_bridge/mappings.py
@@ -74,6 +74,9 @@ MAPPINGS = {
         Mapping('UInt32', 'UInt32'),
         Mapping('String', 'StringMsg'),
     ],
+    'rcl_interfaces': [
+        Mapping('ParameterValue', 'Any'),
+    ],
     'tf2_msgs': [
         Mapping('TFMessage', 'Pose_V'),
     ],

--- a/ros_ign_bridge/ros_ign_bridge/mappings.py
+++ b/ros_ign_bridge/ros_ign_bridge/mappings.py
@@ -38,6 +38,9 @@ MAPPINGS = {
     'nav_msgs': [
         Mapping('Odometry', 'Odometry'),
     ],
+    'rcl_interfaces': [
+        Mapping('ParameterValue', 'Any'),
+    ],
     'ros_ign_interfaces': [
         Mapping('Contact', 'Contact'),
         Mapping('Contacts', 'Contacts'),
@@ -73,9 +76,6 @@ MAPPINGS = {
         Mapping('Int32', 'Int32'),
         Mapping('UInt32', 'UInt32'),
         Mapping('String', 'StringMsg'),
-    ],
-    'rcl_interfaces': [
-        Mapping('ParameterValue', 'Any'),
     ],
     'tf2_msgs': [
         Mapping('TFMessage', 'Pose_V'),

--- a/ros_ign_bridge/src/convert/rcl_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/rcl_interfaces.cpp
@@ -14,6 +14,9 @@
 
 #include "ros_ign_bridge/convert/rcl_interfaces.hpp"
 
+#include <limits>
+#include <string>
+
 namespace ros_ign_bridge
 {
 
@@ -81,8 +84,8 @@ convert_ros_to_ign(
   }
 
   if (!unsupported_type.empty()) {
-    std::cerr << "Converting unsupported ParameterValue ["
-              << unsupported_type << "] failed\n";
+    std::cerr << "Converting unsupported ParameterValue [" <<
+      unsupported_type << "] failed\n";
   }
 }
 

--- a/ros_ign_bridge/src/convert/rcl_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/rcl_interfaces.cpp
@@ -1,0 +1,144 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros_ign_bridge/convert/rcl_interfaces.hpp"
+
+namespace ros_ign_bridge
+{
+
+constexpr auto kIntMax = static_cast<int64_t>(std::numeric_limits<int32_t>::max());
+constexpr auto kIntMin = static_cast<int64_t>(std::numeric_limits<int32_t>::min());
+
+template<>
+void
+convert_ros_to_ign(
+  const rcl_interfaces::msg::ParameterValue & ros_msg,
+  ignition::msgs::Any & ign_msg)
+{
+  using ParameterType = rcl_interfaces::msg::ParameterType;
+  using Any_ValueType = ignition::msgs::Any_ValueType;
+
+  std::string unsupported_type;
+  ign_msg.set_type(Any_ValueType::Any_ValueType_NONE);
+
+  switch (ros_msg.type) {
+    case ParameterType::PARAMETER_NOT_SET:
+      break;
+    case ParameterType::PARAMETER_BOOL:
+      ign_msg.set_type(Any_ValueType::Any_ValueType_BOOLEAN);
+      ign_msg.set_bool_value(ros_msg.bool_value);
+      break;
+    case ParameterType::PARAMETER_INTEGER:
+      ign_msg.set_type(Any_ValueType::Any_ValueType_INT32);
+
+      if (ros_msg.integer_value > kIntMax) {
+        ign_msg.set_int_value(kIntMax);
+        std::cerr << "ParameterValue INTEGER clamped to INT32_MAX\n";
+      } else if (ros_msg.integer_value < kIntMin) {
+        ign_msg.set_int_value(kIntMin);
+        std::cerr << "ParameterValue INTEGER clamped to INT32_MIN\n";
+      } else {
+        ign_msg.set_int_value(ros_msg.integer_value);
+      }
+      break;
+    case ParameterType::PARAMETER_DOUBLE:
+      ign_msg.set_type(Any_ValueType::Any_ValueType_DOUBLE);
+      ign_msg.set_double_value(ros_msg.double_value);
+      break;
+    case ParameterType::PARAMETER_STRING:
+      ign_msg.set_type(Any_ValueType::Any_ValueType_STRING);
+      ign_msg.set_string_value(ros_msg.string_value);
+      break;
+    case ParameterType::PARAMETER_BYTE_ARRAY:
+      unsupported_type = "BYTE_ARRAY";
+      break;
+    case ParameterType::PARAMETER_BOOL_ARRAY:
+      unsupported_type = "BOOL_ARRAY";
+      break;
+    case ParameterType::PARAMETER_INTEGER_ARRAY:
+      unsupported_type = "INTEGER_ARRAY";
+      break;
+    case ParameterType::PARAMETER_DOUBLE_ARRAY:
+      unsupported_type = "DOUBLE_ARRAY";
+      break;
+    case ParameterType::PARAMETER_STRING_ARRAY:
+      unsupported_type = "STRING_ARRAY";
+      break;
+    default:
+      unsupported_type = "UNKNOWN";
+      break;
+  }
+
+  if (!unsupported_type.empty()) {
+    std::cerr << "Converting unsupported ParameterValue ["
+              << unsupported_type << "] failed\n";
+  }
+}
+
+template<>
+void
+convert_ign_to_ros(
+  const ignition::msgs::Any & ign_msg,
+  rcl_interfaces::msg::ParameterValue & ros_msg)
+{
+  using ParameterType = rcl_interfaces::msg::ParameterType;
+  using Any_ValueType = ignition::msgs::Any_ValueType;
+
+  ros_msg.type = ParameterType::PARAMETER_NOT_SET;
+
+  std::string unsupported_type;
+  switch (ign_msg.type()) {
+    case Any_ValueType::Any_ValueType_NONE:
+      break;
+    case Any_ValueType::Any_ValueType_DOUBLE:
+      ros_msg.type = ParameterType::PARAMETER_DOUBLE;
+      ros_msg.double_value = ign_msg.double_value();
+      break;
+    case Any_ValueType::Any_ValueType_INT32:
+      ros_msg.type = ParameterType::PARAMETER_INTEGER;
+      ros_msg.integer_value = ign_msg.int_value();
+      break;
+    case Any_ValueType::Any_ValueType_STRING:
+      ros_msg.type = ParameterType::PARAMETER_STRING;
+      ros_msg.string_value = ign_msg.string_value();
+      break;
+    case Any_ValueType::Any_ValueType_BOOLEAN:
+      ros_msg.type = ParameterType::PARAMETER_BOOL;
+      ros_msg.bool_value = ign_msg.bool_value();
+      break;
+    case Any_ValueType::Any_ValueType_VECTOR3D:
+      unsupported_type = "VECTOR3D";
+      break;
+    case Any_ValueType::Any_ValueType_COLOR:
+      unsupported_type = "COLOR";
+      break;
+    case Any_ValueType::Any_ValueType_POSE3D:
+      unsupported_type = "POSE3D";
+      break;
+    case Any_ValueType::Any_ValueType_QUATERNIOND:
+      unsupported_type = "QUATERNIOND";
+      break;
+    case Any_ValueType::Any_ValueType_TIME:
+      unsupported_type = "TIME";
+      break;
+    default:
+      break;
+  }
+
+  if (!unsupported_type.empty()) {
+    std::cerr << "Converting unsupported gz::msgs::Any ["
+              << unsupported_type << "] failed\n";
+  }
+}
+}  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/convert/rcl_interfaces.cpp
+++ b/ros_ign_bridge/src/convert/rcl_interfaces.cpp
@@ -140,8 +140,8 @@ convert_ign_to_ros(
   }
 
   if (!unsupported_type.empty()) {
-    std::cerr << "Converting unsupported gz::msgs::Any ["
-              << unsupported_type << "] failed\n";
+    std::cerr << "Converting unsupported gz::msgs::Any [" <<
+      unsupported_type << "] failed\n";
   }
 }
 }  // namespace ros_ign_bridge

--- a/ros_ign_bridge/src/convert/rcl_interfaces_TEST.cpp
+++ b/ros_ign_bridge/src/convert/rcl_interfaces_TEST.cpp
@@ -16,6 +16,8 @@
 
 #include <ros_ign_bridge/convert/rcl_interfaces.hpp>
 
+#include <limits>
+
 // A more specific set of tests for the rcl_interfaces/msg/ParamValue to
 // ignition::msgs::Any to verify behaviors that couldn't easily be captured
 // by the generic test framework

--- a/ros_ign_bridge/src/convert/rcl_interfaces_TEST.cpp
+++ b/ros_ign_bridge/src/convert/rcl_interfaces_TEST.cpp
@@ -1,0 +1,205 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <ros_ign_bridge/convert/rcl_interfaces.hpp>
+
+// A more specific set of tests for the rcl_interfaces/msg/ParamValue to
+// ignition::msgs::Any to verify behaviors that couldn't easily be captured
+// by the generic test framework
+
+struct RosToIgnTest : public ::testing::Test
+{
+  using ParameterValue = rcl_interfaces::msg::ParameterValue;
+  using ParameterType = rcl_interfaces::msg::ParameterType;
+  using Any = ignition::msgs::Any;
+  using Any_ValueType = ignition::msgs::Any_ValueType;
+
+  Any ign_msg;
+  ParameterValue ros_msg;
+};
+
+TEST_F(RosToIgnTest, NotSet)
+{
+  ros_msg.type = ParameterType::PARAMETER_NOT_SET;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_NONE, ign_msg.type());
+}
+
+TEST_F(RosToIgnTest, Boolean)
+{
+  ros_msg.type = ParameterType::PARAMETER_BOOL;
+  ros_msg.bool_value = true;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_BOOLEAN, ign_msg.type());
+  EXPECT_EQ(ros_msg.bool_value, ign_msg.bool_value());
+}
+
+TEST_F(RosToIgnTest, Integer)
+{
+  // Within range of int32
+  ros_msg.type = ParameterType::PARAMETER_INTEGER;
+  ros_msg.integer_value = 55;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_INT32, ign_msg.type());
+  EXPECT_EQ(ros_msg.integer_value, ign_msg.int_value());
+
+  // Greater than int32 max, Clamp to max
+  ros_msg.integer_value =
+    static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_INT32, ign_msg.type());
+  EXPECT_EQ(std::numeric_limits<int32_t>::max(), ign_msg.int_value());
+
+  // Less than int32 min, Clamp to min
+  ros_msg.integer_value =
+    static_cast<int64_t>(std::numeric_limits<int32_t>::min()) - 1;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_INT32, ign_msg.type());
+  EXPECT_EQ(std::numeric_limits<int32_t>::min(), ign_msg.int_value());
+}
+
+TEST_F(RosToIgnTest, Double)
+{
+  ros_msg.type = ParameterType::PARAMETER_DOUBLE;
+  ros_msg.double_value = 1.0;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_DOUBLE, ign_msg.type());
+  EXPECT_EQ(ros_msg.double_value, ign_msg.double_value());
+}
+
+TEST_F(RosToIgnTest, String)
+{
+  ros_msg.type = ParameterType::PARAMETER_STRING;
+  ros_msg.string_value = "baz";
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_STRING, ign_msg.type());
+  EXPECT_EQ(ros_msg.string_value, ign_msg.string_value());
+}
+
+TEST_F(RosToIgnTest, ByteArray)
+{
+  ros_msg.type = ParameterType::PARAMETER_BYTE_ARRAY;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_NONE, ign_msg.type());
+}
+
+TEST_F(RosToIgnTest, BoolArray)
+{
+  ros_msg.type = ParameterType::PARAMETER_BOOL_ARRAY;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_NONE, ign_msg.type());
+}
+
+TEST_F(RosToIgnTest, IntegerArray)
+{
+  ros_msg.type = ParameterType::PARAMETER_INTEGER_ARRAY;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_NONE, ign_msg.type());
+}
+
+TEST_F(RosToIgnTest, DoubleArray)
+{
+  ros_msg.type = ParameterType::PARAMETER_DOUBLE_ARRAY;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_NONE, ign_msg.type());
+}
+
+TEST_F(RosToIgnTest, StringArray)
+{
+  ros_msg.type = ParameterType::PARAMETER_STRING_ARRAY;
+  ros_ign_bridge::convert_ros_to_ign(ros_msg, ign_msg);
+  EXPECT_EQ(Any_ValueType::Any_ValueType_NONE, ign_msg.type());
+}
+
+using IgnToRosTest = RosToIgnTest;
+
+TEST_F(IgnToRosTest, None)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_NONE);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_NOT_SET, ros_msg.type);
+}
+
+TEST_F(IgnToRosTest, Double)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_DOUBLE);
+  ign_msg.set_double_value(10.0);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_DOUBLE, ros_msg.type);
+  EXPECT_EQ(ign_msg.double_value(), ros_msg.double_value);
+}
+
+TEST_F(IgnToRosTest, Int32)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_INT32);
+  ign_msg.set_int_value(255);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_INTEGER, ros_msg.type);
+  EXPECT_EQ(ign_msg.int_value(), ros_msg.integer_value);
+}
+
+TEST_F(IgnToRosTest, String)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_STRING);
+  ign_msg.set_string_value("foobar");
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_STRING, ros_msg.type);
+  EXPECT_EQ(ign_msg.string_value(), ros_msg.string_value);
+}
+
+TEST_F(IgnToRosTest, Boolean)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_BOOLEAN);
+  ign_msg.set_bool_value(true);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_BOOL, ros_msg.type);
+  EXPECT_EQ(ign_msg.bool_value(), ros_msg.bool_value);
+}
+
+TEST_F(IgnToRosTest, Vector3d)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_VECTOR3D);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_NOT_SET, ros_msg.type);
+}
+
+TEST_F(IgnToRosTest, Color)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_COLOR);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_NOT_SET, ros_msg.type);
+}
+
+TEST_F(IgnToRosTest, Pose3d)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_POSE3D);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_NOT_SET, ros_msg.type);
+}
+
+TEST_F(IgnToRosTest, Quaterniond)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_QUATERNIOND);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_NOT_SET, ros_msg.type);
+}
+
+TEST_F(IgnToRosTest, Time)
+{
+  ign_msg.set_type(Any_ValueType::Any_ValueType_TIME);
+  ros_ign_bridge::convert_ign_to_ros(ign_msg, ros_msg);
+  EXPECT_EQ(ParameterType::PARAMETER_NOT_SET, ros_msg.type);
+}

--- a/ros_ign_bridge/test/utils/ign_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.cpp
@@ -24,6 +24,21 @@ namespace ros_ign_bridge
 namespace testing
 {
 
+void createTestMsg(ignition::msgs::Any & _msg)
+{
+  _msg.set_type(ignition::msgs::Any_ValueType::Any_ValueType_STRING);
+  _msg.set_string_value("foobar");
+}
+
+void compareTestMsg(const std::shared_ptr<ignition::msgs::Any> & _msg)
+{
+  ignition::msgs::Any expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.type(), _msg->type());
+  EXPECT_EQ(expected_msg.string_value(), _msg->string_value());
+}
+
 void createTestMsg(ignition::msgs::Boolean & _msg)
 {
   _msg.set_data(true);

--- a/ros_ign_bridge/test/utils/ign_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ign_test_msg.hpp
@@ -18,6 +18,7 @@
 #include <ros_ign_bridge/ros_ign_bridge.hpp>
 
 #include <ignition/msgs/actuators.pb.h>
+#include <ignition/msgs/any.pb.h>
 #include <ignition/msgs/axis.pb.h>
 #include <ignition/msgs/battery_state.pb.h>
 #include <ignition/msgs/boolean.pb.h>
@@ -65,6 +66,14 @@ namespace ros_ign_bridge
 {
 namespace testing
 {
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ignition::msgs::Any & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ignition::msgs::Any> & _msg);
+
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.
 void createTestMsg(ignition::msgs::Boolean & _msg);

--- a/ros_ign_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.cpp
@@ -1054,5 +1054,19 @@ void compareTestMsg(const std::shared_ptr<trajectory_msgs::msg::JointTrajectory>
   }
 }
 
+void createTestMsg(rcl_interfaces::msg::ParameterValue & _msg)
+{
+  _msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  _msg.string_value = "foobar";
+}
+
+void compareTestMsg(const std::shared_ptr<rcl_interfaces::msg::ParameterValue> & _msg)
+{
+  rcl_interfaces::msg::ParameterValue expected_msg;
+  createTestMsg(expected_msg);
+  EXPECT_EQ(expected_msg.type, _msg->type);
+  EXPECT_EQ(expected_msg.string_value, _msg->string_value);
+}
+
 }  // namespace testing
 }  // namespace ros_ign_bridge

--- a/ros_ign_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_ign_bridge/test/utils/ros_test_msg.hpp
@@ -61,6 +61,7 @@
 #include <sensor_msgs/msg/point_field.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
+#include <rcl_interfaces/msg/parameter_value.hpp>
 
 #include <memory>
 
@@ -446,6 +447,14 @@ void createTestMsg(trajectory_msgs::msg::JointTrajectory & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(rcl_interfaces::msg::ParameterValue & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<rcl_interfaces::msg::ParameterValue> & _msg);
 
 }  // namespace testing
 }  // namespace ros_ign_bridge


### PR DESCRIPTION
# 🎉 New feature

## Summary

Add support for converting between `gz::msgs::Any` and `rcl_interfaces/msg/ParameterValue`.

This is used in support of MBZIRC's RF ranging sensor: https://github.com/osrf/mbzirc/pull/151 to avoid adding custom messages that won't be supported by the bridge.
Both of these types use a "tagged union" approach to represent multiple datatypes within a single message.  

Currently, the supported types have overlap for the most common types, but aren't identical.  When an unsupported type is converted, the resulting message will be unpopulated.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.