### PR TITLE
Added Altimeter msg bridging

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -25,6 +25,7 @@ The following message types can be bridged for topics:
 | nav_msgs/msg/Odometry                        | gz.msgs.Odometry               |
 | nav_msgs/msg/Odometry                        | gz.msgs.OdometryWithCovariance |
 | rcl_interfaces/msg/ParameterValue            | gz.msgs.Any                    |
+| ros_gz_interfaces/msg/Altimeter              | gz.msgs.Altimeter              |
 | ros_gz_interfaces/msg/Contact                | gz.msgs.Contact                |
 | ros_gz_interfaces/msg/Contacts               | gz.msgs.Contacts               |
 | ros_gz_interfaces/msg/Dataframe              | gz.msgs.Dataframe              |

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
@@ -16,6 +16,7 @@
 #define ROS_GZ_BRIDGE__CONVERT__ROS_GZ_INTERFACES_HPP_
 
 // Gazebo Msgs
+#include <gz/msgs/altimeter.pb.h>
 #include <gz/msgs/entity.pb.h>
 #include <gz/msgs/joint_wrench.pb.h>
 #include <gz/msgs/contact.pb.h>
@@ -32,6 +33,7 @@
 #include <gz/msgs/world_control.pb.h>
 
 // ROS 2 messages
+#include <ros_gz_interfaces/msg/altimeter.hpp>
 #include <ros_gz_interfaces/msg/entity.hpp>
 #include <ros_gz_interfaces/msg/joint_wrench.hpp>
 #include <ros_gz_interfaces/msg/contact.hpp>
@@ -64,6 +66,18 @@ void
 convert_gz_to_ros(
   const gz::msgs::JointWrench & gz_msg,
   ros_gz_interfaces::msg::JointWrench & ros_msg);
+
+template<>
+void
+convert_ros_to_gz(
+  const ros_gz_interfaces::msg::Altimeter & ros_msg,
+  gz::msgs::Altimeter & gz_msg);
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Altimeter & gz_msg,
+  ros_gz_interfaces::msg::Altimeter & ros_msg);
 
 template<>
 void

--- a/ros_gz_bridge/ros_gz_bridge/mappings.py
+++ b/ros_gz_bridge/ros_gz_bridge/mappings.py
@@ -58,6 +58,7 @@ MAPPINGS = {
         Mapping('ParameterValue', 'Any'),
     ],
     'ros_gz_interfaces': [
+        Mapping('Altimeter', 'Altimeter'),
         Mapping('Contact', 'Contact'),
         Mapping('Contacts', 'Contacts'),
         Mapping('Dataframe', 'Dataframe'),

--- a/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
@@ -50,6 +50,30 @@ convert_gz_to_ros(
 template<>
 void
 convert_ros_to_gz(
+  const ros_gz_interfaces::msg::Altimeter & ros_msg,
+  gz::msgs::Altimeter & gz_msg)
+{
+  convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
+  gz_msg.set_vertical_position(ros_msg.vertical_position);
+  gz_msg.set_vertical_velocity(ros_msg.vertical_velocity);
+  gz_msg.set_vertical_reference(ros_msg.vertical_reference);
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Altimeter & gz_msg,
+  ros_gz_interfaces::msg::Altimeter & ros_msg)
+{
+  convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+  ros_msg.vertical_position = gz_msg.vertical_position();
+  ros_msg.vertical_velocity = gz_msg.vertical_velocity();
+  ros_msg.vertical_reference = gz_msg.vertical_reference();
+}
+
+template<>
+void
+convert_ros_to_gz(
   const ros_gz_interfaces::msg::Entity & ros_msg,
   gz::msgs::Entity & gz_msg)
 {

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -247,6 +247,25 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::Vector3d> & _msg)
   EXPECT_EQ(expected_msg.z(), _msg->z());
 }
 
+void createTestMsg(gz::msgs::Altimeter & _msg)
+{
+  createTestMsg(*_msg.mutable_header());
+  _msg.set_vertical_position(100);
+  _msg.set_vertical_velocity(200);
+  _msg.set_vertical_reference(300);
+}
+
+void compareTestMsg(const std::shared_ptr<gz::msgs::Altimeter> & _msg)
+{
+  gz::msgs::Altimeter expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.vertical_position(), _msg->vertical_position());
+  EXPECT_EQ(expected_msg.vertical_velocity(), _msg->vertical_velocity());
+  EXPECT_EQ(expected_msg.vertical_reference(), _msg->vertical_reference());
+  compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
+}
+
 void createTestMsg(gz::msgs::Param & _msg)
 {
   createTestMsg(*_msg.mutable_header());

--- a/ros_gz_bridge/test/utils/gz_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.hpp
@@ -16,6 +16,7 @@
 #define UTILS__GZ_TEST_MSG_HPP_
 
 #include <gz/msgs/actuators.pb.h>
+#include <gz/msgs/altimeter.pb.h>
 #include <gz/msgs/any.pb.h>
 #include <gz/msgs/axis.pb.h>
 #include <gz/msgs/battery_state.pb.h>
@@ -254,6 +255,14 @@ void createTestMsg(gz::msgs::JointWrench & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<gz::msgs::JointWrench> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(gz::msgs::Altimeter & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<gz::msgs::Altimeter> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -756,6 +756,26 @@ void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::JointWrench> &
   compareTestMsg(std::make_shared<geometry_msgs::msg::Wrench>(_msg->body_2_wrench));
 }
 
+void createTestMsg(ros_gz_interfaces::msg::Altimeter & _msg)
+{
+  createTestMsg(_msg.header);
+  _msg.vertical_position = 100;
+  _msg.vertical_velocity = 200;
+  _msg.vertical_reference = 300;
+}
+
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::Altimeter> & _msg)
+{
+  ros_gz_interfaces::msg::Altimeter expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.vertical_position, _msg->vertical_position);
+  EXPECT_EQ(expected_msg.vertical_velocity, _msg->vertical_velocity);
+  EXPECT_EQ(expected_msg.vertical_reference, _msg->vertical_reference);
+
+  compareTestMsg(_msg->header);
+}
+
 void createTestMsg(ros_gz_interfaces::msg::Entity & _msg)
 {
   _msg.id = 1;

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -47,6 +47,7 @@
 #include <geometry_msgs/msg/wrench_stamped.hpp>
 #include <gps_msgs/msg/gps_fix.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <ros_gz_interfaces/msg/altimeter.hpp>
 #include <ros_gz_interfaces/msg/entity.hpp>
 #include <ros_gz_interfaces/msg/gui_camera.hpp>
 #include <ros_gz_interfaces/msg/joint_wrench.hpp>
@@ -378,6 +379,14 @@ void createTestMsg(ros_gz_interfaces::msg::JointWrench & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::JointWrench> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ros_gz_interfaces::msg::Altimeter & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::Altimeter> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_gz_interfaces/CMakeLists.txt
+++ b/ros_gz_interfaces/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
+  "msg/Altimeter.msg"
   "msg/Contact.msg"
   "msg/Contacts.msg"
   "msg/Dataframe.msg"

--- a/ros_gz_interfaces/msg/Altimeter.msg
+++ b/ros_gz_interfaces/msg/Altimeter.msg
@@ -1,0 +1,13 @@
+# A message for Altimeter readings.
+
+# Optional header data.
+std_msgs/Header header
+
+# Vertical position data, in meters.
+float64 vertical_position
+
+# Vertical velocity data, in meters/second.
+float64 vertical_velocity
+
+# Vertical reference.
+float64 vertical_reference


### PR DESCRIPTION


# 🎉 New feature

## Summary
This PR adds a new message to ros_gz_interfaces for altimeter readings and bridges it to the equivalent message in gz-msgs.

## Test it
WIP

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.