### PR TITLE
Fix missing msgs include and packages.xml deps

### DIFF
--- a/ros_gz/package.xml
+++ b/ros_gz/package.xml
@@ -12,8 +12,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>ros_gz_bridge</exec_depend>
-  <exec_depend>ros_gz_gazebo</exec_depend>
-  <exec_depend>ros_gz_gazebo_demos</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <exec_depend>ros_gz_sim_demos</exec_depend>
   <exec_depend>ros_gz_image</exec_depend>
   <!-- See https://github.com/gazebosim/ros_gz/issues/40 -->
   <!--exec_depend>ros_gz_point_cloud</exec_depend-->

--- a/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
@@ -22,6 +22,8 @@
 #include "service_factory.hpp"
 #include "ros_gz_bridge/convert/ros_gz_interfaces.hpp"
 
+#include <ignition/msgs/boolean.pb.h>
+
 
 namespace ros_gz_bridge
 {

--- a/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
@@ -14,6 +14,8 @@
 
 #include "factories/ros_gz_interfaces.hpp"
 
+#include <ignition/msgs/boolean.pb.h>
+
 #include <memory>
 #include <string>
 
@@ -21,8 +23,6 @@
 
 #include "service_factory.hpp"
 #include "ros_gz_bridge/convert/ros_gz_interfaces.hpp"
-
-#include <ignition/msgs/boolean.pb.h>
 
 
 namespace ros_gz_bridge

--- a/ros_gz_shims/ros_ign_gazebo/launch/ign_gazebo.launch.py.in
+++ b/ros_gz_shims/ros_ign_gazebo/launch/ign_gazebo.launch.py.in
@@ -19,8 +19,8 @@ from os import environ
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import ExecuteProcess
-from launch.substitutions import LaunchConfiguration
-from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
+from launch.substitutions import LaunchConfiguration, AndSubstitution, PythonExpression
+from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals, IfCondition
 
 
 def generate_launch_description():
@@ -64,7 +64,12 @@ def generate_launch_description():
         ),
 
         ExecuteProcess(
-            condition=LaunchConfigurationEquals('ign_version', ''),
+            condition=IfCondition(
+                AndSubstitution(
+                    PythonExpression(["'", LaunchConfiguration('ign_version'), "' == ''"]),
+                    PythonExpression(["'", LaunchConfiguration('gz_version'), "' < '7'"])
+                )
+            ),
             cmd=['ign gazebo',
                  LaunchConfiguration('gz_args'),
                  '--force-version',
@@ -74,4 +79,22 @@ def generate_launch_description():
             additional_env=env,
             shell=True
         ),
+
+        ExecuteProcess(
+            condition=IfCondition(
+                AndSubstitution(
+                    PythonExpression(["'", LaunchConfiguration('ign_version'), "' == ''"]),
+                    PythonExpression(["'", LaunchConfiguration('gz_version'), "' >= '7'"])
+                )
+            ),
+            cmd=['gz sim',
+                 LaunchConfiguration('gz_args'),
+                 '--force-version',
+                 LaunchConfiguration('gz_version'),
+                 ],
+            output='screen',
+            additional_env=env,
+            shell=True
+        ),
+
     ])

--- a/ros_gz_sim/launch/gz_sim.launch.py.in
+++ b/ros_gz_sim/launch/gz_sim.launch.py.in
@@ -19,8 +19,8 @@ from os import environ
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import ExecuteProcess
-from launch.substitutions import LaunchConfiguration
-from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
+from launch.substitutions import LaunchConfiguration, AndSubstitution, PythonExpression
+from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals, IfCondition
 
 
 def generate_launch_description():
@@ -64,7 +64,12 @@ def generate_launch_description():
         ),
 
         ExecuteProcess(
-            condition=LaunchConfigurationEquals('ign_version', ''),
+            condition=IfCondition(
+                AndSubstitution(
+                    PythonExpression(["'", LaunchConfiguration('ign_version'), "' == ''"]),
+                    PythonExpression(["'", LaunchConfiguration('gz_version'), "' < '7'"])
+                )
+            ),
             cmd=['ign gazebo',
                  LaunchConfiguration('gz_args'),
                  '--force-version',
@@ -74,4 +79,22 @@ def generate_launch_description():
             additional_env=env,
             shell=True
         ),
+
+        ExecuteProcess(
+            condition=IfCondition(
+                AndSubstitution(
+                    PythonExpression(["'", LaunchConfiguration('ign_version'), "' == ''"]),
+                    PythonExpression(["'", LaunchConfiguration('gz_version'), "' >= '7'"])
+                )
+            ),
+            cmd=['gz sim',
+                 LaunchConfiguration('gz_args'),
+                 '--force-version',
+                 LaunchConfiguration('gz_version'),
+                 ],
+            output='screen',
+            additional_env=env,
+            shell=True
+        ),
+
     ])


### PR DESCRIPTION
https://github.com/gazebosim/gz-transport/pull/315 broke `ros_gz_bridge/src/factories/service_factories/ros_gz_interfaces.cpp` because it was relying on an indirect transitive include of `gz-msgs` that was removed in that PR.

To the best of my knowledge, this issue only really surfaces when building with `GZ_VERSION=garden`, since that PR only applies from Garden onwards.

This PR fixes that, as well as typos in the metapackage package.xml.

... and also adds additional conditions to shunt launch calls to `gz sim` as appropriate.