### PR TITLE
fix(ros_ign_bridge): exports dependencies to downstream packages

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -196,4 +196,15 @@ if(BUILD_TESTING)
   )
 endif()
 
+ament_export_dependencies(
+  geometry_msgs
+  nav_msgs
+  rclcpp
+  rosgraph_msgs
+  sensor_msgs
+  std_msgs
+  tf2_msgs
+  trajectory_msgs
+)
+
 ament_package()


### PR DESCRIPTION
# 🦟 Bug fix
## Summary
Exports dependencies of `ros_ign_bridge` to downstream packages. This way a package using `ros_ign_bridge` won't have to manually import its dependencies (nav_msgs for example)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
