### PR TITLE
[backport iron] Fix double wait in ros_gz_bridge (#347)

### DIFF
--- a/ros_gz_bridge/src/parameter_bridge.cpp
+++ b/ros_gz_bridge/src/parameter_bridge.cpp
@@ -172,8 +172,5 @@ int main(int argc, char * argv[])
   // ROS 2 spinner
   rclcpp::spin(bridge_node);
 
-  // Wait for gz node shutdown
-  ignition::transport::waitForShutdown();
-
   return 0;
 }

--- a/ros_gz_bridge/src/static_bridge.cpp
+++ b/ros_gz_bridge/src/static_bridge.cpp
@@ -44,8 +44,5 @@ int main(int argc, char * argv[])
 
   rclcpp::spin(bridge_node);
 
-  // Wait for gz node shutdown
-  ignition::transport::waitForShutdown();
-
   return 0;
 }

--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -97,7 +97,5 @@ int main(int argc, char * argv[])
   // Spin ROS and Gz until shutdown
   rclcpp::spin(node_);
 
-  ignition::transport::waitForShutdown();
-
   return 0;
 }


### PR DESCRIPTION
# 🦟 Bug fix

Backport Fix double wait in ros_gz_bridge (#347)

## Summary
Remove `gz::transport::waitForShutdown(`) from ros_gz_bridge and ros_gz_image

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
