### PR TITLE
[backport Iron] Added Altimeter msg bridging (#413)

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -33,6 +33,7 @@ The following message types can be bridged for topics:
 | nav_msgs/msg/Odometry                | ignition::msgs::Odometry               |
 | nav_msgs/msg/Odometry                | ignition::msgs::OdometryWithCovariance |
 | rcl_interfaces/msg/ParameterValue    | ignition::msgs::Any                  |
+| ros_gz_interfaces/msg/Altimeter      | ignition.msgs.Altimeter                |
 | ros_gz_interfaces/msg/Contact        | ignition::msgs::Contact                |
 | ros_gz_interfaces/msg/Contacts       | ignition::msgs::Contacts               |
 | ros_gz_interfaces/msg/Dataframe     | ignition::msgs::Dataframe            |

--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -32,11 +32,11 @@ The following message types can be bridged for topics:
 | geometry_msgs/msg/TwistWithCovariance| ignition::msgs::TwistWithCovariance    |
 | nav_msgs/msg/Odometry                | ignition::msgs::Odometry               |
 | nav_msgs/msg/Odometry                | ignition::msgs::OdometryWithCovariance |
-| rcl_interfaces/msg/ParameterValue    | ignition::msgs::Any                  |
+| rcl_interfaces/msg/ParameterValue    | ignition::msgs::Any                    |
 | ros_gz_interfaces/msg/Altimeter      | ignition.msgs.Altimeter                |
 | ros_gz_interfaces/msg/Contact        | ignition::msgs::Contact                |
 | ros_gz_interfaces/msg/Contacts       | ignition::msgs::Contacts               |
-| ros_gz_interfaces/msg/Dataframe     | ignition::msgs::Dataframe            |
+| ros_gz_interfaces/msg/Dataframe      | ignition::msgs::Dataframe              |
 | ros_gz_interfaces/msg/Entity         | ignition::msgs::Entity                 |
 | ros_gz_interfaces/msg/Float32Array   | ignition::msgs::Float_V                |
 | ros_gz_interfaces/msg/GuiCamera      | ignition::msgs::GUICamera              |
@@ -44,8 +44,8 @@ The following message types can be bridged for topics:
 | ros_gz_interfaces/msg/Light          | ignition::msgs::Light                  |
 | ros_gz_interfaces/msg/StringVec      | ignition::msgs::StringMsg_V            |
 | ros_gz_interfaces/msg/TrackVisual    | ignition::msgs::TrackVisual            |
-| ros_gz_interfaces/msg/VideoRecord   | ignition::msgs::VideoRecord            |
-| ros_gz_interfaces/msg/WorldControl  | ignition::msgs::WorldControl           |
+| ros_gz_interfaces/msg/VideoRecord    | ignition::msgs::VideoRecord            |
+| ros_gz_interfaces/msg/WorldControl   | ignition::msgs::WorldControl           |
 | rosgraph_msgs/msg/Clock              | ignition::msgs::Clock                  |
 | sensor_msgs/msg/BatteryState         | ignition::msgs::BatteryState           |
 | sensor_msgs/msg/CameraInfo           | ignition::msgs::CameraInfo             |
@@ -53,10 +53,10 @@ The following message types can be bridged for topics:
 | sensor_msgs/msg/Imu                  | ignition::msgs::IMU                    |
 | sensor_msgs/msg/Image                | ignition::msgs::Image                  |
 | sensor_msgs/msg/JointState           | ignition::msgs::Model                  |
-| sensor_msgs/msg/Joy                  | ignition::msgs::Joy                  |
+| sensor_msgs/msg/Joy                  | ignition::msgs::Joy                    |
 | sensor_msgs/msg/LaserScan            | ignition::msgs::LaserScan              |
 | sensor_msgs/msg/MagneticField        | ignition::msgs::Magnetometer           |
-| sensor_msgs/msg/NavSatFixed          | ignition::msgs::NavSat               |
+| sensor_msgs/msg/NavSatFixed          | ignition::msgs::NavSat                 |
 | sensor_msgs/msg/PointCloud2          | ignition::msgs::PointCloudPacked       |
 | tf2_msgs/msg/TFMessage               | ignition::msgs::Pose_V                 |
 | trajectory_msgs/msg/JointTrajectory  | ignition::msgs::JointTrajectory        |
@@ -65,7 +65,7 @@ And the following for services:
 
 | ROS type                             | Gazebo request             | Gazebo response       |
 |--------------------------------------|:--------------------------:| --------------------- |
-| ros_gz_interfaces/srv/ControlWorld  | ignition.msgs.WorldControl | ignition.msgs.Boolean |
+| ros_gz_interfaces/srv/ControlWorld   | ignition.msgs.WorldControl | ignition.msgs.Boolean |
 
 Run `ros2 run ros_gz_bridge parameter_bridge -h` for instructions.
 

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
@@ -75,12 +75,12 @@ template<>
 void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Altimeter & ros_msg,
-  gz::msgs::Altimeter & gz_msg);
+  ignition::msgs::Altimeter & gz_msg);
 
 template<>
 void
 convert_gz_to_ros(
-  const gz::msgs::Altimeter & gz_msg,
+  const ignition::msgs::Altimeter & gz_msg,
   ros_gz_interfaces::msg::Altimeter & ros_msg);
 
 template<>

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
@@ -16,6 +16,7 @@
 #define ROS_GZ_BRIDGE__CONVERT__ROS_GZ_INTERFACES_HPP_
 
 // Gazebo Msgs
+#include <ignition/msgs/altimeter.pb.h>
 #include <ignition/msgs/entity.pb.h>
 #include <ignition/msgs/joint_wrench.pb.h>
 #include <ignition/msgs/contact.pb.h>
@@ -31,6 +32,7 @@
 #include <ignition/msgs/world_control.pb.h>
 
 // ROS 2 messages
+#include <ros_gz_interfaces/msg/altimeter.hpp>
 #include <ros_gz_interfaces/msg/entity.hpp>
 #include <ros_gz_interfaces/msg/joint_wrench.hpp>
 #include <ros_gz_interfaces/msg/contact.hpp>
@@ -68,6 +70,18 @@ void
 convert_gz_to_ros(
   const ignition::msgs::JointWrench & gz_msg,
   ros_gz_interfaces::msg::JointWrench & ros_msg);
+
+template<>
+void
+convert_ros_to_gz(
+  const ros_gz_interfaces::msg::Altimeter & ros_msg,
+  gz::msgs::Altimeter & gz_msg);
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Altimeter & gz_msg,
+  ros_gz_interfaces::msg::Altimeter & ros_msg);
 
 template<>
 void

--- a/ros_gz_bridge/ros_gz_bridge/mappings.py
+++ b/ros_gz_bridge/ros_gz_bridge/mappings.py
@@ -53,6 +53,7 @@ MAPPINGS = {
         Mapping('ParameterValue', 'Any'),
     ],
     'ros_gz_interfaces': [
+        Mapping('Altimeter', 'Altimeter'),
         Mapping('Contact', 'Contact'),
         Mapping('Contacts', 'Contacts'),
         Mapping('Entity', 'Entity'),

--- a/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
@@ -51,7 +51,7 @@ template<>
 void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Altimeter & ros_msg,
-  gz::msgs::Altimeter & gz_msg)
+  ignition::msgs::Altimeter & gz_msg)
 {
   convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
   gz_msg.set_vertical_position(ros_msg.vertical_position);
@@ -62,7 +62,7 @@ convert_ros_to_gz(
 template<>
 void
 convert_gz_to_ros(
-  const gz::msgs::Altimeter & gz_msg,
+  const ignition::msgs::Altimeter & gz_msg,
   ros_gz_interfaces::msg::Altimeter & ros_msg)
 {
   convert_gz_to_ros(gz_msg.header(), ros_msg.header);

--- a/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
@@ -50,6 +50,30 @@ convert_gz_to_ros(
 template<>
 void
 convert_ros_to_gz(
+  const ros_gz_interfaces::msg::Altimeter & ros_msg,
+  gz::msgs::Altimeter & gz_msg)
+{
+  convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
+  gz_msg.set_vertical_position(ros_msg.vertical_position);
+  gz_msg.set_vertical_velocity(ros_msg.vertical_velocity);
+  gz_msg.set_vertical_reference(ros_msg.vertical_reference);
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Altimeter & gz_msg,
+  ros_gz_interfaces::msg::Altimeter & ros_msg)
+{
+  convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+  ros_msg.vertical_position = gz_msg.vertical_position();
+  ros_msg.vertical_velocity = gz_msg.vertical_velocity();
+  ros_msg.vertical_reference = gz_msg.vertical_reference();
+}
+
+template<>
+void
+convert_ros_to_gz(
   const ros_gz_interfaces::msg::Entity & ros_msg,
   ignition::msgs::Entity & gz_msg)
 {

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -257,13 +257,13 @@ void createTestMsg(ignition::msgs::Altimeter & _msg)
 
 void compareTestMsg(const std::shared_ptr<ignition::msgs::Altimeter> & _msg)
 {
-  gz::msgs::Altimeter expected_msg;
+  ignition::msgs::Altimeter expected_msg;
   createTestMsg(expected_msg);
 
   EXPECT_EQ(expected_msg.vertical_position(), _msg->vertical_position());
   EXPECT_EQ(expected_msg.vertical_velocity(), _msg->vertical_velocity());
   EXPECT_EQ(expected_msg.vertical_reference(), _msg->vertical_reference());
-  compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
+  compareTestMsg(std::make_shared<ignition::msgs::Header>(_msg->header()));
 }
 void createTestMsg(ignition::msgs::Param & _msg)
 {

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -247,6 +247,24 @@ void compareTestMsg(const std::shared_ptr<ignition::msgs::Vector3d> & _msg)
   EXPECT_EQ(expected_msg.z(), _msg->z());
 }
 
+void createTestMsg(ignition::msgs::Altimeter & _msg)
+{
+  createTestMsg(*_msg.mutable_header());
+  _msg.set_vertical_position(100);
+  _msg.set_vertical_velocity(200);
+  _msg.set_vertical_reference(300);
+}
+
+void compareTestMsg(const std::shared_ptr<ignition::msgs::Altimeter> & _msg)
+{
+  gz::msgs::Altimeter expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.vertical_position(), _msg->vertical_position());
+  EXPECT_EQ(expected_msg.vertical_velocity(), _msg->vertical_velocity());
+  EXPECT_EQ(expected_msg.vertical_reference(), _msg->vertical_reference());
+  compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
+}
 void createTestMsg(ignition::msgs::Param & _msg)
 {
   createTestMsg(*_msg.mutable_header());

--- a/ros_gz_bridge/test/utils/gz_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.hpp
@@ -16,6 +16,7 @@
 #define UTILS__GZ_TEST_MSG_HPP_
 
 #include <ignition/msgs/actuators.pb.h>
+#include <ignition/msgs/altimeter.pb.h>
 #include <ignition/msgs/any.pb.h>
 #include <ignition/msgs/axis.pb.h>
 #include <ignition/msgs/battery_state.pb.h>
@@ -257,6 +258,14 @@ void createTestMsg(ignition::msgs::JointWrench & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<ignition::msgs::JointWrench> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ignition::msgs::Altimeter & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ignition::msgs::Altimeter> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -700,6 +700,26 @@ void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::JointWrench> &
   compareTestMsg(std::make_shared<geometry_msgs::msg::Wrench>(_msg->body_2_wrench));
 }
 
+void createTestMsg(ros_gz_interfaces::msg::Altimeter & _msg)
+{
+  createTestMsg(_msg.header);
+  _msg.vertical_position = 100;
+  _msg.vertical_velocity = 200;
+  _msg.vertical_reference = 300;
+}
+
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::Altimeter> & _msg)
+{
+  ros_gz_interfaces::msg::Altimeter expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.vertical_position, _msg->vertical_position);
+  EXPECT_EQ(expected_msg.vertical_velocity, _msg->vertical_velocity);
+  EXPECT_EQ(expected_msg.vertical_reference, _msg->vertical_reference);
+
+  compareTestMsg(_msg->header);
+}
+
 void createTestMsg(ros_gz_interfaces::msg::Entity & _msg)
 {
   _msg.id = 1;

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -44,6 +44,7 @@
 #include <geometry_msgs/msg/wrench.hpp>
 #include <geometry_msgs/msg/wrench_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <ros_gz_interfaces/msg/altimeter.hpp>
 #include <ros_gz_interfaces/msg/entity.hpp>
 #include <ros_gz_interfaces/msg/gui_camera.hpp>
 #include <ros_gz_interfaces/msg/joint_wrench.hpp>
@@ -347,6 +348,14 @@ void createTestMsg(ros_gz_interfaces::msg::JointWrench & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::JointWrench> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ros_gz_interfaces::msg::Altimeter & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::Altimeter> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_gz_interfaces/CMakeLists.txt
+++ b/ros_gz_interfaces/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
+  "msg/Altimeter.msg"
   "msg/Contact.msg"
   "msg/Contacts.msg"
   "msg/Dataframe.msg"

--- a/ros_gz_interfaces/msg/Altimeter.msg
+++ b/ros_gz_interfaces/msg/Altimeter.msg
@@ -1,0 +1,13 @@
+# A message for Altimeter readings.
+
+# Optional header data.
+std_msgs/Header header
+
+# Vertical position data, in meters.
+float64 vertical_position
+
+# Vertical velocity data, in meters/second.
+float64 vertical_velocity
+
+# Vertical reference.
+float64 vertical_reference


### PR DESCRIPTION

# 🎉 New feature

## Summary
backported to Iron: Added Altimeter msg bridging (#413)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
