### PR TITLE
Use stable osrf repo for Garden and stable+prerelease for Harmonic

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -10,10 +10,8 @@ export ROS_PYTHON_VERSION=3
 apt update -qq
 apt install -qq -y lsb-release wget curl build-essential
 
-# Garden only has nightlies for now
 if [ "$GZ_VERSION" == "garden" ]; then
   echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-  echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list
   wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
 
   GZ_DEPS="libgz-sim7-dev"
@@ -21,7 +19,7 @@ if [ "$GZ_VERSION" == "garden" ]; then
   ROSDEP_ARGS="--skip-keys='sdformat-urdf'"
 elif [ "$GZ_VERSION" == "harmonic" ]; then
   echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-  echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list
+  echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list
   wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
 
   GZ_DEPS="libgz-sim8-dev"


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Garden has been in the stable repository for long time and Harmonic is now in the prerelease repository.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
