### PR TITLE
Fixed ign launch

### DIFF
--- a/ros_ign_gazebo/launch/ign_gazebo.launch.py.in
+++ b/ros_ign_gazebo/launch/ign_gazebo.launch.py.in
@@ -31,7 +31,7 @@ def generate_launch_description():
         DeclareLaunchArgument('ign_args', default_value='',
                               description='Arguments to be passed to Ignition Gazebo'),
         # Ignition Gazebo's major version
-        DeclareLaunchArgument('ign_version', default_value='@IGN_GAZEBO_VER@',
+        DeclareLaunchArgument('ign_version', default_value='@GZ_SIM_VER@',
                               description='Ignition Gazebo\'s major version'),
         ExecuteProcess(
             cmd=['ign gazebo',


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

During the `ign` to `gz` migration https://github.com/gazebosim/ros_gz/pull/280 this variable was not migrated

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
