### PR TITLE
Make the bridge aware of both gz and ignition msgs

### DIFF
--- a/ros_gz_bridge/resource/get_mappings.cpp.em
+++ b/ros_gz_bridge/resource/get_mappings.cpp.em
@@ -32,7 +32,7 @@ get_gz_to_ros_mapping(const std::string & gz_type_name, std::string & ros_type_n
 @[end if]@
 
 @[for m in mappings]@
-  if (gz_type_name == "@(m.gz_string())")
+  if (gz_type_name == "@(m.gz_string())" || gz_type_name == "@(m.ign_string())")
   {
     ros_type_name = "@(m.ros2_string())";
     return true;
@@ -68,7 +68,11 @@ get_all_message_mappings_ros_to_gz()
 @[for m in mappings]@
     {
       "@(m.ros2_string())",  // ROS 2
-      "@(m.gz_string())", // Gazebo 
+      "@(m.gz_string())", // Gazebo
+    },
+    {
+      "@(m.ros2_string())",  // ROS 2
+      "@(m.ign_string())", // Gazebo
     },
 @[end for]@
   };

--- a/ros_gz_bridge/resource/pkg_factories.cpp.em
+++ b/ros_gz_bridge/resource/pkg_factories.cpp.em
@@ -39,7 +39,7 @@ get_factory__@(ros2_package_name)(
     return std::make_shared<
       Factory<
         @(m.ros2_type()),
-        @(m.gz_type())
+        @(m.ign_type())
       >
     >("@(m.ros2_string())", "@(m.gz_string())");
   }
@@ -52,10 +52,10 @@ template<>
 void
 Factory<
   @(m.ros2_type()),
-  @(m.gz_type())
+  @(m.ign_type())
 >::convert_ros_to_gz(
   const @(m.ros2_type()) & ros_msg,
-  @(m.gz_type()) & gz_msg)
+  @(m.ign_type()) & gz_msg)
 {
   ros_gz_bridge::convert_ros_to_gz(ros_msg, gz_msg);
 }
@@ -64,9 +64,9 @@ template<>
 void
 Factory<
   @(m.ros2_type()),
-  @(m.gz_type())
+  @(m.ign_type())
 >::convert_gz_to_ros(
-  const @(m.gz_type()) & gz_msg,
+  const @(m.ign_type()) & gz_msg,
   @(m.ros2_type()) & ros_msg)
 {
   ros_gz_bridge::convert_gz_to_ros(gz_msg, ros_msg);

--- a/ros_gz_bridge/resource/pkg_factories.cpp.em
+++ b/ros_gz_bridge/resource/pkg_factories.cpp.em
@@ -34,7 +34,7 @@ get_factory__@(ros2_package_name)(
 {
 @[for m in mappings]@
   if ((ros_type_name == "@(m.ros2_string())" || ros_type_name.empty()) &&
-    gz_type_name == "@(m.gz_string())")
+      (gz_type_name == "@(m.gz_string())" || gz_type_name == "@(m.ign_string())"))
   {
     return std::make_shared<
       Factory<

--- a/ros_gz_bridge/resource/pkg_factories.hpp.em
+++ b/ros_gz_bridge/resource/pkg_factories.hpp.em
@@ -29,7 +29,7 @@ namespace ros_gz_bridge
 
 std::shared_ptr<FactoryInterface>
 get_factory__@(ros2_package_name)(
-  const std::string & ros_type_name, 
+  const std::string & ros_type_name,
   const std::string & gz_type_name);
 
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/ros_gz_bridge/__init__.py
+++ b/ros_gz_bridge/ros_gz_bridge/__init__.py
@@ -36,13 +36,21 @@ class MessageMapping:
         # Return ROS2 type of a message (eg std_msgs::msg::Bool)
         return f'{self.ros2_package_name}::msg::{self.ros2_message_name}'
 
-    def gz_string(self):
+    def ign_string(self):
         # Return GZ string version of a message (eg ignition.msgs.Bool)
         return f'ignition.msgs.{self.gz_message_name}'
 
-    def gz_type(self):
+    def ign_type(self):
         # Return GZ type of a message (eg ignition::msgs::Bool)
         return f'ignition::msgs::{self.gz_message_name}'
+
+    def gz_string(self):
+        # Return GZ string version of a message (eg ignition.msgs.Bool)
+        return f'gz.msgs.{self.gz_message_name}'
+
+    def gz_type(self):
+        # Return GZ type of a message (eg ignition::msgs::Bool)
+        return f'gz::msgs::{self.gz_message_name}'
 
     def unique(self):
         return f'{self.gz_message_name.lower()}_{self.ros2_message_name.lower()}'

--- a/ros_gz_bridge/test/resource/gz_publisher.cpp.em
+++ b/ros_gz_bridge/test/resource/gz_publisher.cpp.em
@@ -55,8 +55,8 @@ int main(int /*argc*/, char **/*argv*/)
 @[for m in mappings]@
   // @(m.gz_string()).
   auto @(m.unique())_pub =
-    node.Advertise<@(m.gz_type())>("@(m.unique())");
-  @(m.gz_type()) @(m.unique())_msg;
+    node.Advertise<@(m.ign_type())>("@(m.unique())");
+  @(m.ign_type()) @(m.unique())_msg;
   ros_gz_bridge::testing::createTestMsg(@(m.unique())_msg);
 
 @[end for]@

--- a/ros_gz_bridge/test/resource/gz_subscriber.cpp.em
+++ b/ros_gz_bridge/test/resource/gz_subscriber.cpp.em
@@ -54,7 +54,7 @@ private: ignition::transport::Node node;
 /////////////////////////////////////////////////
 TEST(GzSubscriberTest, @(m.unique()))
 {
-  MyTestClass<@(m.gz_type())> client("@(m.unique())");
+  MyTestClass<@(m.ign_type())> client("@(m.unique())");
 
   using namespace std::chrono_literals;
   ros_gz_bridge::testing::waitUntilBoolVar(


### PR DESCRIPTION
This makes the bridge aware of gazebo message definition strings either starting with gz or starting with ignition.  This will maximize the compatibility on humble-supported systems.

Note that these changes do not need to be ported to the `ros2` branch, where on `gz` messages are supported.

Fixes #339.

Signed-off-by: Michael Carroll <michael@openrobotics.org>