### PR TITLE
Improve documentation around yaml configuration

### DIFF
--- a/ros_ign_bridge/README.md
+++ b/ros_ign_bridge/README.md
@@ -200,6 +200,7 @@ various parameters.
 The configuration file must be a YAML array of maps.
 An example configuration for 5 bridges is below, showing the various ways that a
 bridge may be specified:
+
 ```yaml
  # Set just topic name, applies to both
 - topic_name: "chatter"
@@ -227,9 +228,12 @@ bridge may be specified:
   ign_topic_name: "ign_chatter"
   ros_type_name: "std_msgs/msg/String"
   ign_type_name: "ignition.msgs.StringMsg"
-  subscriber_queue: 5
-  publisher_queue: 6
-  lazy: true
+  subscriber_queue: 5       # Default 10
+  publisher_queue: 6        # Default 10
+  lazy: true                # Default "false"
+  direction: BIDIRECTIONAL  # Default "BIDIRECTIONAL" - Bridge both directions
+                            # "IGN_TO_ROS" - Bridge Ignition topic to ROS
+                            # "ROS_TO_IGN" - Bridge ROS topic to Ignition
 ```
 
 To run the bridge node with the above configuration:


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>

# 🦟 Bug fix

Fixes #269 

## Summary

Add more documentation about the defaults of the yaml-configured bridge as well as include documentation about configuring the bridge direction.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.