### PR TITLE
[foxy] Backport: Add std_msgs as dependency of ros_ign_gazebo (#264)

### DIFF
--- a/ros_ign_gazebo/CMakeLists.txt
+++ b/ros_ign_gazebo/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ignition-math6 REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
 
 # Edifice
 if("$ENV{IGNITION_VERSION}" STREQUAL "edifice")
@@ -48,6 +49,7 @@ add_executable(create src/create.cpp)
 ament_target_dependencies(create
   rclcpp
   ignition-math6
+  std_msgs
 )
 target_link_libraries(create
   gflags

--- a/ros_ign_gazebo/package.xml
+++ b/ros_ign_gazebo/package.xml
@@ -16,6 +16,7 @@
   <depend>libgflags-dev</depend>
   <depend>rclcpp</depend>
   <depend>ignition-math6</depend>
+  <depend>std_msgs</depend>
 
   <!-- Edifice -->
   <depend condition="$IGNITION_VERSION == edifice">ignition-gazebo5</depend>


### PR DESCRIPTION
# 🦟 Bug fix

Backport: Add std_msgs as dependency of ros_ign_gazebo (#264)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
