### PR TITLE
Additional tip for limiting number of CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ The following steps are for Linux and OSX.
     ```
   > [!TIP]
   > The `ros_gz` library makes heavy use of templates which causes compilers to consume a lot of memory. If your build fails with `c++: fatal error: Killed signal terminated program cc1plus`
-  > try building with `colcon build --parallel-workers=1 --executor sequential`.
+  > try building with `colcon build --parallel-workers=1 --executor sequential`. You might also have to set `export MAKEFLAGS="-j 1"` before running `colcon build` to limit
+  > the number of processors used to build a single package.
 
 ## ROSCon 2022
 


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
From https://robotics.stackexchange.com/a/97898/31574, colcon uses all available CPU cores when building a single package. Setting `MAKEFLAGS="-j 1"` would help if users are running out of memory.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
