### PR TITLE
Add ROS namespaces to GZ topics

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -299,7 +299,7 @@ ign topic -e -t /demo/chatter
 
 Now we start the ROS talker.
 
-```
+```bash
 # Shell C:
 . /opt/ros/humble/setup.bash
 ros2 topic pub /demo/chatter std_msgs/msg/String "data: 'Hi from inside of a namespace'" --once

--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -292,7 +292,7 @@ ros2 run ros_gz_bridge parameter_bridge chatter@std_msgs/msg/String@ignition.msg
 
 Now we start the Gazebo Transport listener.
 
-```
+```bash
 # Shell B:
 ign topic -e -t /demo/chatter
 ```

--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -283,7 +283,7 @@ Namespaces are applied to Gazebo topic both when specified as `topic_name` as we
 By default, the Bridge will not apply ROS namespace on the Gazebo topics. To enable this feature, use parameter `expand_gz_topic_names`.
 Let's test our topic with namespace:
 
-```
+```bash
 # Shell A:
 . ~/bridge_ws/install/setup.bash
 ros2 run ros_gz_bridge parameter_bridge chatter@std_msgs/msg/String@ignition.msgs.StringMsg \

--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -307,7 +307,6 @@ ros2 topic pub /demo/chatter std_msgs/msg/String "data: 'Hi from inside of a nam
 
 By changing `chatter` to `/chatter` or `~/chatter` you can obtain different results.
 
-
 ## API
 
 ROS 2 Parameters:

--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -164,7 +164,7 @@ You should see the current images in `rqt_image_view` which are coming from
 Gazebo (published as Gazebo Msgs over Gazebo Transport).
 
 The screenshot shows all the shell windows and their expected content
-(it was taken using ROS 2 humble and Gazebo Fortress):
+(it was taken using ROS 2 Galactic and Gazebo Fortress):
 
 ![Gazebo Transport images and ROS rqt](images/bridge_image_exchange.png)
 

--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -86,7 +86,7 @@ Now we start the ROS listener.
 
 ```
 # Shell B:
-. /opt/ros/galactic/setup.bash
+. /opt/ros/humble/setup.bash
 ros2 topic echo /chatter
 ```
 
@@ -118,7 +118,7 @@ Now we start the ROS talker.
 
 ```
 # Shell C:
-. /opt/ros/galactic/setup.bash
+. /opt/ros/humble/setup.bash
 ros2 topic pub /chatter std_msgs/msg/String "data: 'Hi'" --once
 ```
 
@@ -156,7 +156,7 @@ Now we start the ROS GUI:
 
 ```
 # Shell C:
-. /opt/ros/galactic/setup.bash
+. /opt/ros/humble/setup.bash
 ros2 run rqt_image_view rqt_image_view /rgbd_camera/image
 ```
 
@@ -164,7 +164,7 @@ You should see the current images in `rqt_image_view` which are coming from
 Gazebo (published as Gazebo Msgs over Gazebo Transport).
 
 The screenshot shows all the shell windows and their expected content
-(it was taken using ROS 2 Galactic and Gazebo Fortress):
+(it was taken using ROS 2 humble and Gazebo Fortress):
 
 ![Gazebo Transport images and ROS rqt](images/bridge_image_exchange.png)
 
@@ -274,9 +274,44 @@ To run the bridge node with the above configuration:
 ros2 run ros_gz_bridge parameter_bridge --ros-args -p config_file:=$WORKSPACE/ros_gz/ros_gz_bridge/test/config/full.yaml
 ```
 
+## Example 6: Using ROS namespace with the Bridge
+
+When spawning multiple robots inside the same ROS environment, it is convenient to use namespaces to avoid overlapping topic names.
+There are three main types of namespaces: relative, global (`/`) and private (`~/`). For more information, refer to ROS documentation.
+Namespaces are applied to Gazebo topic both when specified as `topic_name` as well as `gz_topic_name`.
+
+By default, the Bridge will not apply ROS namespace on the Gazebo topics. To enable this feature, use parameter `expand_gz_topic_names`.
+Let's test our topic with namespace:
+
+```
+# Shell A:
+. ~/bridge_ws/install/setup.bash
+ros2 run ros_gz_bridge parameter_bridge chatter@std_msgs/msg/String@ignition.msgs.StringMsg \
+  --ros-args -p expand_gz_topic_names:=true -r __ns:=/demo
+```
+
+Now we start the Gazebo Transport listener.
+
+```
+# Shell B:
+ign topic -e -t /demo/chatter
+```
+
+Now we start the ROS talker.
+
+```
+# Shell C:
+. /opt/ros/humble/setup.bash
+ros2 topic pub /demo/chatter std_msgs/msg/String "data: 'Hi from inside of a namespace'" --once
+```
+
+By changing `chatter` to `/chatter` or `~/chatter` you can obtain different results.
+
+
 ## API
 
 ROS 2 Parameters:
 
  * `subscription_heartbeat` - Period at which the node checks for new subscribers for lazy bridges.
  * `config_file` - YAML file to be loaded as the bridge configuration
+ * `expand_gz_topic_names` - Enable or disable ROS namespace applied on GZ topics.

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -61,7 +61,6 @@ void RosGzBridge::spin()
       }
     }
   }
-  
   for (auto & bridge : handles_) {
     bridge->Spin();
   }

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -44,11 +44,20 @@ void RosGzBridge::spin()
     std::string config_file;
     this->get_parameter("config_file", config_file);
     const std::string ros_ns = this->get_namespace();
+    const std::string ros_node_name = this->get_name();
     if (!config_file.empty()) {
       auto entries = readFromYamlFile(config_file);
       for (auto & entry : entries) {
-        if (entry.gz_topic_name[0] != '/' && ros_ns.length() > 1) {
-          entry.gz_topic_name = ros_ns + '/' + entry.gz_topic_name;
+        if (entry.gz_topic_name[0] != '/') {
+          if (entry.gz_topic_name[0] == '~' && 
+              entry.gz_topic_name[1] == '/' &&
+              ros_node_name.length() > 1) {
+            entry.gz_topic_name = ros_node_name + '/' + 
+              entry.gz_topic_name.substr(2);
+          }
+          if (ros_ns.length() > 1) {
+            entry.gz_topic_name = ros_ns + '/' + entry.gz_topic_name;
+          }
         }
         this->add_bridge(entry);
       }

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -63,11 +63,12 @@ void RosGzBridge::spin()
       }
     }
   }
-
+  
   for (auto & bridge : handles_) {
     bridge->Spin();
   }
 }
+
 void RosGzBridge::add_bridge(const BridgeConfig & config)
 {
   bool gz_to_ros = false;

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -17,11 +17,10 @@
 #include <memory>
 #include <string>
 
-#include "rclcpp/expand_topic_or_service_name.hpp"
-
 #include "bridge_handle_ros_to_gz.hpp"
 #include "bridge_handle_gz_to_ros.hpp"
 
+#include <rclcpp/expand_topic_or_service_name.hpp>
 namespace ros_gz_bridge
 {
 

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -43,9 +43,13 @@ void RosGzBridge::spin()
   if (handles_.empty()) {
     std::string config_file;
     this->get_parameter("config_file", config_file);
+    const std::string ros_ns = this->get_namespace();
     if (!config_file.empty()) {
       auto entries = readFromYamlFile(config_file);
-      for (const auto & entry : entries) {
+      for (auto & entry : entries) {
+        if (entry.gz_topic_name[0] != '/' && ros_ns.length() > 1) {
+          entry.gz_topic_name = ros_ns + '/' + entry.gz_topic_name;
+        }
         this->add_bridge(entry);
       }
     }
@@ -55,7 +59,6 @@ void RosGzBridge::spin()
     bridge->Spin();
   }
 }
-
 void RosGzBridge::add_bridge(const BridgeConfig & config)
 {
   bool gz_to_ros = false;

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -21,6 +21,7 @@
 #include "bridge_handle_gz_to_ros.hpp"
 
 #include <rclcpp/expand_topic_or_service_name.hpp>
+
 namespace ros_gz_bridge
 {
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
This PR adds the ability to apply ROS node namespace onto GZ topics. This adds option for global namespaces, private namespaces and should also work for substitutions.

I believe this feature later could be easily ported to Iron and Rolling.

As it is an API breaking feature, I also introduced a new ROS parameter, preserving backward compatibility.

## Test it
In the `config_file` YAML file, create topics as:
```yaml
- topic_name: "chatter"
  ros_type_name: "std_msgs/msg/String"
  gz_type_name: "gz.msgs.StringMsg"
  direction: ROS_TO_GZ

- topic_name: "/chatter_global"
  ros_type_name: "std_msgs/msg/String"
  gz_type_name: "gz.msgs.StringMsg"
  direction: ROS_TO_GZ

- topic_name: "~/chatter_private_ns"
  ros_type_name: "std_msgs/msg/String"
  gz_type_name: "gz.msgs.StringMsg"
  direction: ROS_TO_GZ

- ros_topic_name: "chatter_ros_ns"
  gz_topic_name: "/chatter_ign_global"
  ros_type_name: "std_msgs/msg/String"
  gz_type_name: "gz.msgs.StringMsg"
  direction: ROS_TO_GZ
```

This should create ROS topics:
```bash
$ ros2 topic list
/my_namespace/chatter
/chatter_global
/my_namespace/ros_gz_bridge/chatter_private_ns
/my_namespace/chatter_ros_ns
```
And GZ topics:
```bash
$ ign topic --list
/my_namespace/chatter
/chatter_global
/my_namespace/ros_gz_bridge/chatter_private_ns
/chatter_ign_global
```