### PR TITLE
Undeprecate use of commandline flags

### DIFF
--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -214,10 +214,6 @@ int main(int _argc, char ** _argv)
         ros2_node->get_logger(), "Must specify either -file, -param, -string or -topic");
       return -1;
     }
-    RCLCPP_WARN(
-      ros2_node->get_logger(),
-      "Usage of Commandline flags for spawning entities is deprecated. Please use ROS 2 parameters."
-    );
   } else {
     RCLCPP_ERROR(
       ros2_node->get_logger(), "Must specify either file, string or topic as ROS 2 parameters");

--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -214,6 +214,8 @@ int main(int _argc, char ** _argv)
         ros2_node->get_logger(), "Must specify either -file, -param, -string or -topic");
       return -1;
     }
+    // TODO(azeey) Deprecate use of command line flags in ROS 2 K-turtle in
+    // favor of ROS 2 parameters.
   } else {
     RCLCPP_ERROR(
       ros2_node->get_logger(), "Must specify either file, string or topic as ROS 2 parameters");


### PR DESCRIPTION
## Summary

I'm writing a migration guide for Gazebo classic users and using the command line flags since that's what's available in Humble. It's also very closely matched with `gazebo_ros_pkgs` so the migration is a lot easier if we keep the flags. I think it would be best to keep these flags, at least for another ROS release cycle.

 
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.