### PR TITLE
populate imu covariances when converting

### DIFF
--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -274,6 +274,16 @@ convert_ros_to_gz(
   convert_ros_to_gz(ros_msg.orientation, (*gz_msg.mutable_orientation()));
   convert_ros_to_gz(ros_msg.angular_velocity, (*gz_msg.mutable_angular_velocity()));
   convert_ros_to_gz(ros_msg.linear_acceleration, (*gz_msg.mutable_linear_acceleration()));
+
+  for (const auto & elem : ros_msg.linear_acceleration_covariance){
+    gz_msg.mutable_linear_acceleration_covariance()->add_data(elem);
+  }
+  for (const auto & elem : ros_msg.orientation_covariance){
+    gz_msg.mutable_orientation_covariance()->add_data(elem);
+  }
+  for (const auto & elem : ros_msg.angular_velocity_covariance){
+    gz_msg.mutable_angular_velocity_covariance()->add_data(elem);
+  }
 }
 
 template<>
@@ -288,6 +298,30 @@ convert_gz_to_ros(
   convert_gz_to_ros(gz_msg.linear_acceleration(), ros_msg.linear_acceleration);
 
   // Covariances not supported in gz::msgs::IMU
+  int data_size = gz_msg.linear_acceleration_covariance().data_size();
+  if (data_size == 9)
+  {
+    for (int i = 0; i < data_size; ++i) {
+      auto data = gz_msg.linear_acceleration_covariance().data()[i];
+      ros_msg.linear_acceleration_covariance[i] = data;
+    }
+  }
+  data_size = gz_msg.angular_velocity_covariance().data_size();
+  if (data_size == 9)
+  {
+    for (int i = 0; i < data_size; ++i) {
+      auto data = gz_msg.angular_velocity_covariance().data()[i];
+      ros_msg.angular_velocity_covariance[i] = data;
+    }
+  }
+  data_size = gz_msg.orientation_covariance().data_size();
+  if (data_size == 9)
+  {
+    for (int i = 0; i < data_size; ++i) {
+      auto data = gz_msg.orientation_covariance().data()[i];
+      ros_msg.orientation_covariance[i] = data;
+    }
+  }
 }
 
 template<>

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -282,13 +282,13 @@ convert_ros_to_gz(
   convert_ros_to_gz(ros_msg.linear_acceleration, (*gz_msg.mutable_linear_acceleration()));
 
 #ifdef GZ_MSGS_IMU_HAS_COVARIANCE
-  for (const auto & elem : ros_msg.linear_acceleration_covariance){
+  for (const auto & elem : ros_msg.linear_acceleration_covariance) {
     gz_msg.mutable_linear_acceleration_covariance()->add_data(elem);
   }
-  for (const auto & elem : ros_msg.orientation_covariance){
+  for (const auto & elem : ros_msg.orientation_covariance) {
     gz_msg.mutable_orientation_covariance()->add_data(elem);
   }
-  for (const auto & elem : ros_msg.angular_velocity_covariance){
+  for (const auto & elem : ros_msg.angular_velocity_covariance) {
     gz_msg.mutable_angular_velocity_covariance()->add_data(elem);
   }
 #endif
@@ -307,24 +307,21 @@ convert_gz_to_ros(
 
 #ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   int data_size = gz_msg.linear_acceleration_covariance().data_size();
-  if (data_size == 9)
-  {
+  if (data_size == 9) {
     for (int i = 0; i < data_size; ++i) {
       auto data = gz_msg.linear_acceleration_covariance().data()[i];
       ros_msg.linear_acceleration_covariance[i] = data;
     }
   }
   data_size = gz_msg.angular_velocity_covariance().data_size();
-  if (data_size == 9)
-  {
+  if (data_size == 9) {
     for (int i = 0; i < data_size; ++i) {
       auto data = gz_msg.angular_velocity_covariance().data()[i];
       ros_msg.angular_velocity_covariance[i] = data;
     }
   }
   data_size = gz_msg.orientation_covariance().data_size();
-  if (data_size == 9)
-  {
+  if (data_size == 9) {
     for (int i = 0; i < data_size; ++i) {
       auto data = gz_msg.orientation_covariance().data()[i];
       ros_msg.orientation_covariance[i] = data;

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -17,6 +17,12 @@
 #include "convert/utils.hpp"
 #include "ros_gz_bridge/convert/sensor_msgs.hpp"
 
+#include "gz/msgs/config.hh"
+
+#if GZ_MSGS_MAJOR_VERSION >= 10
+#define GZ_MSGS_IMU_HAS_COVARIANCE
+#endif
+
 namespace ros_gz_bridge
 {
 
@@ -275,6 +281,7 @@ convert_ros_to_gz(
   convert_ros_to_gz(ros_msg.angular_velocity, (*gz_msg.mutable_angular_velocity()));
   convert_ros_to_gz(ros_msg.linear_acceleration, (*gz_msg.mutable_linear_acceleration()));
 
+#ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   for (const auto & elem : ros_msg.linear_acceleration_covariance){
     gz_msg.mutable_linear_acceleration_covariance()->add_data(elem);
   }
@@ -284,6 +291,7 @@ convert_ros_to_gz(
   for (const auto & elem : ros_msg.angular_velocity_covariance){
     gz_msg.mutable_angular_velocity_covariance()->add_data(elem);
   }
+#endif
 }
 
 template<>
@@ -297,7 +305,7 @@ convert_gz_to_ros(
   convert_gz_to_ros(gz_msg.angular_velocity(), ros_msg.angular_velocity);
   convert_gz_to_ros(gz_msg.linear_acceleration(), ros_msg.linear_acceleration);
 
-  // Covariances not supported in gz::msgs::IMU
+#ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   int data_size = gz_msg.linear_acceleration_covariance().data_size();
   if (data_size == 9)
   {
@@ -322,6 +330,7 @@ convert_gz_to_ros(
       ros_msg.orientation_covariance[i] = data;
     }
   }
+#endif
 }
 
 template<>

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -757,6 +757,11 @@ void createTestMsg(gz::msgs::IMU & _msg)
   _msg.mutable_orientation()->CopyFrom(quaternion_msg);
   _msg.mutable_angular_velocity()->CopyFrom(vector3_msg);
   _msg.mutable_linear_acceleration()->CopyFrom(vector3_msg);
+  for (int i = 0; i < 9; i++) {
+    _msg.mutable_orientation_covariance()->add_data(i);
+    _msg.mutable_angular_velocity_covariance()->add_data(i);
+    _msg.mutable_linear_acceleration_covariance()->add_data(i);
+  }
 }
 
 void compareTestMsg(const std::shared_ptr<gz::msgs::IMU> & _msg)
@@ -765,6 +770,11 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::IMU> & _msg)
   compareTestMsg(std::make_shared<gz::msgs::Quaternion>(_msg->orientation()));
   compareTestMsg(std::make_shared<gz::msgs::Vector3d>(_msg->angular_velocity()));
   compareTestMsg(std::make_shared<gz::msgs::Vector3d>(_msg->linear_acceleration()));
+  for (int i = 0; i < 9; i++) {
+    EXPECT_EQ(_msg->orientation_covariance().data(i), i);
+    EXPECT_EQ(_msg->angular_velocity_covariance().data(i), i);
+    EXPECT_EQ(_msg->linear_acceleration_covariance().data(i), i);
+  }
 }
 
 void createTestMsg(gz::msgs::Axis & _msg)

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -19,6 +19,10 @@
 #include <memory>
 #include <string>
 
+#if GZ_MSGS_MAJOR_VERSION >= 10
+#define GZ_MSGS_IMU_HAS_COVARIANCE
+#endif
+
 namespace ros_gz_bridge
 {
 namespace testing
@@ -807,11 +811,13 @@ void createTestMsg(gz::msgs::IMU & _msg)
   _msg.mutable_orientation()->CopyFrom(quaternion_msg);
   _msg.mutable_angular_velocity()->CopyFrom(vector3_msg);
   _msg.mutable_linear_acceleration()->CopyFrom(vector3_msg);
+#ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   for (int i = 0; i < 9; i++) {
     _msg.mutable_orientation_covariance()->add_data(i);
     _msg.mutable_angular_velocity_covariance()->add_data(i);
     _msg.mutable_linear_acceleration_covariance()->add_data(i);
   }
+#endif
 }
 
 void compareTestMsg(const std::shared_ptr<gz::msgs::IMU> & _msg)
@@ -820,11 +826,13 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::IMU> & _msg)
   compareTestMsg(std::make_shared<gz::msgs::Quaternion>(_msg->orientation()));
   compareTestMsg(std::make_shared<gz::msgs::Vector3d>(_msg->angular_velocity()));
   compareTestMsg(std::make_shared<gz::msgs::Vector3d>(_msg->linear_acceleration()));
+#ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   for (int i = 0; i < 9; i++) {
     EXPECT_EQ(_msg->orientation_covariance().data(i), i);
     EXPECT_EQ(_msg->angular_velocity_covariance().data(i), i);
     EXPECT_EQ(_msg->linear_acceleration_covariance().data(i), i);
   }
+#endif
 }
 
 void createTestMsg(gz::msgs::Axis & _msg)

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -828,9 +828,9 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::IMU> & _msg)
   compareTestMsg(std::make_shared<gz::msgs::Vector3d>(_msg->linear_acceleration()));
 #ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   for (int i = 0; i < 9; i++) {
-    EXPECT_EQ(_msg->orientation_covariance().data(i), i);
-    EXPECT_EQ(_msg->angular_velocity_covariance().data(i), i);
-    EXPECT_EQ(_msg->linear_acceleration_covariance().data(i), i);
+    EXPECT_EQ(_msg->orientation_covariance().data(i), i + 1);
+    EXPECT_EQ(_msg->angular_velocity_covariance().data(i), i + 1);
+    EXPECT_EQ(_msg->linear_acceleration_covariance().data(i), i + 1);
   }
 #endif
 }

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -813,9 +813,9 @@ void createTestMsg(gz::msgs::IMU & _msg)
   _msg.mutable_linear_acceleration()->CopyFrom(vector3_msg);
 #ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   for (int i = 0; i < 9; i++) {
-    _msg.mutable_orientation_covariance()->add_data(i);
-    _msg.mutable_angular_velocity_covariance()->add_data(i);
-    _msg.mutable_linear_acceleration_covariance()->add_data(i);
+    _msg.mutable_orientation_covariance()->add_data(i + 1);
+    _msg.mutable_angular_velocity_covariance()->add_data(i + 1);
+    _msg.mutable_linear_acceleration_covariance()->add_data(i + 1);
   }
 #endif
 }

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -948,6 +948,9 @@ void createTestMsg(sensor_msgs::msg::Imu & _msg)
   _msg.orientation = quaternion_msg;
   _msg.angular_velocity = vector3_msg;
   _msg.linear_acceleration = vector3_msg;
+  _msg.orientation_covariance = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  _msg.angular_velocity_covariance = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  _msg.linear_acceleration_covariance = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 }
 
 void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Imu> & _msg)
@@ -956,6 +959,12 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Imu> & _msg)
   compareTestMsg(_msg->orientation);
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->angular_velocity));
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->linear_acceleration));
+
+  for (int i = 1; i < 10; ++i){
+    EXPECT_EQ(_msg->orientation_covariance[i], i);
+    EXPECT_EQ(_msg->angular_velocity_covariance[i], i);
+    EXPECT_EQ(_msg->linear_acceleration_covariance[i], i);
+  }
 }
 
 void createTestMsg(sensor_msgs::msg::JointState & _msg)

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -1085,7 +1085,7 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Imu> & _msg)
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->linear_acceleration));
 
 #ifdef GZ_MSGS_IMU_HAS_COVARIANCE
-  for (int i = 0; i < 9; ++i){
+  for (int i = 0; i < 9; ++i) {
     EXPECT_EQ(_msg->orientation_covariance[i], i + 1);
     EXPECT_EQ(_msg->angular_velocity_covariance[i], i + 1);
     EXPECT_EQ(_msg->linear_acceleration_covariance[i], i + 1);

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -473,7 +473,7 @@ void compareTestMsg(const std::shared_ptr<gps_msgs::msg::GPSFix> & _msg)
   EXPECT_EQ(expected_msg.position_covariance_type, _msg->position_covariance_type);
 
   for (auto i = 0u; i < 9; ++i) {
-    EXPECT_FLOAT_EQ(0, _msg->position_covariance[i]);
+    EXPECT_FLOAT_EQ(i + 1, _msg->position_covariance[i]);
   }
 }
 
@@ -960,10 +960,10 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Imu> & _msg)
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->angular_velocity));
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->linear_acceleration));
 
-  for (int i = 1; i < 10; ++i){
-    EXPECT_EQ(_msg->orientation_covariance[i], i);
-    EXPECT_EQ(_msg->angular_velocity_covariance[i], i);
-    EXPECT_EQ(_msg->linear_acceleration_covariance[i], i);
+  for (int i = 0; i < 9; ++i){
+    EXPECT_EQ(_msg->orientation_covariance[i], i + 1);
+    EXPECT_EQ(_msg->angular_velocity_covariance[i], i + 1);
+    EXPECT_EQ(_msg->linear_acceleration_covariance[i], i + 1);
   }
 }
 
@@ -1109,7 +1109,7 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::NavSatFix> & _msg)
   EXPECT_EQ(expected_msg.position_covariance_type, _msg->position_covariance_type);
 
   for (auto i = 0u; i < 9; ++i) {
-    EXPECT_FLOAT_EQ(0, _msg->position_covariance[i]);
+    EXPECT_FLOAT_EQ(i + 1, _msg->position_covariance[i]);
   }
 }
 

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -548,7 +548,7 @@ void compareTestMsg(const std::shared_ptr<gps_msgs::msg::GPSFix> & _msg)
   EXPECT_EQ(expected_msg.position_covariance_type, _msg->position_covariance_type);
 
   for (auto i = 0u; i < 9; ++i) {
-    EXPECT_FLOAT_EQ(i + 1, _msg->position_covariance[i]);
+    EXPECT_FLOAT_EQ(0, _msg->position_covariance[i]);
   }
 }
 
@@ -1235,7 +1235,7 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::NavSatFix> & _msg)
   EXPECT_EQ(expected_msg.position_covariance_type, _msg->position_covariance_type);
 
   for (auto i = 0u; i < 9; ++i) {
-    EXPECT_FLOAT_EQ(i + 1, _msg->position_covariance[i]);
+    EXPECT_FLOAT_EQ(0, _msg->position_covariance[i]);
   }
 }
 

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -19,6 +19,12 @@
 #include <memory>
 #include <string>
 
+#include "gz/msgs/config.hh"
+
+#if GZ_MSGS_MAJOR_VERSION >= 10
+#define GZ_MSGS_IMU_HAS_COVARIANCE
+#endif
+
 namespace ros_gz_bridge
 {
 namespace testing
@@ -1064,9 +1070,11 @@ void createTestMsg(sensor_msgs::msg::Imu & _msg)
   _msg.orientation = quaternion_msg;
   _msg.angular_velocity = vector3_msg;
   _msg.linear_acceleration = vector3_msg;
+#ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   _msg.orientation_covariance = {1, 2, 3, 4, 5, 6, 7, 8, 9};
   _msg.angular_velocity_covariance = {1, 2, 3, 4, 5, 6, 7, 8, 9};
   _msg.linear_acceleration_covariance = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+#endif
 }
 
 void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Imu> & _msg)
@@ -1076,11 +1084,13 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Imu> & _msg)
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->angular_velocity));
   compareTestMsg(std::make_shared<geometry_msgs::msg::Vector3>(_msg->linear_acceleration));
 
+#ifdef GZ_MSGS_IMU_HAS_COVARIANCE
   for (int i = 0; i < 9; ++i){
     EXPECT_EQ(_msg->orientation_covariance[i], i + 1);
     EXPECT_EQ(_msg->angular_velocity_covariance[i], i + 1);
     EXPECT_EQ(_msg->linear_acceleration_covariance[i], i + 1);
   }
+#endif
 }
 
 void createTestMsg(sensor_msgs::msg::JointState & _msg)


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR depends on those two other PR:
- https://github.com/gazebosim/gz-sensors/pull/333
- https://github.com/gazebosim/gz-msgs/pull/333

Once those are merged, this PR will allow forwarding the IMU covariance between ros <--> gz.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

