### PR TITLE
feat: `override_timestamps_with_wall_time` parameter

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -89,6 +89,9 @@ You should create an unidirectional `/clock` bridge:
 ros2 run ros_gz_bridge parameter_bridge /clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock
 ```
 
+An alternative set-up can be using the bridge with the `override_timestamps_with_wall_time` ros parameter set to `true` (default=`false`). In this set-up,
+all header timestamps of the outgoing messages will be stamped with the wall time. This can be useful when the simulator has to communicate with an external system that requires wall times.
+
 ## Example 1a: Gazebo Transport talker and ROS 2 listener
 
 Start the parameter bridge which will watch the specified topics.

--- a/ros_gz_bridge/src/bridge_handle.cpp
+++ b/ros_gz_bridge/src/bridge_handle.cpp
@@ -30,6 +30,7 @@ BridgeHandle::BridgeHandle(
   config_(config),
   factory_(get_factory(config.ros_type_name, config.gz_type_name))
 {
+  ros_node_->get_parameter("override_timestamps_with_wall_time", override_timestamps_with_wall_time_);
 }
 
 BridgeHandle::~BridgeHandle() = default;

--- a/ros_gz_bridge/src/bridge_handle.hpp
+++ b/ros_gz_bridge/src/bridge_handle.hpp
@@ -101,6 +101,9 @@ protected:
 
   /// \brief Typed factory used to create publishers/subscribers
   std::shared_ptr<FactoryInterface> factory_;
+
+  /// \brief Whether to override the header.stamp field of the outgoing ROS messages with the wall time
+  bool override_timestamps_with_wall_time_ = false;
 };
 
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
@@ -71,8 +71,7 @@ void BridgeHandleGzToRos::StartSubscriber()
     this->config_.gz_topic_name,
     this->config_.subscriber_queue_size,
     this->ros_publisher_,
-    this->ros_node_->declare_parameter<bool>(
-      "override_timestamps_with_wall_time", false));
+    override_timestamps_with_wall_time_);
 
   this->gz_subscriber_ = this->gz_node_;
 }

--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
@@ -70,7 +70,9 @@ void BridgeHandleGzToRos::StartSubscriber()
     this->gz_node_,
     this->config_.gz_topic_name,
     this->config_.subscriber_queue_size,
-    this->ros_publisher_);
+    this->ros_publisher_,
+    this->ros_node_->declare_parameter<bool>(
+      "override_timestamps_with_wall_time", false));
 
   this->gz_subscriber_ = this->gz_node_;
 }

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -28,6 +28,16 @@
 
 #include "factory_interface.hpp"
 
+template <class T, class = void>
+struct has_header : std::false_type
+{
+};
+
+template <class T>
+struct has_header<T, std::void_t<decltype(T::header)>> : std::true_type
+{
+};
+
 namespace ros_gz_bridge
 {
 
@@ -104,12 +114,13 @@ public:
     std::shared_ptr<gz::transport::Node> node,
     const std::string & topic_name,
     size_t /*queue_size*/,
-    rclcpp::PublisherBase::SharedPtr ros_pub)
+    rclcpp::PublisherBase::SharedPtr ros_pub,
+    bool override_timestamps_with_wall_time)
   {
     std::function<void(const GZ_T &)> subCb =
-      [this, ros_pub](const GZ_T & _msg)
+      [this, ros_pub, override_timestamps_with_wall_time](const GZ_T & _msg)
       {
-        this->gz_callback(_msg, ros_pub);
+        this->gz_callback(_msg, ros_pub, override_timestamps_with_wall_time);
       };
 
     // Ignore messages that are published from this bridge.
@@ -139,10 +150,20 @@ protected:
   static
   void gz_callback(
     const GZ_T & gz_msg,
-    rclcpp::PublisherBase::SharedPtr ros_pub)
+    rclcpp::PublisherBase::SharedPtr ros_pub,
+    bool override_timestamps_with_wall_time)
   {
     ROS_T ros_msg;
     convert_gz_to_ros(gz_msg, ros_msg);
+    if constexpr (has_header<ROS_T>::value) {
+      if (override_timestamps_with_wall_time) {
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        auto ns =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
+        ros_msg.header.stamp.sec = ns / 1e9;
+        ros_msg.header.stamp.nanosec = ns - ros_msg.header.stamp.sec * 1e9;
+      }
+    }
     std::shared_ptr<rclcpp::Publisher<ROS_T>> pub =
       std::dynamic_pointer_cast<rclcpp::Publisher<ROS_T>>(ros_pub);
     if (pub != nullptr) {

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -28,13 +28,13 @@
 
 #include "factory_interface.hpp"
 
-template <class T, class = void>
+template<class T, class = void>
 struct has_header : std::false_type
 {
 };
 
-template <class T>
-struct has_header<T, std::void_t<decltype(T::header)>> : std::true_type
+template<class T>
+struct has_header<T, std::void_t<decltype(T::header)>>: std::true_type
 {
 };
 

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -15,9 +15,11 @@
 #ifndef FACTORY_HPP_
 #define FACTORY_HPP_
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 
 #include <gz/transport/Node.hh>
 #include <gz/transport/SubscribeOptions.hh>

--- a/ros_gz_bridge/src/factory_interface.hpp
+++ b/ros_gz_bridge/src/factory_interface.hpp
@@ -60,7 +60,8 @@ public:
     std::shared_ptr<gz::transport::Node> node,
     const std::string & topic_name,
     size_t queue_size,
-    rclcpp::PublisherBase::SharedPtr ros_pub) = 0;
+    rclcpp::PublisherBase::SharedPtr ros_pub,
+    bool override_timestamps_with_wall_time) = 0;
 };
 
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -33,6 +33,7 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
   this->declare_parameter<int>("subscription_heartbeat", 1000);
   this->declare_parameter<std::string>("config_file", "");
   this->declare_parameter<bool>("expand_gz_topic_names", false);
+  this->declare_parameter<bool>("override_timestamps_with_wall_time", false);
 
   int heartbeat;
   this->get_parameter("subscription_heartbeat", heartbeat);


### PR DESCRIPTION
# 🎉 New feature

Closes #546 

## Summary
Stamp all outgoing headers with the wall time if parameter `override_timestamps_with_wall_time` is set to `true`.

## Test it
Start the bridge with the additional parameter `override_timestamps_with_wall_time` set to `true`. Note that the outgoing messages have the wall time stamp and not the gazebo time stamp.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
