### PR TITLE
Improve error messages around config loading

### DIFF
--- a/ros_gz_bridge/test/bridge_config.cpp
+++ b/ros_gz_bridge/test/bridge_config.cpp
@@ -16,7 +16,59 @@
 
 #include <ros_gz_bridge/bridge_config.hpp>
 
-TEST(BridgeConfig, Minimum)
+#include "rcutils/logging.h"
+
+size_t g_log_calls = 0;
+
+struct LogEvent
+{
+  const rcutils_log_location_t * location;
+  int level;
+  std::string name;
+  rcutils_time_point_value_t timestamp;
+  std::string message;
+};
+LogEvent g_last_log_event;
+
+class BridgeConfig : public ::testing::Test
+{
+public:
+  rcutils_logging_output_handler_t previous_output_handler;
+  void SetUp()
+  {
+    g_log_calls = 0;
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+    rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_DEBUG);
+
+    auto rcutils_logging_console_output_handler = [](
+      const rcutils_log_location_t * location,
+      int level, const char * name, rcutils_time_point_value_t timestamp,
+      const char * format, va_list * args) -> void
+      {
+        g_log_calls += 1;
+        g_last_log_event.location = location;
+        g_last_log_event.level = level;
+        g_last_log_event.name = name ? name : "";
+        g_last_log_event.timestamp = timestamp;
+        char buffer[1024];
+        vsnprintf(buffer, sizeof(buffer), format, *args);
+        g_last_log_event.message = buffer;
+      };
+
+    this->previous_output_handler = rcutils_logging_get_output_handler();
+    rcutils_logging_set_output_handler(rcutils_logging_console_output_handler);
+  }
+
+  void TearDown()
+  {
+    rcutils_logging_set_output_handler(this->previous_output_handler);
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+    EXPECT_FALSE(g_rcutils_logging_initialized);
+  }
+};
+
+
+TEST_F(BridgeConfig, Minimum)
 {
   auto results = ros_gz_bridge::readFromYamlFile("test/config/minimum.yaml");
   EXPECT_EQ(4u, results.size());
@@ -63,7 +115,7 @@ TEST(BridgeConfig, Minimum)
   }
 }
 
-TEST(BridgeConfig, FullGz)
+TEST_F(BridgeConfig, FullGz)
 {
   auto results = ros_gz_bridge::readFromYamlFile("test/config/full.yaml");
   EXPECT_EQ(2u, results.size());
@@ -93,7 +145,7 @@ TEST(BridgeConfig, FullGz)
   }
 }
 
-TEST(BridgeConfig, InvalidSetTwoRos)
+TEST_F(BridgeConfig, InvalidSetTwoRos)
 {
   // Cannot set topic_name and ros_topic_name
   auto yaml = R"(
@@ -102,9 +154,12 @@ TEST(BridgeConfig, InvalidSetTwoRos)
 
   auto results = ros_gz_bridge::readFromYamlString(yaml);
   EXPECT_EQ(0u, results.size());
+  EXPECT_EQ(
+    "Could not parse entry: topic_name and ros_topic_name are mutually exclusive",
+    g_last_log_event.message);
 }
 
-TEST(BridgeConfig, InvalidSetTwoGz)
+TEST_F(BridgeConfig, InvalidSetTwoGz)
 {
   // Cannot set topic_name and gz_topic_name
   auto yaml = R"(
@@ -113,9 +168,12 @@ TEST(BridgeConfig, InvalidSetTwoGz)
 
   auto results = ros_gz_bridge::readFromYamlString(yaml);
   EXPECT_EQ(0u, results.size());
+  EXPECT_EQ(
+    "Could not parse entry: topic_name and gz_topic_name are mutually exclusive",
+    g_last_log_event.message);
 }
 
-TEST(BridgeConfig, InvalidSetTypes)
+TEST_F(BridgeConfig, InvalidSetTypes)
 {
   // Both ros_type_name and gz_type_name must be set
   auto yaml = R"(
@@ -124,9 +182,12 @@ TEST(BridgeConfig, InvalidSetTypes)
 
   auto results = ros_gz_bridge::readFromYamlString(yaml);
   EXPECT_EQ(0u, results.size());
+  EXPECT_EQ(
+    "Could not parse entry: both ros_type_name and gz_type_name must be set",
+    g_last_log_event.message);
 }
 
-TEST(BridgeConfig, ParseDirection)
+TEST_F(BridgeConfig, ParseDirection)
 {
   {
     // Check that default is bidirectional
@@ -186,10 +247,38 @@ TEST(BridgeConfig, ParseDirection)
   - topic_name: foo
     ros_type_name: std_msgs/msg/String
     gz_type_name: ignition.msgs.StringMsg
-    direction: asdfasdfasdfasdf
+    direction: foobar
     )";
 
     auto results = ros_gz_bridge::readFromYamlString(yaml);
     EXPECT_EQ(0u, results.size());
+    EXPECT_EQ("Could not parse entry: invalid direction [foobar]", g_last_log_event.message);
   }
+}
+
+TEST_F(BridgeConfig, InvalidFileDoesntExist)
+{
+  auto results = ros_gz_bridge::readFromYamlFile("this/should/never/be/a/file.yaml");
+  EXPECT_EQ(0u, results.size());
+  EXPECT_EQ(
+    "Could not parse config: failed to open file [this/should/never/be/a/file.yaml]",
+    g_last_log_event.message);
+}
+
+TEST_F(BridgeConfig, InvalidTopLevel)
+{
+  auto results = ros_gz_bridge::readFromYamlFile("test/config/invalid.yaml");
+  EXPECT_EQ(0u, results.size());
+  EXPECT_EQ(
+    "Could not parse config: top level must be a YAML sequence",
+    g_last_log_event.message);
+}
+
+TEST_F(BridgeConfig, EmptyYAML)
+{
+  auto results = ros_gz_bridge::readFromYamlFile("test/config/empty.yaml");
+  EXPECT_EQ(0u, results.size());
+  EXPECT_EQ(
+    "Could not parse config: file empty [test/config/empty.yaml]",
+    g_last_log_event.message);
 }

--- a/ros_gz_bridge/test/config/invalid.yaml
+++ b/ros_gz_bridge/test/config/invalid.yaml
@@ -1,0 +1,8 @@
+ros_topic_name: "ros_chatter"
+gz_topic_name: "gz_chatter"
+ros_type_name: "std_msgs/msg/String"
+gz_type_name: "ignition.msgs.StringMsg"
+subscriber_queue: 5
+publisher_queue: 6
+lazy: true
+direction: ROS_TO_GZ


### PR DESCRIPTION
# 🦟 Bug fix

Partially addresses #354 

## Summary

This improves the error messages when attempting to load a non-existent or empty yaml file.
It differentiates those errors from the "YAML Sequence" error that was typically presented.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
