### PR TITLE
Add actuator_msgs to bridge.

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -40,6 +40,7 @@ set(GZ_MSGS_VERSION_FULL ${GZ_MSGS_VERSION_MAJOR}.${GZ_MSGS_VERSION_MINOR}.${GZ_
 
 set(BRIDGE_MESSAGE_TYPES
   builtin_interfaces
+  actuator_msgs
   geometry_msgs
   gps_msgs
   nav_msgs

--- a/ros_gz_bridge/include/ros_gz_bridge/convert.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert.hpp
@@ -15,6 +15,7 @@
 #ifndef ROS_GZ_BRIDGE__CONVERT_HPP_
 #define ROS_GZ_BRIDGE__CONVERT_HPP_
 
+#include <ros_gz_bridge/convert/actuator_msgs.hpp>
 #include <ros_gz_bridge/convert/geometry_msgs.hpp>
 #include <ros_gz_bridge/convert/gps_msgs.hpp>
 #include <ros_gz_bridge/convert/nav_msgs.hpp>

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/actuator_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/actuator_msgs.hpp
@@ -1,0 +1,43 @@
+// Copyright 2023 Rudis Laboratories LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS_GZ_BRIDGE__CONVERT__ACTUATOR_MSGS_HPP_
+#define ROS_GZ_BRIDGE__CONVERT__ACTUATOR_MSGS_HPP_
+
+// Gazebo Msgs
+#include <gz/msgs/actuators.pb.h>
+
+// ROS 2 messages
+#include <actuator_msgs/msg/actuators.hpp>
+
+#include <ros_gz_bridge/convert_decl.hpp>
+
+namespace ros_gz_bridge
+{
+// actuator_msgs
+template<>
+void
+convert_ros_to_gz(
+  const actuator_msgs::msg::Actuators & ros_msg,
+  gz::msgs::Actuators & gz_msg);
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Actuators & gz_msg,
+  actuator_msgs::msg::Actuators & ros_msg);
+
+}  // namespace ros_gz_bridge
+
+#endif  // ROS_GZ_BRIDGE__CONVERT__ACTUATOR_MSGS_HPP_

--- a/ros_gz_bridge/package.xml
+++ b/ros_gz_bridge/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
+  <depend>actuator_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>gps_msgs</depend>
   <depend>nav_msgs</depend>

--- a/ros_gz_bridge/ros_gz_bridge/mappings.py
+++ b/ros_gz_bridge/ros_gz_bridge/mappings.py
@@ -27,6 +27,9 @@ MAPPINGS = {
     'builtin_interfaces': [
         Mapping('Time', 'Time'),
     ],
+    'actuator_msgs': [
+        Mapping('Actuators', 'Actuators'),
+    ],
     'geometry_msgs': [
         Mapping('Point', 'Vector3d'),
         Mapping('Pose', 'Pose'),

--- a/ros_gz_bridge/src/convert/actuator_msgs.cpp
+++ b/ros_gz_bridge/src/convert/actuator_msgs.cpp
@@ -1,0 +1,61 @@
+// Copyright 2023 Rudis Laboratories LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "convert/utils.hpp"
+#include "ros_gz_bridge/convert/actuator_msgs.hpp"
+
+namespace ros_gz_bridge
+{
+template<>
+void
+convert_ros_to_gz(
+  const actuator_msgs::msg::Actuators & ros_msg,
+  gz::msgs::Actuators & gz_msg)
+{
+  convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
+
+  for (auto i = 0u; i < ros_msg.position.size(); ++i) {
+    gz_msg.add_position(ros_msg.position[i]);
+  }
+
+  for (auto i = 0u; i < ros_msg.velocity.size(); ++i) {
+    gz_msg.add_velocity(ros_msg.velocity[i]);
+  }
+  for (auto i = 0u; i < ros_msg.normalized.size(); ++i) {
+    gz_msg.add_normalized(ros_msg.normalized[i]);
+  }
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Actuators & gz_msg,
+  actuator_msgs::msg::Actuators & ros_msg)
+{
+  convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+
+  for (auto i = 0; i < gz_msg.position_size(); ++i) {
+    ros_msg.position.push_back(gz_msg.position(i));
+  }
+
+  for (auto i = 0; i < gz_msg.velocity_size(); ++i) {
+    ros_msg.velocity.push_back(gz_msg.velocity(i));
+  }
+
+  for (auto i = 0; i < gz_msg.normalized_size(); ++i) {
+    ros_msg.normalized.push_back(gz_msg.normalized(i));
+  }
+}
+
+}  // namespace ros_gz_bridge

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -953,10 +953,10 @@ void createTestMsg(gz::msgs::Actuators & _msg)
   createTestMsg(header_msg);
   _msg.mutable_header()->CopyFrom(header_msg);
 
-  for (int i = 0u; i < 5; ++i) {
-    _msg.add_position(i);
-    _msg.add_velocity(i);
-    _msg.add_normalized(i);
+  for (int i = 0u; i < 3; ++i) {
+    _msg.add_position(0.5);
+    _msg.add_velocity(1.0);
+    _msg.add_normalized(0.2);
   }
 }
 
@@ -968,9 +968,15 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::Actuators> & _msg)
   compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
 
   for (int i = 0; i < expected_msg.position_size(); ++i) {
-    EXPECT_EQ(expected_msg.position(i), _msg->position(i));
-    EXPECT_EQ(expected_msg.velocity(i), _msg->velocity(i));
-    EXPECT_EQ(expected_msg.normalized(i), _msg->normalized(i));
+    EXPECT_FLOAT_EQ(expected_msg.position(i), _msg->position(i));
+  }
+
+  for (int i = 0; i < expected_msg.velocity_size(); ++i) {
+    EXPECT_FLOAT_EQ(expected_msg.velocity(i), _msg->velocity(i));
+  }
+
+  for (int i = 0; i < expected_msg.normalized_size(); ++i) {
+    EXPECT_FLOAT_EQ(expected_msg.normalized(i), _msg->normalized(i));
   }
 }
 

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -59,6 +59,37 @@ void createTestMsg(std_msgs::msg::ColorRGBA & _msg)
   _msg.a = 0.8;
 }
 
+void createTestMsg(actuator_msgs::msg::Actuators & _msg)
+{
+  std_msgs::msg::Header header_msg;
+  createTestMsg(header_msg);
+
+  _msg.header = header_msg;
+  _msg.position = {0.5, 0.5, 0.5};
+  _msg.velocity = {1.0, 1.0, 1.0};
+  _msg.normalized = {0.2, 0.2, 0.2};
+}
+
+void compareTestMsg(const std::shared_ptr<actuator_msgs::msg::Actuators> & _msg)
+{
+  actuator_msgs::msg::Actuators expected_msg;
+  createTestMsg(expected_msg);
+
+  compareTestMsg(_msg->header);
+
+  for (auto i = 0u; i < _msg->position.size(); ++i) {
+    EXPECT_FLOAT_EQ(expected_msg.position[i], _msg->position[i]);
+  }
+
+  for (auto i = 0u; i < _msg->velocity.size(); ++i) {
+    EXPECT_FLOAT_EQ(expected_msg.velocity[i], _msg->velocity[i]);
+  }
+
+  for (auto i = 0u; i < _msg->normalized.size(); ++i) {
+    EXPECT_FLOAT_EQ(expected_msg.normalized[i], _msg->normalized[i]);
+  }
+}
+
 void compareTestMsg(const std::shared_ptr<std_msgs::msg::ColorRGBA> & _msg)
 {
   std_msgs::msg::ColorRGBA expected_msg;

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -29,6 +29,7 @@
 #include <std_msgs/msg/u_int32.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <actuator_msgs/msg/actuators.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
@@ -178,6 +179,16 @@ void createTestMsg(rosgraph_msgs::msg::Clock & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<rosgraph_msgs::msg::Clock> & _msg);
+
+/// actuator_msgs
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(actuator_msgs::msg::Actuators & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<actuator_msgs::msg::Actuators> & _msg);
 
 /// geometry_msgs
 


### PR DESCRIPTION
# 🎉 New feature

Adds actuators message to the ROS side of the bridge allowing for control of most (all?) types of actuators in simulation.

https://github.com/gazebosim/gz-sim/pull/1952
https://github.com/gazebosim/gz-sim/pull/1953
https://github.com/gazebosim/gz-sim/pull/1954

As seen in the Gazebo community meeting:
https://vimeo.com/812911652#t=39m58s

Depends on release of: https://github.com/rudislabs/actuator_msgs

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.