### PR TITLE
Fix typo in ROS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rolling | Edifice | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only
 Rolling | Fortress | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | https://packages.ros.org
 Rolling | Garden | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source
 
-For information on ROS 2 and Gazebo compatibility, refer to the [melodic branch README](https://github.com/gazebosim/ros_gz/tree/melodic)
+For information on ROS(1) and Gazebo compatibility, refer to the [melodic branch README](https://github.com/gazebosim/ros_gz/tree/melodic)
 
 > Please [ticket an issue](https://github.com/gazebosim/ros_gz/issues/) if you'd like support to be added for some combination.
 


### PR DESCRIPTION
The sentence is referring to Melodic but mentions ROS 2. I think it should be ROS.