### PR TITLE
Replace deprecated ign_find_package with gz_find_package

### DIFF
--- a/ros_gz_sim/CMakeLists.txt
+++ b/ros_gz_sim/CMakeLists.txt
@@ -38,7 +38,7 @@ else()
   message(FATAL_ERROR "This branch is only compatible with Gazebo Garden forward.")
 endif()
 
-ign_find_package(gflags
+gz_find_package(gflags
     REQUIRED
     PKGCONFIG gflags)
 find_package(std_msgs REQUIRED)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes the following warning seen when building:
```
CMake Warning at /usr/share/cmake/gz-cmake3/cmake3/GzFindPackage.cmake:155 (message):
  ign_find_package is deprecated, use gz_find_package instead.
Call Stack (most recent call first):
  CMakeLists.txt:41 (ign_find_package)
```

## Summary
This PR follows the warning suggestion and replaces the deprecated `ign_find_package` with `gz_find_package`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
