### PR TITLE
feat: adhere to 'use_sim_time' parameter

### DIFF
--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
@@ -70,7 +70,8 @@ void BridgeHandleGzToRos::StartSubscriber()
     this->gz_node_,
     this->config_.gz_topic_name,
     this->config_.subscriber_queue_size,
-    this->ros_publisher_);
+    this->ros_publisher_,
+    this->ros_node_->get_clock()->ros_time_is_active());
 
   this->gz_subscriber_ = this->gz_node_;
 }

--- a/ros_gz_bridge/src/factory_interface.hpp
+++ b/ros_gz_bridge/src/factory_interface.hpp
@@ -60,7 +60,8 @@ public:
     std::shared_ptr<gz::transport::Node> node,
     const std::string & topic_name,
     size_t queue_size,
-    rclcpp::PublisherBase::SharedPtr ros_pub) = 0;
+    rclcpp::PublisherBase::SharedPtr ros_pub,
+    bool use_sim_time) = 0;
 };
 
 }  // namespace ros_gz_bridge


### PR DESCRIPTION
Stamp all outgoing headers with the wall time if use_sim_time is set to false.
