### PR TITLE
Ensure the same container is used for the bridge and gz_server

### DIFF
--- a/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
+++ b/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
@@ -34,6 +34,7 @@ class RosGzBridge(Action):
     def __init__(
         self,
         *,
+        name: SomeSubstitutionsType,
         config_file: Optional[SomeSubstitutionsType] = None,
         container_name: Optional[SomeSubstitutionsType] = None,
         namespace: Optional[SomeSubstitutionsType] = None,
@@ -48,6 +49,7 @@ class RosGzBridge(Action):
         All arguments are forwarded to `ros_gz_bridge.launch.ros_gz_bridge.launch.py`,
         so see the documentation of that class for further details.
 
+        :param: name Name of ros_gz_bridge  node
         :param: config_file YAML config file.
         :param: container_name Name of container that nodes will load in if use composition.
         :param: namespace Top-level namespace.
@@ -56,6 +58,7 @@ class RosGzBridge(Action):
         :param: log_level Log level.
         """
         super().__init__(**kwargs)
+        self.__name = name
         self.__config_file = config_file
         self.__container_name = container_name
         self.__namespace = namespace
@@ -67,6 +70,10 @@ class RosGzBridge(Action):
     def parse(cls, entity: Entity, parser: Parser):
         """Parse ros_gz_bridge."""
         _, kwargs = super().parse(entity, parser)
+
+        name = entity.get_attr(
+            'name', data_type=str,
+            optional=False)
 
         config_file = entity.get_attr(
             'config_file', data_type=str,
@@ -91,6 +98,10 @@ class RosGzBridge(Action):
         log_level = entity.get_attr(
             'log_level', data_type=str,
             optional=True)
+
+        if isinstance(name, str):
+            name = parser.parse_substitution(name)
+            kwargs['name'] = name
 
         if isinstance(config_file, str):
             config_file = parser.parse_substitution(config_file)
@@ -125,7 +136,8 @@ class RosGzBridge(Action):
                 [PathJoinSubstitution([FindPackageShare('ros_gz_bridge'),
                                        'launch',
                                        'ros_gz_bridge.launch.py'])]),
-            launch_arguments=[('config_file', self.__config_file),
+            launch_arguments=[('name', self.__name),
+                              ('config_file', self.__config_file),
                               ('container_name', self.__container_name),
                               ('namespace',   self.__namespace),
                               ('use_composition',  self.__use_composition),


### PR DESCRIPTION
# 🦟 Bug fix

Part of #544

## Summary
Using `ComposableNodeContainer` for both `gz_server` and `ros_gz_bridge` caused a new container to be created for each of them. This changes ros_gz_bridge to use `LoadComposableNodes` which uses an existing container, which would be created when launching `gz_server`. I've tested that this works even if `ros_gz_bridge` was launched first.

This also adds a required `name` parameter for the bridge so that multiple different bridges can be created without name collision


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
