### PR TITLE
enapsulate space with quotes for shim packages

### DIFF
--- a/ros_ign_bridge/src/parameter_bridge_shim.cpp
+++ b/ros_ign_bridge/src/parameter_bridge_shim.cpp
@@ -30,8 +30,15 @@ int main(int argc, char * argv[])
 
   if (argc > 1)
   {
-    for (int i = 1; i < argc; i++)
-      cli_call << " " << argv[i];
+    for (int i = 1; i < argc; i++){
+      // If argv[i] contains a space, encapsulate it with double quotes
+      if (std::string{argv[i]}.find(" ") == std::string::npos)
+      {
+        cli_call << " " << argv[i];
+      } else {
+        cli_call << " \"" << argv[i] << "\"";
+      }
+    }
   }
 
   std::cerr << "[ros_ign_bridge] is deprecated! "

--- a/ros_ign_bridge/src/static_bridge_shim.cpp
+++ b/ros_ign_bridge/src/static_bridge_shim.cpp
@@ -30,8 +30,15 @@ int main(int argc, char * argv[])
 
   if (argc > 1)
   {
-    for (int i = 1; i < argc; i++)
-      cli_call << " " << argv[i];
+    for (int i = 1; i < argc; i++){
+      // If argv[i] contains a space, encapsulate it with double quotes
+      if (std::string{argv[i]}.find(" ") == std::string::npos)
+      {
+        cli_call << " " << argv[i];
+      } else {
+        cli_call << " \"" << argv[i] << "\"";
+      }
+    }
   }
 
   std::cerr << "[ros_ign_bridge] is deprecated! "

--- a/ros_ign_gazebo/src/create_shim.cpp
+++ b/ros_ign_gazebo/src/create_shim.cpp
@@ -30,8 +30,15 @@ int main(int argc, char * argv[])
 
   if (argc > 1)
   {
-    for (int i = 1; i < argc; i++)
-      cli_call << " " << argv[i];
+    for (int i = 1; i < argc; i++){
+      // If argv[i] contains a space, encapsulate it with double quotes
+      if (std::string{argv[i]}.find(" ") == std::string::npos)
+      {
+        cli_call << " " << argv[i];
+      } else {
+        cli_call << " \"" << argv[i] << "\"";
+      }
+    }
   }
 
   std::cerr << "[ros_ign_gazebo] is deprecated! "

--- a/ros_ign_image/src/image_bridge_shim.cpp
+++ b/ros_ign_image/src/image_bridge_shim.cpp
@@ -30,8 +30,15 @@ int main(int argc, char * argv[])
 
   if (argc > 1)
   {
-    for (int i = 1; i < argc; i++)
-      cli_call << " " << argv[i];
+    for (int i = 1; i < argc; i++){
+      // If argv[i] contains a space, encapsulate it with double quotes
+      if (std::string{argv[i]}.find(" ") == std::string::npos)
+      {
+        cli_call << " " << argv[i];
+      } else {
+        cli_call << " \"" << argv[i] << "\"";
+      }
+    }
   }
 
   std::cerr << "[ros_ign_bridge] is deprecated! "


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Calling shim executables with arguments that contain white spaces encapsulated in double quotes fails on ROS 2 Humble.

To reproduce, create a xacro file ``test.xacro`` with contents:

```xml
<!-- test.xacro -->
<?xml version="1.0" ?>
<robot name="test"/>
```

and run ``create_shim.cpp`` with an argument that evaluates to have a space within double quotes:

```sh
ros2 run ros_ign_gazebo create -string "$(xacro test.xacro)"
```

The expected behaviour is that the command works, but it results in the following error:

```sh
sh: 2: Syntax error: newline unexpected
```

When running this with the new ``create.cpp`` from ros_gz_sim:

```sh
ros2 run ros_gz_sim create -string "$(xacro test.xacro)"
```
works fine.

With the changes in this PR, arguments that contain spaces will be encapsulated by double quotes upon the system call.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
