### PR TITLE
fix warning message

### DIFF
--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -110,8 +110,8 @@ void RosGzBridge::add_bridge(const BridgeConfig & config)
       "Failed to create a bridge for topic [%s] with ROS2 type [%s] "
       "to topic [%s] with Gazebo Transport type [%s]",
       config.ros_topic_name.c_str(),
-      config.gz_topic_name.c_str(),
       config.ros_type_name.c_str(),
+      config.gz_topic_name.c_str(),
       config.gz_type_name.c_str());
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The warning message had the ros_type and gz_type swapped out, which woud throw warnings that looked like this:

```
Failed to create a bridge for topic [ros_topic_name] with ROS2 type [gz_topic_name] to topic [sensor_msgs.msg.Imu] with Gazebo Transport type [gz.msgs.IMU]
```
The line in the code were swapped out. This PR just fixes that

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
