### PR TITLE
Use `ignoreLocalMessages` in the bridge

### DIFF
--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -109,13 +109,13 @@ public:
       const gz::transport::MessageInfo &)> subCb =
       [this, ros_pub](const GZ_T & _msg, const gz::transport::MessageInfo & _info)
       {
-        // Ignore messages that are published from this bridge.
-        if (!_info.IntraProcess()) {
-          this->gz_callback(_msg, ros_pub);
-        }
+        this->gz_callback(_msg, ros_pub);
       };
 
-    node->Subscribe(topic_name, subCb);
+    // Ignore messages that are published from this bridge.
+    gz::transport::SubscriptionOptions opts;
+    opts.SetIgnoreLocalMessages(true);
+    node->Subscribe(topic_name, subCb, opts);
   }
 
 protected:

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include <gz/transport/Node.hh>
-#include <gz/transport/SubscriptionOptions.hh>
+#include <gz/transport/SubscribeOptions.hh>
 
 // include ROS 2
 #include <rclcpp/rclcpp.hpp>

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -106,9 +106,8 @@ public:
     size_t /*queue_size*/,
     rclcpp::PublisherBase::SharedPtr ros_pub)
   {
-    std::function<void(const GZ_T &,
-      const gz::transport::MessageInfo &)> subCb =
-      [this, ros_pub](const GZ_T & _msg, const gz::transport::MessageInfo & _info)
+    std::function<void(const GZ_T &)> subCb =
+      [this, ros_pub](const GZ_T & _msg)
       {
         this->gz_callback(_msg, ros_pub);
       };

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <gz/transport/Node.hh>
+#include <gz/transport/SubscriptionOptions.hh>
 
 // include ROS 2
 #include <rclcpp/rclcpp.hpp>

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -114,7 +114,7 @@ public:
       };
 
     // Ignore messages that are published from this bridge.
-    gz::transport::SubscriptionOptions opts;
+    gz::transport::SubscribeOptions opts;
     opts.SetIgnoreLocalMessages(true);
     node->Subscribe(topic_name, subCb, opts);
   }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #555

Requires https://github.com/gazebosim/gz-transport/pull/506

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Instead of discarding all messages from nodes within the same process as the subscriber, we only discard messages published from the same node (the one used by the bridge).

This way we should be able to use the bridge with composable nodes, where all nodes share the same process with the bridge.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.