### PR TITLE
Update README.md to fix humble from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Install either [Edifice, Fortress, or Garden](https://gazebosim.org/docs).
 Set the `GZ_VERSION` environment variable to the Gazebo version you'd
 like to compile against. For example:
 
-    export GZ_VERSION=edifice
+    export GZ_VERSION=edifice # IMPORTANT: Replace with correct version
 
 > You only need to set this variable when compiling, not when running.
 
@@ -99,7 +99,7 @@ The following steps are for Linux and OSX.
     cd ~/ws/src
 
     # Download needed software
-    git clone https://github.com/gazebosim/ros_gz.git -b ros2
+    git clone https://github.com/gazebosim/ros_gz.git -b humble
     ```
 
 1. Install dependencies (this may also install Gazebo):
@@ -119,6 +119,22 @@ The following steps are for Linux and OSX.
 
     # Build and install into workspace
     cd ~/ws
+    colcon build
+    ```
+
+    If `colcon build` fails with [this issue](https://github.com/gazebosim/ros_gz/issues/401)
+
+    ```
+    CMake Error at CMakeLists.txt:81 (find_package):
+      By not providing "Findactuator_msgs.cmake" in CMAKE_MODULE_PATH this
+      project has asked CMake to find a package configuration file provided by
+      "actuator_msgs", but CMake did not find one.
+    ```
+
+    ```bash
+    cd src
+    git clone git@github.com:rudislabs/actuator_msgs.git
+    cd ../
     colcon build
     ```
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes N/A

## Summary
Fix the branch name when checking out ros_gz otherwise `rosdep install -r --from-paths src -i -y --rosdistro humble` errors with incompatible versions. Additonally link to https://github.com/gazebosim/ros_gz/issues/401#issuecomment-1564347874 which allows compilation on Ubuntu 20.04 + ROS2 Humble + Ignition Fortress

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
