### PR TITLE
Set on_exit_shutdown argument for gz-sim ExecuteProcess

### DIFF
--- a/ros_gz_sim/launch/gz_sim.launch.py.in
+++ b/ros_gz_sim/launch/gz_sim.launch.py.in
@@ -18,7 +18,7 @@ from os import environ
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.actions import ExecuteProcess
+from launch.actions import ExecuteProcess, Shutdown
 from launch.substitutions import LaunchConfiguration
 
 def launch_gz(context, *args, **kwargs):
@@ -34,6 +34,7 @@ def launch_gz(context, *args, **kwargs):
     ign_args = LaunchConfiguration('ign_args').perform(context)
     ign_version = LaunchConfiguration('ign_version').perform(context)
     debugger = LaunchConfiguration('debugger').perform(context)
+    on_exit_shutdown = LaunchConfiguration('on_exit_shutdown').perform(context)
 
     if not len(gz_args) and len(ign_args):
         print("ign_args is deprecated, migrate to gz_args!")
@@ -54,12 +55,18 @@ def launch_gz(context, *args, **kwargs):
     else:
         debug_prefix = None
 
+    if on_exit_shutdown:
+        on_exit = Shutdown()
+    else:
+        on_exit = None
+
     return [ExecuteProcess(
             cmd=[exec, exec_args, '--force-version', gz_version],
             output='screen',
             additional_env=env,
             shell=True,
-            prefix=debug_prefix
+            prefix=debug_prefix,
+            on_exit=on_exit
         )]
 
 
@@ -84,5 +91,8 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'debugger', default_value='false',
             description='Run in Debugger'),
+        DeclareLaunchArgument(
+            'on_exit_shutdown', default_value='false',
+            description='Shutdown on gz-sim exit'),
         OpaqueFunction(function = launch_gz),
     ])


### PR DESCRIPTION
Signed-off-by: Michael Anderson <anderson@mbari.org>


# 🎉 New feature

## Summary
Add launch argument to set gz-sim to be a required node: if argument `on_exit_shutdown` is `True`, set `on_exit=Shutdown()`

## Test it
Make a launch file that includes gz_sim.launch.py as well as some other node. set `gz_args` to use `--iterations 5000` and set `on_exit_shutdown` to `True`. When gz-sim exits, everything should quit.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.