### PR TITLE
Update README to include harmonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Galactic | Edifice | [galactic](https://github.com/gazebosim/ros_gz/tree/galacti
 Galactic | Fortress | [galactic](https://github.com/gazebosim/ros_gz/tree/galactic) | only from source
 Humble | Fortress | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | https://packages.ros.org
 Humble | Garden | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | only from source
-Humble | Harmonic | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | only from source
 Iron | Fortress | [iron](https://github.com/gazebosim/ros_gz/tree/iron) | https://packages.ros.org
 Iron | Garden | [iron](https://github.com/gazebosim/ros_gz/tree/iron) | only from source
 Iron | Harmonic | [iron](https://github.com/gazebosim/ros_gz/tree/iron) | only from source

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Galactic | Edifice | [galactic](https://github.com/gazebosim/ros_gz/tree/galacti
 Galactic | Fortress | [galactic](https://github.com/gazebosim/ros_gz/tree/galactic) | only from source
 Humble | Fortress | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | https://packages.ros.org
 Humble | Garden | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | only from source
+Humble | Harmonic | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | only from source
 Iron | Fortress | [iron](https://github.com/gazebosim/ros_gz/tree/iron) | https://packages.ros.org
 Iron | Garden | [iron](https://github.com/gazebosim/ros_gz/tree/iron) | only from source
-Rolling | Edifice | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source
+Iron | Harmonic | [iron](https://github.com/gazebosim/ros_gz/tree/iron) | only from source
 Rolling | Fortress | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | https://packages.ros.org
 Rolling | Garden | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source
+Rolling | Harmonic | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source
 
 
 For information on ROS(1) and Gazebo compatibility, refer to the [noetic branch README](https://github.com/gazebosim/ros_gz/tree/noetic)


### PR DESCRIPTION
This few liner just updates the README to include harmonic.
I admittedly didn't test all the configurations, instead I looked at the [package.xml from ros_gz_bridge](https://github.com/gazebosim/ros_gz/blob/ros2/ros_gz_bridge/package.xml) to try to guess since `humble`, `iron` and `ros2` all seem to have a branch for detecting and building with Harmonic