### PR TITLE
Make tests faster and more robust

### DIFF
--- a/ros_ign_bridge/test/resource/ign_publisher.cpp.em
+++ b/ros_ign_bridge/test/resource/ign_publisher.cpp.em
@@ -54,19 +54,19 @@ int main(int /*argc*/, char **/*argv*/)
 
 @[for m in mappings]@
   // @(m.ign_string()).
-  auto @(m.unique())_pub = 
+  auto @(m.unique())_pub =
     node.Advertise<@(m.ign_type())>("@(m.unique())");
   @(m.ign_type()) @(m.unique())_msg;
   ros_ign_bridge::testing::createTestMsg(@(m.unique())_msg);
 
 @[end for]@
 
-  // Publish messages at 1Hz.
+  // Publish messages at 100 Hz.
   while (!g_terminatePub) {
 @[for m in mappings]@
     @(m.unique())_pub.Publish(@(m.unique())_msg);
 @[end for]@
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
   return 0;

--- a/ros_ign_bridge/test/resource/ign_subscriber.cpp.em
+++ b/ros_ign_bridge/test/resource/ign_subscriber.cpp.em
@@ -58,7 +58,7 @@ TEST(IgnSubscriberTest, @(m.unique()))
 
   using namespace std::chrono_literals;
   ros_ign_bridge::testing::waitUntilBoolVar(
-    client.callbackExecuted, 100ms, 200);
+    client.callbackExecuted, 10ms, 200);
 
   EXPECT_TRUE(client.callbackExecuted);
 }

--- a/ros_ign_bridge/test/resource/ros_publisher.cpp.em
+++ b/ros_ign_bridge/test/resource/ros_publisher.cpp.em
@@ -21,12 +21,12 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("ros_string_publisher");
-  rclcpp::Rate loop_rate(1);
+  rclcpp::Rate loop_rate(100);
 
 @[for m in mappings]@
   // @(m.ros2_string()).
-  auto @(m.unique())_pub = 
-    node->create_publisher<@(m.ros2_type())>("@(m.unique())", 1000);
+  auto @(m.unique())_pub =
+    node->create_publisher<@(m.ros2_type())>("@(m.unique())", 1);
   @(m.ros2_type()) @(m.unique())_msg;
   ros_ign_bridge::testing::createTestMsg(@(m.unique())_msg);
 

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.cpp
@@ -19,14 +19,15 @@
 
 #include "ros_subscriber.hpp"
 
+static std::shared_ptr<rclcpp::Node> kTestNode;
+
 /////////////////////////////////////////////////
-std::shared_ptr<rclcpp::Node> ros_subscriber::TestNode()
+rclcpp::Node * ros_subscriber::TestNode()
 {
-  static std::shared_ptr<rclcpp::Node> kTestNode;
   if (kTestNode == nullptr) {
     kTestNode = rclcpp::Node::make_shared("ros_subscriber");
   }
-  return kTestNode;
+  return kTestNode.get();
 }
 
 /////////////////////////////////////////////////
@@ -34,5 +35,8 @@ int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+
+  auto ret = RUN_ALL_TESTS();
+  kTestNode.reset();
+  return ret;
 }

--- a/ros_ign_bridge/test/subscribers/ros_subscriber.hpp
+++ b/ros_ign_bridge/test/subscribers/ros_subscriber.hpp
@@ -27,7 +27,7 @@ namespace ros_subscriber
 {
 /////////////////////////////////////////////////
 /// \brief Retrieve a common node used for testing
-std::shared_ptr<rclcpp::Node> TestNode();
+rclcpp::Node * TestNode();
 
 /////////////////////////////////////////////////
 /// \brief A class for testing ROS topic subscription.

--- a/ros_ign_bridge/test/utils/test_utils.hpp
+++ b/ros_ign_bridge/test/utils/test_utils.hpp
@@ -59,16 +59,16 @@ void waitUntilBoolVar(
 ///   waitUntilBoolVar(myVar, 1ms, 10);
 template<class Rep, class Period>
 void waitUntilBoolVarAndSpin(
-  std::shared_ptr<rclcpp::Node> node,
+  rclcpp::Node * node,
   bool & _boolVar,
   const std::chrono::duration<Rep, Period> & _sleepEach,
   const int _retries)
 {
   int i = 0;
-  while (!_boolVar && i < _retries) {
+  while (!_boolVar && i < _retries && rclcpp::ok()) {
     ++i;
     std::this_thread::sleep_for(_sleepEach);
-    rclcpp::spin_some(node);
+    rclcpp::spin_some(node->get_node_base_interface());
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

I noticed that tests on galactic are slower than they have to be.  I boosted the publication speed so that the tests execute faster.

Additionally, the static shared_ptr was holding up shutdown causing the test to timeout or segfault.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
