### PR TITLE
Fix catkin dependencies for demos

### DIFF
--- a/ros_ign_gazebo_demos/package.xml
+++ b/ros_ign_gazebo_demos/package.xml
@@ -23,6 +23,7 @@
   <!--exec_depend>ros_ign_point_cloud</exec_depend-->
   <exec_depend>rqt_image_view</exec_depend>
   <exec_depend>rqt_plot</exec_depend>
+  <exec_depend>rqt_topic</exec_depend>
   <exec_depend>rviz</exec_depend>
 
   <replace>ros1_ign_gazebo_demos</replace>


### PR DESCRIPTION
Add missing dependency on rqt_topic for ros_ign_gazebo_demos to package.xml.
# 🦟 Bug fix

Fixes: #276

## Summary
Added missing packages to package.xml for demos package.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers