### PR TITLE
Making use_composition true by default

### DIFF
--- a/ros_gz_bridge/launch/ros_gz_bridge.launch
+++ b/ros_gz_bridge/launch/ros_gz_bridge.launch
@@ -3,7 +3,7 @@
   <arg name="config_file" default="" />
   <arg name="container_name" default="ros_gz_container" />
   <arg name="namespace" default="" />
-  <arg name="use_composition" default="False" />
+  <arg name="use_composition" default="True" />
   <arg name="use_respawn" default="False" />
   <arg name="log_level" default="info" />
   <ros_gz_bridge

--- a/ros_gz_bridge/launch/ros_gz_bridge.launch.py
+++ b/ros_gz_bridge/launch/ros_gz_bridge.launch.py
@@ -51,7 +51,7 @@ def generate_launch_description():
     )
 
     declare_use_composition_cmd = DeclareLaunchArgument(
-        'use_composition', default_value='False', description='Use composed bringup if True'
+        'use_composition', default_value='True', description='Use composed bringup if True'
     )
 
     declare_use_respawn_cmd = DeclareLaunchArgument(

--- a/ros_gz_sim/launch/gz_server.launch
+++ b/ros_gz_sim/launch/gz_server.launch
@@ -2,7 +2,7 @@
   <arg name="world_sdf_file" default="empty.sdf" />
   <arg name="world_sdf_string" default="" />
   <arg name="container_name" default="ros_gz_container" />
-  <arg name="use_composition" default="False" />
+  <arg name="use_composition" default="True" />
   <gz_server 
     world_sdf_file="$(var world_sdf_file)"
     world_sdf_string="$(var world_sdf_string)"

--- a/ros_gz_sim/launch/gz_server.launch.py
+++ b/ros_gz_sim/launch/gz_server.launch.py
@@ -34,7 +34,7 @@ def generate_launch_description():
         'container_name', default_value='ros_gz_container',
         description='Name of container that nodes will load in if use composition',)
     declare_use_composition_cmd = DeclareLaunchArgument(
-        'use_composition', default_value='False',
+        'use_composition', default_value='True',
         description='Use composed bringup if True')
 
     load_nodes = Node(

--- a/ros_gz_sim/launch/ros_gz_sim.launch
+++ b/ros_gz_sim/launch/ros_gz_sim.launch
@@ -3,7 +3,7 @@
   <arg name="config_file" default="" />
   <arg name="container_name" default="ros_gz_container" />
   <arg name="namespace" default="" />
-  <arg name="use_composition" default="False" />
+  <arg name="use_composition" default="True" />
   <arg name="use_respawn" default="False" />
   <arg name="log_level" default="info" />
   <arg name="world_sdf_file" default="empty.sdf" />

--- a/ros_gz_sim/launch/ros_gz_sim.launch.py
+++ b/ros_gz_sim/launch/ros_gz_sim.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     )
 
     declare_use_composition_cmd = DeclareLaunchArgument(
-        'use_composition', default_value='False', description='Use composed bringup if True'
+        'use_composition', default_value='True', description='Use composed bringup if True'
     )
 
     declare_use_respawn_cmd = DeclareLaunchArgument(

--- a/ros_gz_sim/launch/ros_gz_spawn_model.launch.py
+++ b/ros_gz_sim/launch/ros_gz_spawn_model.launch.py
@@ -58,7 +58,7 @@ def generate_launch_description():
     )
 
     declare_use_composition_cmd = DeclareLaunchArgument(
-        'use_composition', default_value='False', description='Use composed bringup if True'
+        'use_composition', default_value='True', description='Use composed bringup if True'
     )
 
     declare_use_respawn_cmd = DeclareLaunchArgument(


### PR DESCRIPTION
# 🎉 New feature


## Summary
Since this improves the performance of the bridge it should be on by default. Advanced users that need to run a bridge in a separate process can then opt out.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
