### PR TITLE
Skip process name from bridge topic argument

### DIFF
--- a/ros_ign_image/src/image_bridge.cpp
+++ b/ros_ign_image/src/image_bridge.cpp
@@ -84,6 +84,9 @@ int main(int argc, char * argv[])
 
   std::vector<std::shared_ptr<Handler>> handlers;
 
+  // skip the process name in argument procesing
+  ++argv;
+  --argc;
   auto args = rclcpp::remove_ros_arguments(argc, argv);
 
   // Create publishers and subscribers


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Fixed an issue where the name of the topic to be bridged in `image_bridge` could contain the name of the process to be executed.

This problem occurred when using the ignition gazebo fortress with ros2 galactic.

I tried to bridge `/camera/image` with `image_bridge`.
Then the executable file appeared in the `ros2 topic list` as shown below.

```
$ ros2 topic list
/camera/image_raw
/camera/image_raw/compressed
/camera/image_raw/compressedDepth
/camera/image_raw/theora
<path to workspace>/install/lib/ros_ign_image/image_bridge
<path to workspace>/install/lib/ros_ign_image/image_bridge/compressed
<path to workspace>/install/lib/ros_ign_image/image_bridge/compressedDepth
<path to workspace>/install/lib/ros_ign_image/image_bridge/theora
```

So I added argument processing to `image_bridge` similar to `parameter_bridge` in `ros_ign_bridge` package.

https://github.com/gazebosim/ros_gz/blob/d94e7c7731b22bb5e0e2532312a881e0b49181cc/ros_ign_bridge/src/parameter_bridge.cpp#L86-L88

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
