### PR TITLE
Name Gazebo sim node

### DIFF
--- a/ros_gz_sim/launch/gz_sim.launch.py.in
+++ b/ros_gz_sim/launch/gz_sim.launch.py.in
@@ -128,6 +128,7 @@ def launch_gz(context, *args, **kwargs):
 
     return [ExecuteProcess(
             cmd=[exec, exec_args, '--force-version', gz_version],
+            name='gazebo',
             output='screen',
             additional_env=env,
             shell=True,


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #610 

This is my first PR to this repo, it is super minor, but let me know if I have not followed any contributing instructions!

## Summary
Adds a name to the Gazebo node started, so that it doesn't appear as `ruby $(which gz) sim-1` (Harmonic) or `ruby $(which ign) gazebo-1` (Fortress)

![image](https://github.com/user-attachments/assets/953e327e-e403-4528-8e10-b4c1f62b4335)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.