### PR TITLE
Add a ROS node that runs Gazebo

### DIFF
--- a/ros_gz_sim/CMakeLists.txt
+++ b/ros_gz_sim/CMakeLists.txt
@@ -86,6 +86,16 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/${PROJECT_NAME}
 )
 
+add_executable(gzserver src/gzserver.cpp)
+ament_target_dependencies(gzserver
+  rclcpp
+  std_msgs
+)
+target_link_libraries(gzserver
+  ${GZ_TARGET_PREFIX}-sim${GZ_SIM_VER}::core
+)
+ament_target_dependencies(gzserver std_msgs)
+
 configure_file(
   launch/gz_sim.launch.py.in
   launch/gz_sim.launch.py.configured
@@ -103,6 +113,10 @@ install(FILES
 
 install(TARGETS
   create
+  DESTINATION lib/${PROJECT_NAME}
+)
+install(TARGETS
+  gzserver
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros_gz_sim/CMakeLists.txt
+++ b/ros_gz_sim/CMakeLists.txt
@@ -66,7 +66,7 @@ ament_target_dependencies(gzserver
   std_msgs
 )
 target_link_libraries(gzserver
-  ${GZ_TARGET_PREFIX}-sim${GZ_SIM_VER}::core
+  gz-sim::core
 )
 ament_target_dependencies(gzserver std_msgs)
 

--- a/ros_gz_sim/src/gzserver.cpp
+++ b/ros_gz_sim/src/gzserver.cpp
@@ -29,7 +29,6 @@ int main(int _argc, char ** _argv)
   common::Console::SetVerbosity(4);
   sim::ServerConfig server_config;
 
-
   if (!world_sdf_file.empty())
   {
     server_config.SetSdfFile(world_sdf_file);
@@ -43,26 +42,6 @@ int main(int _argc, char ** _argv)
     return -1;
   }
 
-  // (azeey) Testing if a plugin can be loaded along side the defaults. Not working yet.
-
-  // <plugin
-  //   filename="gz-sim-imu-system"
-  //   name="gz::sim::systems::Imu">
-  // </plugin>
-  sdf::Plugin imu_sdf_plugin;
-  imu_sdf_plugin.SetName("gz::sim::systems::Imu");
-  imu_sdf_plugin.SetFilename("gz-sim-imu-system");
-  sim::SystemLoader loader;
-  auto imu_plugin = loader.LoadPlugin(imu_sdf_plugin);
-  std::cout << imu_plugin.value() << std::endl;
-
   gz::sim::Server server(server_config);
-  server.RunOnce();
-  if (!server.AddSystem(*imu_plugin))
-  {
-    RCLCPP_ERROR(
-      node->get_logger(), "IMU system not added");
-
-  }
   server.Run(true /*blocking*/, 0, false /*paused*/);
 }

--- a/ros_gz_sim/src/gzserver.cpp
+++ b/ros_gz_sim/src/gzserver.cpp
@@ -1,0 +1,68 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gz/common/Console.hh>
+#include <gz/sim/Server.hh>
+#include <gz/sim/SystemLoader.hh>
+#include <gz/sim/ServerConfig.hh>
+#include <rclcpp/rclcpp.hpp>
+
+int main(int _argc, char ** _argv)
+{
+  using namespace gz;
+  auto filtered_arguments = rclcpp::init_and_remove_ros_arguments(_argc, _argv);
+  auto node = rclcpp::Node::make_shared("gzserver");
+  auto world_sdf_file = node->declare_parameter("world_sdf_file", "");
+  auto world_sdf_string = node->declare_parameter("world_sdf_string", "");
+
+  common::Console::SetVerbosity(4);
+  sim::ServerConfig server_config;
+
+
+  if (!world_sdf_file.empty())
+  {
+    server_config.SetSdfFile(world_sdf_file);
+  }
+  else if (!world_sdf_string.empty()) {
+    server_config.SetSdfString(world_sdf_string);
+  }
+  else {
+    RCLCPP_ERROR(
+      node->get_logger(), "Must specify either 'world_sdf_file' or 'world_sdf_string'");
+    return -1;
+  }
+
+  // (azeey) Testing if a plugin can be loaded along side the defaults. Not working yet.
+
+  // <plugin
+  //   filename="gz-sim-imu-system"
+  //   name="gz::sim::systems::Imu">
+  // </plugin>
+  sdf::Plugin imu_sdf_plugin;
+  imu_sdf_plugin.SetName("gz::sim::systems::Imu");
+  imu_sdf_plugin.SetFilename("gz-sim-imu-system");
+  sim::SystemLoader loader;
+  auto imu_plugin = loader.LoadPlugin(imu_sdf_plugin);
+  std::cout << imu_plugin.value() << std::endl;
+
+  gz::sim::Server server(server_config);
+  server.RunOnce();
+  if (!server.AddSystem(*imu_plugin))
+  {
+    RCLCPP_ERROR(
+      node->get_logger(), "IMU system not added");
+
+  }
+  server.Run(true /*blocking*/, 0, false /*paused*/);
+}

--- a/ros_gz_sim/src/gzserver.cpp
+++ b/ros_gz_sim/src/gzserver.cpp
@@ -18,25 +18,22 @@
 #include <gz/sim/ServerConfig.hh>
 #include <rclcpp/rclcpp.hpp>
 
+// ROS node that executes a gz-sim Server given a world SDF file or string.
 int main(int _argc, char ** _argv)
 {
-  using namespace gz;
   auto filtered_arguments = rclcpp::init_and_remove_ros_arguments(_argc, _argv);
   auto node = rclcpp::Node::make_shared("gzserver");
   auto world_sdf_file = node->declare_parameter("world_sdf_file", "");
   auto world_sdf_string = node->declare_parameter("world_sdf_string", "");
 
-  common::Console::SetVerbosity(4);
-  sim::ServerConfig server_config;
+  gz::common::Console::SetVerbosity(4);
+  gz::sim::ServerConfig server_config;
 
-  if (!world_sdf_file.empty())
-  {
+  if (!world_sdf_file.empty()) {
     server_config.SetSdfFile(world_sdf_file);
-  }
-  else if (!world_sdf_string.empty()) {
+  } else if (!world_sdf_string.empty()) {
     server_config.SetSdfString(world_sdf_string);
-  }
-  else {
+  } else {
     RCLCPP_ERROR(
       node->get_logger(), "Must specify either 'world_sdf_file' or 'world_sdf_string'");
     return -1;


### PR DESCRIPTION
# 🎉 New feature

Closes #497

## Summary
- [x] Add gzserver with ability to load an SDF file or string

## TODO
- [ ] Add ability to load additional systems in addition to the ones loaded by default or as part of the SDF world
- [ ] Configure SDFormat to understand `package://` URIs

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
