### PR TITLE
Fix compilation against Garden

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -16,7 +16,7 @@ if [ "$IGNITION_VERSION" == "garden" ]; then
   echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list
   wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
 
-  IGN_DEPS="libignition-gazebo7-dev"
+  IGN_DEPS="libgz-sim7-dev"
 fi
 
 # Fortress comes through rosdep for Focal and Jammy

--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -30,14 +30,18 @@ if("$ENV{IGNITION_VERSION}" STREQUAL "edifice")
   find_package(ignition-msgs7 REQUIRED)
   set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
 
+  set(GZ_TARGET_PREFIX ignition)
+
   message(STATUS "Compiling against Ignition Edifice")
 # Garden
 elseif("$ENV{IGNITION_VERSION}" STREQUAL "garden")
-  find_package(ignition-transport12 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport12_VERSION_MAJOR})
+  find_package(gz-transport12 REQUIRED)
+  set(IGN_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
 
-  find_package(ignition-msgs9 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs9_VERSION_MAJOR})
+  find_package(gz-msgs9 REQUIRED)
+  set(IGN_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
+
+  set(GZ_TARGET_PREFIX gz)
 
   message(STATUS "Compiling against Gazebo Garden")
 # Default to Fortress
@@ -47,6 +51,8 @@ else()
 
   find_package(ignition-msgs8 REQUIRED)
   set(IGN_MSGS_VER ${ignition-msgs8_VERSION_MAJOR})
+
+  set(GZ_TARGET_PREFIX ignition)
 
   message(STATUS "Compiling against Ignition Fortress")
 endif()
@@ -87,8 +93,8 @@ foreach(PKG ${PACKAGES})
   )
   target_link_libraries(${PKG}_bridge
     bridge_utils
-    ignition-msgs${IGN_MSGS_VER}::core
-    ignition-transport${IGN_TRANSPORT_VER}::core
+    ${GZ_TARGET_PREFIX}-msgs${IGN_MSGS_VER}::core
+    ${GZ_TARGET_PREFIX}-transport${IGN_TRANSPORT_VER}::core
     rclcpp::rclcpp
   )
   set_target_properties(${PKG}_bridge
@@ -140,8 +146,8 @@ foreach(bridge ${bridge_executables})
   )
   target_link_libraries(${bridge}
     ${bridge_lib}
-    ignition-msgs${IGN_MSGS_VER}::core
-    ignition-transport${IGN_TRANSPORT_VER}::core
+    ${GZ_TARGET_PREFIX}-msgs${IGN_MSGS_VER}::core
+    ${GZ_TARGET_PREFIX}-transport${IGN_TRANSPORT_VER}::core
   )
   ament_target_dependencies(${bridge}
     "rclcpp"
@@ -170,8 +176,8 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_utils
     ${GTEST_LIBRARIES}
-    ignition-msgs${IGN_MSGS_VER}::core
-    ignition-transport${IGN_TRANSPORT_VER}::core
+    ${GZ_TARGET_PREFIX}-msgs${IGN_MSGS_VER}::core
+    ${GZ_TARGET_PREFIX}-transport${IGN_TRANSPORT_VER}::core
   )
   ament_target_dependencies(test_utils
     builtin_interfaces

--- a/ros_ign_bridge/package.xml
+++ b/ros_ign_bridge/package.xml
@@ -24,8 +24,8 @@
   <depend>trajectory_msgs</depend>
 
   <!-- Garden -->
-  <depend condition="$IGNITION_VERSION == garden">ignition-msgs9</depend>
-  <depend condition="$IGNITION_VERSION == garden">ignition-transport12</depend>
+  <depend condition="$IGNITION_VERSION == garden">gz-msgs9</depend>
+  <depend condition="$IGNITION_VERSION == garden">gz-transport12</depend>
   <!-- Fortress (default) -->
   <depend condition="$IGNITION_VERSION == fortress">ignition-msgs8</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-transport11</depend>

--- a/ros_ign_gazebo/CMakeLists.txt
+++ b/ros_ign_gazebo/CMakeLists.txt
@@ -28,20 +28,24 @@ if("$ENV{IGNITION_VERSION}" STREQUAL "edifice")
   find_package(ignition-gazebo5 REQUIRED)
   set(IGN_GAZEBO_VER ${ignition-gazebo5_VERSION_MAJOR})
 
+  set(GZ_TARGET_PREFIX ignition)
+
   message(STATUS "Compiling against Ignition Edifice")
 # Garden
 elseif("$ENV{IGNITION_VERSION}" STREQUAL "garden")
-  find_package(ignition-math7 REQUIRED)
-  set(IGN_MATH_VER ${ignition-math7_VERSION_MAJOR})
+  find_package(gz-math7 REQUIRED)
+  set(IGN_MATH_VER ${gz-math7_VERSION_MAJOR})
 
-  find_package(ignition-transport12 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport12_VERSION_MAJOR})
+  find_package(gz-transport12 REQUIRED)
+  set(IGN_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
 
-  find_package(ignition-msgs9 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs9_VERSION_MAJOR})
+  find_package(gz-msgs9 REQUIRED)
+  set(IGN_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
 
-  find_package(ignition-gazebo7 REQUIRED)
-  set(IGN_GAZEBO_VER ${ignition-gazebo7_VERSION_MAJOR})
+  find_package(gz-sim7 REQUIRED)
+  set(IGN_GAZEBO_VER ${gz-sim7_VERSION_MAJOR})
+
+  set(GZ_TARGET_PREFIX gz)
 
   message(STATUS "Compiling against Gazebo Garden")
 # Default to Fortress
@@ -58,6 +62,8 @@ else()
   find_package(ignition-gazebo6 REQUIRED)
   set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
 
+  set(GZ_TARGET_PREFIX ignition)
+
   message(STATUS "Compiling against Ignition Fortress")
 endif()
 
@@ -73,9 +79,9 @@ ament_target_dependencies(create
 )
 target_link_libraries(create
   gflags
-  ignition-math${IGN_MATH_VER}::core
-  ignition-msgs${IGN_MSGS_VER}::core
-  ignition-transport${IGN_TRANSPORT_VER}::core
+  ${GZ_TARGET_PREFIX}-math${IGN_MATH_VER}::core
+  ${GZ_TARGET_PREFIX}-msgs${IGN_MSGS_VER}::core
+  ${GZ_TARGET_PREFIX}-transport${IGN_TRANSPORT_VER}::core
 )
 ament_target_dependencies(create std_msgs)
 

--- a/ros_ign_gazebo/package.xml
+++ b/ros_ign_gazebo/package.xml
@@ -18,8 +18,8 @@
   <depend>std_msgs</depend>
 
   <!-- Garden -->
-  <depend condition="$IGNITION_VERSION == garden">ignition-gazebo7</depend>
-  <depend condition="$IGNITION_VERSION == garden">ignition-math7</depend>
+  <depend condition="$IGNITION_VERSION == garden">gz-sim7</depend>
+  <depend condition="$IGNITION_VERSION == garden">gz-math7</depend>
   <!-- Fortress (default) -->
   <depend condition="$IGNITION_VERSION == fortress">ignition-gazebo6</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-math6</depend>

--- a/ros_ign_image/CMakeLists.txt
+++ b/ros_ign_image/CMakeLists.txt
@@ -24,14 +24,18 @@ if("$ENV{IGNITION_VERSION}" STREQUAL "edifice")
   find_package(ignition-msgs7 REQUIRED)
   set(IGN_MSGS_VER ${ignition-msgs7_VERSION_MAJOR})
 
+  set(GZ_TARGET_PREFIX ignition)
+
   message(STATUS "Compiling against Ignition Edifice")
 # Fortress
 elseif("$ENV{IGNITION_VERSION}" STREQUAL "garden")
-  find_package(ignition-transport12 REQUIRED)
-  set(IGN_TRANSPORT_VER ${ignition-transport12_VERSION_MAJOR})
+  find_package(gz-transport12 REQUIRED)
+  set(IGN_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
 
-  find_package(ignition-msgs9 REQUIRED)
-  set(IGN_MSGS_VER ${ignition-msgs9_VERSION_MAJOR})
+  find_package(gz-msgs9 REQUIRED)
+  set(IGN_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
+
+  set(GZ_TARGET_PREFIX gz)
 
   message(STATUS "Compiling against Gazebo Garden")
 # Default to Fortress
@@ -41,6 +45,8 @@ else()
 
   find_package(ignition-msgs8 REQUIRED)
   set(IGN_MSGS_VER ${ignition-msgs8_VERSION_MAJOR})
+
+  set(GZ_TARGET_PREFIX ignition)
 
   message(STATUS "Compiling against Ignition Fortress")
 endif()
@@ -56,8 +62,8 @@ add_executable(${executable}
 )
 
 target_link_libraries(${executable}
-  ignition-msgs${IGN_MSGS_VER}::core
-  ignition-transport${IGN_TRANSPORT_VER}::core
+  ${GZ_TARGET_PREFIX}-msgs${IGN_MSGS_VER}::core
+  ${GZ_TARGET_PREFIX}-transport${IGN_TRANSPORT_VER}::core
 )
 
 ament_target_dependencies(${executable}
@@ -91,8 +97,8 @@ if(BUILD_TESTING)
   #   )
   #   target_link_libraries(${test_publisher}_image
   #     ${catkin_LIBRARIES}
-  #     ignition-msgs${IGN_MSGS_VER}::core
-  #     ignition-transport${IGN_TRANSPORT_VER}::core
+  #     ${GZ_TARGET_PREFIX}-msgs${IGN_MSGS_VER}::core
+  #     ${GZ_TARGET_PREFIX}-transport${IGN_TRANSPORT_VER}::core
   #     gtest
   #     gtest_main
   #   )
@@ -104,8 +110,8 @@ if(BUILD_TESTING)
   #     test/subscribers/${test_subscriber}.cpp)
   #   target_link_libraries(test_${test_subscriber}_image
   #     ${catkin_LIBRARIES}
-  #     ignition-msgs${IGN_MSGS_VER}::core
-  #     ignition-transport${IGN_TRANSPORT_VER}::core
+  #     ${GZ_TARGET_PREFIX}-msgs${IGN_MSGS_VER}::core
+  #     ${GZ_TARGET_PREFIX}-transport${IGN_TRANSPORT_VER}::core
   #   )
   # endforeach(test_subscriber)
 endif()

--- a/ros_ign_image/package.xml
+++ b/ros_ign_image/package.xml
@@ -14,8 +14,8 @@
   <depend>sensor_msgs</depend>
 
   <!-- Garden -->
-  <depend condition="$IGNITION_VERSION == garden">ignition-msgs9</depend>
-  <depend condition="$IGNITION_VERSION == garden">ignition-transport12</depend>
+  <depend condition="$IGNITION_VERSION == garden">gz-msgs9</depend>
+  <depend condition="$IGNITION_VERSION == garden">gz-transport12</depend>
   <!-- Fortress (default) -->
   <depend condition="$IGNITION_VERSION == fortress">ignition-msgs8</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-transport11</depend>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

There have been some breaking changes upstream because of the rename from `ignition` to `gz` which need to be accounted for here.

This PR keeps compatibility with Edifice and Fortress.

This PR has the bare minimum to fix compilation, but I haven't addressed any of the warnings. That's on purpose, because we'll backport some `gz` changes to Citadel and Fortress and it will be easier to suppress warnings then.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
