### PR TITLE
Fix gazebo lidar sensor output to ROS topic

### DIFF
--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -377,20 +377,20 @@ convert_gz_to_ros(
   auto vertical_count = gz_msg.vertical_count();
 
   // If there are multiple vertical beams, use the one in the middle.
-  size_t start = (vertical_count / 2) * count;
+  //size_t start = (vertical_count / 2) * count;
 
   // Copy ranges into ROS message.
-  ros_msg.ranges.resize(count);
+  ros_msg.ranges.resize(count*vertical_count);
   std::copy(
-    gz_msg.ranges().begin() + start,
-    gz_msg.ranges().begin() + start + count,
+    gz_msg.ranges().begin(),
+    gz_msg.ranges().end(),
     ros_msg.ranges.begin());
 
   // Copy intensities into ROS message.
-  ros_msg.intensities.resize(count);
+  ros_msg.intensities.resize(count*vertical_count);
   std::copy(
-    gz_msg.intensities().begin() + start,
-    gz_msg.intensities().begin() + start + count,
+    gz_msg.intensities().begin(),
+    gz_msg.intensities().end(),
     ros_msg.intensities.begin());
 }
 

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -376,9 +376,6 @@ convert_gz_to_ros(
   auto count = gz_msg.count();
   auto vertical_count = gz_msg.vertical_count();
 
-  // If there are multiple vertical beams, use the one in the middle.
-  //size_t start = (vertical_count / 2) * count;
-
   // Copy ranges into ROS message.
   ros_msg.ranges.resize(count*vertical_count);
   std::copy(

--- a/ros_gz_sim_demos/launch/lidar_test.launch.py
+++ b/ros_gz_sim_demos/launch/lidar_test.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2022 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,15 +36,6 @@ def generate_launch_description():
         launch_arguments={'gz_args': '-v4 -r lidar_test.sdf' }.items(),
     )
 
-    # RViz
-    rviz = Node(
-       package='rviz2',
-       executable='rviz2',
-       # FIXME: Generate new RViz config once this demo is usable again
-       # arguments=['-d', os.path.join(pkg_ros_gz_sim_demos, 'rviz', 'gpu_lidar.rviz')],
-       condition=IfCondition(LaunchConfiguration('rviz'))
-    )
-
     # Bridge
     bridge = Node(
         package='ros_gz_bridge',
@@ -53,7 +44,6 @@ def generate_launch_description():
         output='screen'
     )
 
-    # FIXME: need a SDF file (gpu_lidar.sdf) inside ros_gz_point_cloud/
     return LaunchDescription([
         gz_sim,
         bridge,

--- a/ros_gz_sim_demos/launch/lidar_test.launch.py
+++ b/ros_gz_sim_demos/launch/lidar_test.launch.py
@@ -1,0 +1,60 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+
+    pkg_ros_gz_sim = get_package_share_directory('ros_gz_sim')
+
+    gz_sim = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_ros_gz_sim, 'launch', 'gz_sim.launch.py')),
+        launch_arguments={'gz_args': '-v4 -r lidar_test.sdf' }.items(),
+    )
+
+    # RViz
+    rviz = Node(
+       package='rviz2',
+       executable='rviz2',
+       # FIXME: Generate new RViz config once this demo is usable again
+       # arguments=['-d', os.path.join(pkg_ros_gz_sim_demos, 'rviz', 'gpu_lidar.rviz')],
+       condition=IfCondition(LaunchConfiguration('rviz'))
+    )
+
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/lidar@sensor_msgs/msg/LaserScan[gz.msgs.LaserScan'],
+        output='screen'
+    )
+
+    # FIXME: need a SDF file (gpu_lidar.sdf) inside ros_gz_point_cloud/
+    return LaunchDescription([
+        gz_sim,
+        bridge,
+    ])

--- a/ros_gz_sim_demos/models/block_detect/model.config
+++ b/ros_gz_sim_demos/models/block_detect/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>block</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Connor Taylor</name>
+    <email>connor.taylor@dal.ca</email>
+  </author>
+
+  <description>
+    A floating box.
+  </description>
+
+</model>

--- a/ros_gz_sim_demos/models/block_detect/model.sdf
+++ b/ros_gz_sim_demos/models/block_detect/model.sdf
@@ -1,0 +1,36 @@
+<?xml version='1.0'?>
+<sdf version='1.6'>
+  <model name='block_detect'>
+    <static>true</static>
+    <link name="base_link">
+      <visual name="base_visual">
+        <geometry>
+          <box>
+            <size>2 2 8</size>
+          </box>
+        </geometry>
+      </visual>
+
+      <collision name="base_collision">
+        <geometry>
+          <box>
+            <size>2 5 8</size>
+          </box>
+        </geometry>
+      </collision>
+      
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>400</mass>
+        <inertia>
+          <ixx>266</ixx>
+          <ixy>0</ixy>
+          <iyy>266</iyy>
+          <iyz>0</iyz>
+          <izz>266</izz>
+        </inertia>
+      </inertial>
+    </link>
+   
+  </model>
+</sdf>

--- a/ros_gz_sim_demos/models/lidar_block/model.config
+++ b/ros_gz_sim_demos/models/lidar_block/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>block</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Connor Taylor</name>
+    <email>connor.taylor@dal.ca</email>
+  </author>
+
+  <description>
+    A floating box.
+  </description>
+
+</model>

--- a/ros_gz_sim_demos/models/lidar_block/model.sdf
+++ b/ros_gz_sim_demos/models/lidar_block/model.sdf
@@ -1,0 +1,83 @@
+<?xml version='1.0'?>
+<sdf version='1.6'>
+  <model name='lidar_block'>
+    <static>true</static>
+    <link name="base_link">
+      <visual name="base_visual">
+        <geometry>
+          <box>
+            <size>0.5 0.5 0.5</size>
+          </box>
+        </geometry>
+      </visual>
+
+      <collision name="base_collision">
+        <geometry>
+          <box>
+            <size>0.5 0.5 0.5</size>
+          </box>
+        </geometry>
+      </collision>
+      
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>400</mass>
+        <inertia>
+          <ixx>266</ixx>
+          <ixy>0</ixy>
+          <iyy>266</iyy>
+          <iyz>0</iyz>
+          <izz>266</izz>
+        </inertia>
+      </inertial>
+    </link>
+   	<link name="lidar_link">
+    	<inertial>
+      	<pose>0 0 0 0 0 0</pose>
+      	<mass>0.05</mass>
+      	<inertia>
+          <ixx>0.0133</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.0133</iyy>
+          <iyz>0</iyz>
+          <izz>0.0133</izz>
+      	</inertia>
+    	</inertial>  
+    	<sensor name='gpu_lidar' type='gpu_lidar'>
+    		<pose>0.25 0.25 0.25 0 0 0</pose>
+    		<topic>lidar</topic>
+      	<update_rate>10</update_rate>
+      	<lidar>
+      		<scan>
+        		<horizontal>
+        	  	<samples>10</samples>
+        	    <resolution>1</resolution>
+        	    <min_angle>-0.396263</min_angle>
+        	    <max_angle>0.396263</max_angle>
+        	  </horizontal>
+        	  <vertical>
+        	  	<samples>10</samples>
+        	    <resolution>1</resolution>
+        	    <min_angle>-0.261799</min_angle>
+        	    <max_angle>0.261799</max_angle>
+        	  </vertical>
+       		</scan>
+        	<range>
+        		<min>0.08</min>
+          	<max>10.0</max>
+          	<resolution>0.01</resolution>
+        	</range>
+      	</lidar>
+      	<always_on>1</always_on>
+      	<visualize>true</visualize>
+  		</sensor>
+  	</link>
+  	<joint name="lidar_joint" type="fixed">
+    	<parent>base_link</parent>
+    	<child>lidar_link</child>
+    	<pose>0 0 0 0 0 0</pose>
+    	<axis>1 0 0</axis>
+  	</joint>
+  </model>
+</sdf>

--- a/ros_gz_sim_demos/worlds/lidar_test.sdf
+++ b/ros_gz_sim_demos/worlds/lidar_test.sdf
@@ -1,21 +1,7 @@
 <?xml version="1.0" ?>
-<!--
-  Gazebo Sim sdformat_urdf parser plugin demo
-
-  Try sending commands:
-
-    gz topic -t "/model/vehicle/cmd_vel" -m gz.msgs.Twist -p "linear: {x: 1.0}, angular: {z: -0.1}"
-    ros2 topic pub /model/vehicle/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 5.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -0.1}}"
-
-  Listen to odometry:
-
-    gz topic -e -t /model/vehicle/odometry
-    ros2 topic echo /model/vehicle/odometry
-
--->
 <sdf version="1.8">
   <world name="demo">
-		<plugin filename="gz-sim-physics-system"
+    <plugin filename="gz-sim-physics-system"
             name="gz::sim::systems::Physics">
     </plugin>
     <plugin filename="gz-sim-sensors-system"
@@ -190,12 +176,12 @@
     </model>
 
     <include>
-			<pose>0 0 1.5 0 0 0</pose>
-			<uri>model://lidar_block</uri>
-		</include>
-		<include>
-			<pose>5 0 0 0 0 0</pose>
-			<uri>model://block_detect</uri>
-		</include>
+      <pose>0 0 1.5 0 0 0</pose>
+      <uri>model://lidar_block</uri>
+    </include>
+    <include>
+      <pose>5 0 0 0 0 0</pose>
+      <uri>model://block_detect</uri>
+    </include>
   </world>
 </sdf>

--- a/ros_gz_sim_demos/worlds/lidar_test.sdf
+++ b/ros_gz_sim_demos/worlds/lidar_test.sdf
@@ -1,0 +1,201 @@
+<?xml version="1.0" ?>
+<!--
+  Gazebo Sim sdformat_urdf parser plugin demo
+
+  Try sending commands:
+
+    gz topic -t "/model/vehicle/cmd_vel" -m gz.msgs.Twist -p "linear: {x: 1.0}, angular: {z: -0.1}"
+    ros2 topic pub /model/vehicle/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 5.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -0.1}}"
+
+  Listen to odometry:
+
+    gz topic -e -t /model/vehicle/odometry
+    ros2 topic echo /model/vehicle/odometry
+
+-->
+<sdf version="1.8">
+  <world name="demo">
+		<plugin filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+      <background_color>0.8 0.8 0.8</background_color>
+    </plugin>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+            name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin filename="gz-sim-user-commands-system"
+            name="gz::sim::systems::UserCommands">
+    </plugin>
+    
+    <gui fullscreen="0">
+
+      <!-- 3D scene -->
+      <plugin filename="MinimalScene" name="3D View">
+        <gz-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>0.4 0.4 0.4</ambient_light>
+        <background_color>0.8 0.8 0.8</background_color>
+        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
+      </plugin>
+
+      <!-- Plugins that add functionality to the scene -->
+      <plugin filename="EntityContextMenuPlugin" name="Entity context menu">
+        <gz-gui>
+          <property key="state" type="string">floating</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+      <plugin filename="GzSceneManager" name="Scene Manager">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+      <plugin filename="InteractiveViewControl" name="Interactive view control">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+      <plugin filename="CameraTracking" name="Camera Tracking">
+        <gz-gui>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+      <!-- World control -->
+      <plugin filename="WorldControl" name="World control">
+        <gz-gui>
+          <title>World control</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="width">121</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </gz-gui>
+
+        <play_pause>true</play_pause>
+        <step>true</step>
+        <start_paused>true</start_paused>
+        <use_event>true</use_event>
+
+      </plugin>
+
+      <!-- World statistics -->
+      <plugin filename="WorldStats" name="World stats">
+        <gz-gui>
+          <title>World stats</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">110</property>
+          <property type="double" key="width">290</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </gz-gui>
+
+        <sim_time>true</sim_time>
+        <real_time>true</real_time>
+        <real_time_factor>true</real_time_factor>
+        <iterations>true</iterations>
+      </plugin>
+
+      <plugin filename="VisualizeLidar" name="Visualize Lidar">
+      </plugin>
+
+      <!-- Inspector -->
+      <plugin filename="ComponentInspector" name="Component inspector">
+        <gz-gui>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+      </plugin>
+
+      <!-- Entity tree -->
+      <plugin filename="EntityTree" name="Entity tree">
+        <gz-gui>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+      </plugin>
+    </gui>
+    
+    <light name="sun" type="directional">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <include>
+			<pose>0 0 1.5 0 0 0</pose>
+			<uri>model://lidar_block</uri>
+		</include>
+		<include>
+			<pose>5 0 0 0 0 0</pose>
+			<uri>model://block_detect</uri>
+		</include>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #325

## Summary
I noticed that the GPU LIDAR sensor would only pass one horizontal line of ranges and intensities from Gazebo to ROS instead of all of the ranges defined by horizontal*vertical counts. So, I changed this in the source code to allow all of these ranges to be passed. 
To replicate before: Simply put a GPU lidar sensor into the environment and try to use the bridge in the launch file to pass the gazebo messages to ROS2. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
