### PR TITLE
Use memcpy instead of std::copy when bridging images

### DIFF
--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -168,6 +168,7 @@ convert_gz_to_ros(
   ros_msg.step = ros_msg.width * num_channels * octets_per_channel;
   ros_msg.data.resize(ros_msg.step * ros_msg.height);
 
+  # prefer memcpy over std::copy for performance reasons, see https://github.com/gazebosim/ros_gz/pull/565
   memcpy(ros_msg.data.data(), gz_msg.data().c_str(), gz_msg.data().size());
 }
 

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -168,7 +168,8 @@ convert_gz_to_ros(
   ros_msg.step = ros_msg.width * num_channels * octets_per_channel;
   ros_msg.data.resize(ros_msg.step * ros_msg.height);
 
-  # prefer memcpy over std::copy for performance reasons, see https://github.com/gazebosim/ros_gz/pull/565
+  // Prefer memcpy over std::copy for performance reasons,
+  // see https://github.com/gazebosim/ros_gz/pull/565
   memcpy(ros_msg.data.data(), gz_msg.data().c_str(), gz_msg.data().size());
 }
 

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -166,9 +166,8 @@ convert_gz_to_ros(
 
   ros_msg.is_bigendian = false;
   ros_msg.step = ros_msg.width * num_channels * octets_per_channel;
-
-  auto count = ros_msg.step * ros_msg.height;
   ros_msg.data.resize(ros_msg.step * ros_msg.height);
+
   memcpy(ros_msg.data.data(), gz_msg.data().c_str(), gz_msg.data().size());
 }
 

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -169,10 +169,7 @@ convert_gz_to_ros(
 
   auto count = ros_msg.step * ros_msg.height;
   ros_msg.data.resize(ros_msg.step * ros_msg.height);
-  std::copy(
-    gz_msg.data().begin(),
-    gz_msg.data().begin() + count,
-    ros_msg.data.begin());
+  memcpy(ros_msg.data.data(), gz_msg.data().c_str(), gz_msg.data().size());
 }
 
 template<>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Optimization

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While testing ros <-> gz communication using the bridge I noticed that the bridge was talking quite a bit of time copying images from Gazebo to ROS. I found that the `std::copy` operation that we're doing is substantially slower than the `memcpy` alternative. I think that in principle this shouldn't happen but the numbers are quite clear. Perhaps `std::copy` is doing something that doesn't use cache effectively...

How to test it?

First, modify [this code](https://github.com/gazebosim/ros_gz/blob/ros2/ros_gz_bridge/src/convert/sensor_msgs.cpp#L172-L175) to see some stats:

```
auto beg = std::chrono::high_resolution_clock::now();
// Option 1: Using memcpy
// memcpy(ros_msg.data.data(), gz_msg.data().c_str(), gz_msg.data().size());

// Option 2: Using std::copy
auto count = ros_msg.step * ros_msg.height;
std::copy(
  gz_msg.data().begin(),
  gz_msg.data().begin() + count,
  ros_msg.data.begin());

auto end = std::chrono::high_resolution_clock::now();
auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - beg);
std::cerr << "Elapsed Time: " << duration.count() << " us" << std::endl; 
```

Recompile and launch one of our examples that publish 320x240 images:

```
ros2 launch ros_gz_sim_demos gpu_lidar_bridge.launch.py
```

The default code shows:
```
[parameter_bridge-2] Elapsed Time: 548 us
```

Enable the `memcpy`, comment the old code and relaunch the example again. The new code shows:
```
[parameter_bridge-2] Elapsed Time: 11 us
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.