### PR TITLE
Correctly export ros_gz_bridge for downstream targets

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -100,7 +100,7 @@ add_custom_command(
   COMMENT "Generating factories for interface types")
 
 set(bridge_lib
-  ros_gz_bridge_lib
+  ros_gz_bridge
 )
 
 add_library(${bridge_lib}
@@ -130,8 +130,12 @@ ament_target_dependencies(${bridge_lib}
 )
 
 target_include_directories(${bridge_lib}
-  PUBLIC include
-  PRIVATE src ${generated_path}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>"
 )
 
 target_link_libraries(${bridge_lib}
@@ -144,18 +148,15 @@ rclcpp_components_register_node(
   PLUGIN ros_gz_bridge::RosGzBridge
   EXECUTABLE bridge_node)
 
-install(TARGETS ${bridge_lib}
+install(TARGETS ${bridge_lib} EXPORT export_${PROJECT_NAME}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin)
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
-
-ament_export_include_directories(include)
-ament_export_libraries(${bridge_lib})
 
 set(bridge_executables
   parameter_bridge
@@ -175,7 +176,7 @@ foreach(bridge ${bridge_executables})
     ${BRIDGE_MESSAGE_TYPES}
   )
   install(TARGETS ${bridge}
-    DESTINATION lib/${PROJECT_NAME}
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
   )
 endforeach()
 
@@ -330,9 +331,19 @@ if(BUILD_TESTING)
 
 endif()
 
-ament_export_dependencies(
-  rclcpp
-  ${BRIDGE_MESSAGE_TYPES}
-)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(${bridge_lib})
+
+# Export modern CMake targets
+ament_export_targets(export_${PROJECT_NAME})
+
+# specific order: dependents before dependencies
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(rclcpp_components)
+ament_export_dependencies(${GZ_TARGET_PREFIX}-msgs${GZ_MSGS_VER})
+ament_export_dependencies(${GZ_TARGET_PREFIX}-transport${GZ_TRANSPORT_VER})
+ament_export_dependencies(yaml_cpp_vendor)
+ament_export_dependencies(${BRIDGE_MESSAGE_TYPES})
 
 ament_package()

--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(${bridge_lib}
   src/bridge_handle_ros_to_gz.cpp
   src/bridge_handle_gz_to_ros.cpp
   src/factory_interface.cpp
+  src/service_factory_interface.cpp
   src/service_factories/ros_gz_interfaces.cpp
   src/ros_gz_bridge.cpp
   ${convert_files}

--- a/ros_gz_bridge/src/service_factory_interface.cpp
+++ b/ros_gz_bridge/src/service_factory_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Open Source Robotics Foundation, Inc.
+// Copyright 2024 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,33 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef  SERVICE_FACTORY_INTERFACE_HPP_
-#define  SERVICE_FACTORY_INTERFACE_HPP_
-
-#include <memory>
-#include <string>
-
-#include <gz/transport/Node.hh>
-
-#include <rclcpp/service.hpp>
-#include <rclcpp/node.hpp>
+#include "service_factory_interface.hpp"
 
 namespace ros_gz_bridge
 {
 
-class ServiceFactoryInterface
+ServiceFactoryInterface::~ServiceFactoryInterface()
 {
-public:
-  virtual ~ServiceFactoryInterface() = 0;
-
-  virtual
-  rclcpp::ServiceBase::SharedPtr
-  create_ros_service(
-    rclcpp::Node::SharedPtr ros_node,
-    std::shared_ptr<gz::transport::Node> gz_node,
-    const std::string & service_name) = 0;
-};
+}
 
 }  // namespace ros_gz_bridge
-
-#endif  // SERVICE_FACTORY_INTERFACE_HPP_

--- a/test_ros_gz_bridge/CMakeLists.txt
+++ b/test_ros_gz_bridge/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(test_ros_gz_bridge)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ros_gz_bridge REQUIRED)
+
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  ament_find_gtest()
+
+  ament_add_gtest(test_ros_gz_bridge src/test_ros_gz_bridge.cpp)
+  target_link_libraries(test_ros_gz_bridge ros_gz_bridge::ros_gz_bridge)
+endif()
+
+ament_package()

--- a/test_ros_gz_bridge/package.xml
+++ b/test_ros_gz_bridge/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_ros_gz_bridge</name>
+  <version>0.246.0</version>
+  <description>Bridge communication between ROS and Gazebo Transport</description>
+  <maintainer email="adityapande@intrinsic.ai">Aditya Pande</maintainer>
+  <maintainer email="ahcorde@openrobotics.org">Alejandro Hernandez</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <author>Michael Carroll</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>ros_gz_bridge</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test_ros_gz_bridge/src/test_ros_gz_bridge.cpp
+++ b/test_ros_gz_bridge/src/test_ros_gz_bridge.cpp
@@ -1,0 +1,36 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <ros_gz_bridge/ros_gz_bridge.hpp>
+
+class test_ros_gz_bridge : public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(test_ros_gz_bridge, SpawnNode)
+{
+  ros_gz_bridge::RosGzBridge node;
+}


### PR DESCRIPTION
Additionally adds a `test_ros_gz_bridge` target to verify that this behavior is working.  

We could also put our integration tests in here in the long run, but I will leave that to a follow up.

Replaces #496