### PR TITLE
Bringing the Joy to gazebo.

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -44,6 +44,7 @@ The following message types can be bridged for topics:
 | sensor_msgs/Image                  | gz.msgs.Image                      |
 | sensor_msgs/Imu                    | gz.msgs.IMU                        |
 | sensor_msgs/JointState             | gz.msgs.Model                      |
+| sensor_msgs/Joy                    | gz.msgs.Joy                        |
 | sensor_msgs/LaserScan              | gz.msgs.LaserScan                  |
 | sensor_msgs/MagneticField          | gz.msgs.Magnetometer               |
 | sensor_msgs/NavSatFix              | gz.msgs.NavSat                     |

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/sensor_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/sensor_msgs.hpp
@@ -21,6 +21,7 @@
 #include <gz/msgs/fluid_pressure.pb.h>
 #include <gz/msgs/image.pb.h>
 #include <gz/msgs/imu.pb.h>
+#include <gz/msgs/joy.pb.h>
 #include <gz/msgs/laserscan.pb.h>
 #include <gz/msgs/magnetometer.pb.h>
 #include <gz/msgs/model.pb.h>
@@ -34,6 +35,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
+#include <sensor_msgs/msg/joy.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
@@ -45,6 +47,18 @@ namespace ros_gz_bridge
 {
 
 // sensor_msgs
+template<>
+void
+convert_ros_to_gz(
+  const sensor_msgs::msg::Joy & ros_msg,
+  gz::msgs::Joy & gz_msg);
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Joy & gz_msg,
+  sensor_msgs::msg::Joy & ros_msg);
+
 template<>
 void
 convert_ros_to_gz(

--- a/ros_gz_bridge/ros_gz_bridge/mappings.py
+++ b/ros_gz_bridge/ros_gz_bridge/mappings.py
@@ -76,6 +76,7 @@ MAPPINGS = {
         Mapping('Image', 'Image'),
         Mapping('Imu', 'IMU'),
         Mapping('JointState', 'Model'),
+        Mapping('Joy', 'Joy'),
         Mapping('LaserScan', 'LaserScan'),
         Mapping('MagneticField', 'Magnetometer'),
         Mapping('NavSatFix', 'NavSat'),

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -326,6 +326,40 @@ convert_gz_to_ros(
 template<>
 void
 convert_ros_to_gz(
+  const sensor_msgs::msg::Joy & ros_msg,
+  gz::msgs::Joy & gz_msg)
+{
+  convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
+
+  for (auto i = 0u; i < ros_msg.axes.size(); ++i) {
+    gz_msg.add_axes(ros_msg.axes[i]);
+  }
+
+  for (auto i = 0u; i < ros_msg.buttons.size(); ++i) {
+    gz_msg.add_buttons(ros_msg.buttons[i]);
+  }
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Joy & gz_msg,
+  sensor_msgs::msg::Joy & ros_msg)
+{
+  convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+
+  for (auto i = 0; i < gz_msg.axes_size(); ++i) {
+    ros_msg.axes.push_back(gz_msg.axes(i));
+  }
+
+  for (auto i = 0; i < gz_msg.buttons_size(); ++i) {
+    ros_msg.buttons.push_back(gz_msg.buttons(i));
+  }
+}
+
+template<>
+void
+convert_ros_to_gz(
   const sensor_msgs::msg::LaserScan & ros_msg,
   gz::msgs::LaserScan & gz_msg)
 {

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -814,6 +814,35 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::Model> & _msg)
   }
 }
 
+void createTestMsg(gz::msgs::Joy & _msg)
+{
+  gz::msgs::Header header_msg;
+
+  createTestMsg(header_msg);
+  _msg.mutable_header()->CopyFrom(header_msg);
+
+  for (int i = 0u; i < 3; ++i) {
+    _msg.add_axes(0.5);
+    _msg.add_buttons(0);
+  }
+}
+
+void compareTestMsg(const std::shared_ptr<gz::msgs::Joy> & _msg)
+{
+  gz::msgs::Joy expected_msg;
+  createTestMsg(expected_msg);
+
+  compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
+
+  for (int i = 0; i < expected_msg.axes_size(); ++i) {
+    EXPECT_FLOAT_EQ(expected_msg.axes(i), _msg->axes(i));
+  }
+
+  for (int i = 0; i < expected_msg.buttons_size(); ++i) {
+    EXPECT_EQ(expected_msg.buttons(i), _msg->buttons(i));
+  }
+}
+
 void createTestMsg(gz::msgs::LaserScan & _msg)
 {
   gz::msgs::Header header_msg;

--- a/ros_gz_bridge/test/utils/gz_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.hpp
@@ -38,6 +38,7 @@
 #include <gz/msgs/int32.pb.h>
 #include <gz/msgs/joint_trajectory.pb.h>
 #include <gz/msgs/joint_wrench.pb.h>
+#include <gz/msgs/joy.pb.h>
 #include <gz/msgs/laserscan.pb.h>
 #include <gz/msgs/light.pb.h>
 #include <gz/msgs/magnetometer.pb.h>
@@ -253,6 +254,14 @@ void createTestMsg(gz::msgs::JointWrench & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<gz::msgs::JointWrench> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(gz::msgs::Joy & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<gz::msgs::Joy> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -990,6 +990,32 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::JointState> & _msg)
   }
 }
 
+void createTestMsg(sensor_msgs::msg::Joy & _msg)
+{
+  std_msgs::msg::Header header_msg;
+  createTestMsg(header_msg);
+
+  _msg.header = header_msg;
+  _msg.axes = {0.5, 0.5, 0.5};
+  _msg.buttons = {0, 0, 0};
+}
+
+void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Joy> & _msg)
+{
+  sensor_msgs::msg::Joy expected_msg;
+  createTestMsg(expected_msg);
+
+  compareTestMsg(_msg->header);
+
+  for (auto i = 0u; i < _msg->axes.size(); ++i) {
+    EXPECT_FLOAT_EQ(expected_msg.buttons[i], _msg->buttons[i]);
+  }
+
+  for (auto i = 0u; i < _msg->buttons.size(); ++i) {
+    EXPECT_EQ(expected_msg.buttons[i], _msg->buttons[i]);
+  }
+}
+
 void createTestMsg(sensor_msgs::msg::LaserScan & _msg)
 {
   const unsigned int num_readings = 100u;

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -62,6 +62,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
+#include <sensor_msgs/msg/joy.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
@@ -465,6 +466,14 @@ void createTestMsg(sensor_msgs::msg::JointState & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::JointState> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(sensor_msgs::msg::Joy & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Joy> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.


### PR DESCRIPTION
# 🎉 New feature

Closes: #351 

## Summary
Adds Joy message to pass through the ros2<->gz bridge.

You too can have Joy again using Gazebo.

## Test it
Tested with a Logitech Gamepad F310 and FlySky FS i6X plugged in and running: 

``` bash
ros2 run joy joy_node
```
![Untitled](https://user-images.githubusercontent.com/10233412/211699363-0b9303bf-0fa2-41e0-9e56-53dba279dea0.png)

```bash
ros2 run ros_gz_bridge parameter_bridge /joy@sensor_msgs/msg/Joy@gz.msgs.Joy
```
![Untitled2](https://user-images.githubusercontent.com/10233412/211699571-0e8945b7-73c5-471b-b44c-d37850353d0f.png)

``` bash
gz topic -e -t /joy
```
![Untitled3](https://user-images.githubusercontent.com/10233412/211699818-fc49a0e2-8ff9-49df-94e1-11e0b4513efa.png)



## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
