### PR TITLE
Update noetic README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,10 @@
 
 ROS version | Ignition version | Branch | Binaries hosted at
 -- | -- | -- | --
-Melodic | Citadel | [melodic](https://github.com/osrf/ros_ign/tree/melodic) | only from source
-Melodic | Fortress | [melodic](https://github.com/osrf/ros_ign/tree/melodic) | only from source
 Noetic | Citadel | [noetic](https://github.com/osrf/ros_ign/tree/noetic) | https://packages.ros.org
 Noetic | Edifice | [noetic](https://github.com/osrf/ros_ign/tree/noetic) | only from source
-Noetic | Fortress (not released) | [noetic](https://github.com/osrf/ros_ign/tree/noetic) | only from source
-Foxy | Citadel | [foxy](https://github.com/osrf/ros_ign/tree/foxy) | https://packages.ros.org
-Foxy | Edifice | [foxy](https://github.com/osrf/ros_ign/tree/foxy) | only from source
-Galactic | Edifice | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | https://packages.ros.org
-Rolling | Edifice | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | https://packages.ros.org
-Rolling | Fortress (not released) | [ros2](https://github.com/osrf/ros_ign/tree/ros2) | only from source
+Noetic | Fortress | [noetic](https://github.com/osrf/ros_ign/tree/noetic) | only from source
+ROS2 distributions | [Check ros2 branch in this repository](https://github.com/gazebosim/ros_gz/blob/ros2/README.md) |
 
 > Please [ticket an issue](https://github.com/ignitionrobotics/ros_ign/issues/) if you'd like support to be added for some combination.
 


### PR DESCRIPTION
* Update Fortress to be supported in Noetic
* Remove ROS 2 distributions in favor of a link to the ros2 branch of the README