### PR TITLE
[forwardport Iron]Fix incorrect subscription on demo (#405)

### DIFF
--- a/ros_gz_sim_demos/rviz/gpu_lidar_bridge.rviz
+++ b/ros_gz_sim_demos/rviz/gpu_lidar_bridge.rviz
@@ -98,7 +98,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Flat Squares
-      Topic: /lidar
+      Topic: /lidar/points
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This PR fixes an incorrect subscription on one of the demos. Running
```
ros2 launch ros_gz_sim_demos gpu_lidar_bridge.launch.py
```
causes rviz2 to crash and exit with the error:
```
rviz2-3]
[rviz2-3] >>> [rcutils|error_handling.c:108] rcutils_set_error_state()
[rviz2-3] This error state is being overwritten:
[rviz2-3]
[rviz2-3]   'create_subscription() called for existing topic name rt/lidar with incompatible type sensor_msgs::msg::dds_::PointCloud2_, at ./src/subscription.cpp:146, at ./src/rcl/subscription.c:108'
[rviz2-3]
[rviz2-3] with this new error message:
[rviz2-3]
[rviz2-3]   'invalid allocator, at ./src/rcl/subscription.c:218'
[rviz2-3]
[rviz2-3] rcutils_reset_error() should be called after error handling to avoid this.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
