### PR TITLE
Add missing GZ_VERSION ticktocks

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(trajectory_msgs REQUIRED)
 # TODO(CH3): Deprecated. Remove on tock.
 if("$ENV{GZ_VERSION}" STREQUAL "" AND NOT "$ENV{IGNITION_VERSION}" STREQUAL "")
   message(DEPRECATION "Environment variable [IGNITION_VERSION] is deprecated. Use [GZ_VERSION] instead.")
-  set(ENV{GZ_VERSION} ENV{IGNITION_VERSION})
+  set(ENV{GZ_VERSION} $ENV{IGNITION_VERSION})
 endif()
 
 # Edifice

--- a/ros_gz_image/CMakeLists.txt
+++ b/ros_gz_image/CMakeLists.txt
@@ -16,11 +16,10 @@ find_package(ros_gz_bridge REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-
 # TODO(CH3): Deprecated. Remove on tock.
 if("$ENV{GZ_VERSION}" STREQUAL "" AND NOT "$ENV{IGNITION_VERSION}" STREQUAL "")
   message(DEPRECATION "Environment variable [IGNITION_VERSION] is deprecated. Use [GZ_VERSION] instead.")
-  set(ENV{GZ_VERSION} ENV{IGNITION_VERSION})
+  set(ENV{GZ_VERSION} $ENV{IGNITION_VERSION})
 endif()
 
 # Edifice

--- a/ros_gz_shims/ros_ign_gazebo/CMakeLists.txt
+++ b/ros_gz_shims/ros_ign_gazebo/CMakeLists.txt
@@ -22,6 +22,12 @@ ament_export_dependencies(
   ros_gz_bridge
 )
 
+# TODO(CH3): Deprecated. Remove on tock.
+if("$ENV{GZ_VERSION}" STREQUAL "" AND NOT "$ENV{IGNITION_VERSION}" STREQUAL "")
+  message(DEPRECATION "Environment variable [IGNITION_VERSION] is deprecated. Use [GZ_VERSION] instead.")
+  set(ENV{GZ_VERSION} $ENV{IGNITION_VERSION})
+endif()
+
 # Edifice
 if("$ENV{GZ_VERSION}" STREQUAL "edifice")
   find_package(ignition-gazebo5 REQUIRED)


### PR DESCRIPTION
# 🦟 Bug fix

Setting IGNITION_VERSION as an environment variable only is supposed to trigger a deprecation warning and a redirection to the GZ_VERSION env var.

This happens as expected for `ros_gz_sim`, but not the other packages, either due to a missing `$`, or missing redirection blocks to begin with. I originally though they weren't needed because the top level CMakeLists was supposed to set the env var, but actually it only sets it for the specific process building the top level package, oops... This PR fixes that.