### PR TITLE
Add QoS profile parameter to image bridge

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ros.distro": "humble"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "ros.distro": "humble"
-}

--- a/ros_gz_image/README.md
+++ b/ros_gz_image/README.md
@@ -9,3 +9,14 @@ For compressed images, install
 and the bridge will publish `/compressed` images. The same goes for other
 `image_transport` plugins.
 
+To run the bridge from the command line:
+
+```shell
+ros2 run ros_gz_image image_bridge /topic1 /topic2
+```
+
+You can also modify the [Quality of Service (QoS) policy](https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html#qos-policies) used to publish images using an additional `qos` ROS parameter. For example:
+
+```shell
+ros2 run ros_gz_image image_bridge /topic1 /topic2 --ros-args qos:=sensor_data
+```

--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -22,22 +22,39 @@
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <ros_gz_bridge/convert.hpp>
+#include <rmw/qos_profiles.h>
 
 //////////////////////////////////////////////////
-/// \brief Bridges one topic
+/// \brief Bridges one image topic
 class Handler
 {
 public:
   /// \brief Constructor
   /// \param[in] _topic Image base topic
-  /// \param[in] _it_node Pointer to image transport node
+  /// \param[in] _node Pointer to ROS node
   /// \param[in] _gz_node Pointer to Gazebo node
   Handler(
     const std::string & _topic,
-    std::shared_ptr<image_transport::ImageTransport> _it_node,
+    std::shared_ptr<rclcpp::Node> _node,
     std::shared_ptr<gz::transport::Node> _gz_node)
   {
-    this->ros_pub = _it_node->advertise(_topic, 1);
+    // Get QoS profile from parameter
+    rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+    const auto qos_str =
+      _node->get_parameter("qos").get_parameter_value().get<std::string>();
+    if (qos_str == "system_default") {
+      qos_profile = rmw_qos_profile_system_default;
+    } else if (qos_str == "sensor_data") {
+      qos_profile = rmw_qos_profile_sensor_data;
+    } else if (qos_str != "default") {
+      RCLCPP_ERROR(_node->get_logger(),
+        "Invalid QoS profile %s specified. Using default profile.",
+        qos_str.c_str());
+    }
+
+    // Create publishers and subscribers
+    this->ros_pub = image_transport::create_publisher(
+      _node.get(), _topic, qos_profile);
 
     _gz_node->Subscribe(_topic, &Handler::OnImage, this);
   }
@@ -77,7 +94,7 @@ int main(int argc, char * argv[])
 
   // ROS node
   auto node_ = rclcpp::Node::make_shared("ros_gz_image");
-  auto it_node = std::make_shared<image_transport::ImageTransport>(node_);
+  node_->declare_parameter("qos", "default");
 
   // Gazebo node
   auto gz_node = std::make_shared<gz::transport::Node>();
@@ -91,7 +108,7 @@ int main(int argc, char * argv[])
 
   // Create publishers and subscribers
   for (auto topic : args) {
-    handlers.push_back(std::make_shared<Handler>(topic, it_node, gz_node));
+    handlers.push_back(std::make_shared<Handler>(topic, node_, gz_node));
   }
 
   // Spin ROS and Gz until shutdown

--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -18,11 +18,11 @@
 #include <string>
 #include <vector>
 
+#include <rmw/qos_profiles.h>
 #include <gz/transport/Node.hh>
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <ros_gz_bridge/convert.hpp>
-#include <rmw/qos_profiles.h>
 
 //////////////////////////////////////////////////
 /// \brief Bridges one image topic
@@ -47,7 +47,8 @@ public:
     } else if (qos_str == "sensor_data") {
       qos_profile = rmw_qos_profile_sensor_data;
     } else if (qos_str != "default") {
-      RCLCPP_ERROR(_node->get_logger(),
+      RCLCPP_ERROR(
+        _node->get_logger(),
         "Invalid QoS profile %s specified. Using default profile.",
         qos_str.c_str());
     }

--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gz/transport/Node.hh>
+#include <rmw/qos_profiles.h>
 
 #include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include <rmw/qos_profiles.h>
-#include <gz/transport/Node.hh>
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <ros_gz_bridge/convert.hpp>


### PR DESCRIPTION
🎉 New feature

Closes #336

## Summary
This PR modifies the `image_bridge` node in the `ros_gz_image` package to optionally specify a different (non-default) [QoS profile](https://github.com/ros2/rmw/blob/rolling/rmw/include/rmw/qos_profiles.h). This was motivated by the fact that we (and presumably many others) want to use the "sensor data" QoS profile.

This exposes a new string parameter in the node named `qos` which defaults to `default`. This should be the same behavior as the original implementation of `image_bridge.cpp`.

## Summary

## Test it
To test this, you can run an image bridge:

```bash
ros2 run ros_gz_image image_bridge /topic1 /topic2
ros2 run ros_gz_image image_bridge /topic1 /topic2 --ros-args qos:=sensor_data
```

or in e.g. a Python launch file:

```python
bridge_node = Node(
        package="ros_gz_image",
        executable="image_bridge",
        name="my_bridge",
        arguments=["/topic1", "/topic2"],
        parameters=[{"qos": "sensor_data"}],
    )
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.