### PR TITLE
Fix ros_gz_sim.launch.py when create_own_container is enabled

### DIFF
--- a/ros_gz_sim/launch/ros_gz_sim.launch.py
+++ b/ros_gz_sim/launch/ros_gz_sim.launch.py
@@ -83,19 +83,6 @@ def generate_launch_description():
         description='SDF world string'
     )
 
-    bridge_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            [PathJoinSubstitution([FindPackageShare('ros_gz_bridge'),
-                                   'launch',
-                                   'ros_gz_bridge.launch.py'])]),
-        launch_arguments=[('bridge_name', bridge_name),
-                          ('config_file', config_file),
-                          ('container_name', container_name),
-                          ('namespace', namespace),
-                          ('use_composition', use_composition),
-                          ('use_respawn', use_respawn),
-                          ('bridge_log_level', bridge_log_level)])
-
     gz_server_description = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
@@ -106,6 +93,20 @@ def generate_launch_description():
                           ('container_name', container_name),
                           ('create_own_container', create_own_container),
                           ('use_composition', use_composition), ])
+
+    bridge_description = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [PathJoinSubstitution([FindPackageShare('ros_gz_bridge'),
+                                   'launch',
+                                   'ros_gz_bridge.launch.py'])]),
+        launch_arguments=[('bridge_name', bridge_name),
+                          ('config_file', config_file),
+                          ('container_name', container_name),
+                          ('namespace', namespace),
+                          ('create_own_container', str(False)),
+                          ('use_composition', use_composition),
+                          ('use_respawn', use_respawn),
+                          ('bridge_log_level', bridge_log_level), ])
 
     # Create the launch description and populate
     ld = LaunchDescription()
@@ -122,7 +123,7 @@ def generate_launch_description():
     ld.add_action(declare_world_sdf_file_cmd)
     ld.add_action(declare_world_sdf_string_cmd)
     # Add the actions to launch all of the bridge + gz_server nodes
-    ld.add_action(bridge_description)
     ld.add_action(gz_server_description)
+    ld.add_action(bridge_description)
 
     return ld


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

I noticed that running the following example:

```
ros2 launch ros_gz_sim ros_gz_sim.launch.py world_sdf_file:=sensors_demo.sdf bridge_name:=ros_gz_bridge config_file:=/home/caguero/ros_gz_ws/src/ros_gz/ros_gz_bridge/test/config/full.yaml use_composition:=True create_own_container:=True
```

duplicates the number of running nodes and containers.

```
caguero@cold:~/ros_gz_ws$ ros2 node list
/gz_server
/gz_server
/launch_ros_1390503
/ros_gz_bridge
/ros_gz_bridge
/ros_gz_container
/ros_gz_container
```

After this patch:

```
caguero@cold:~/ros_gz_ws$ ros2 node list
/gz_server
/launch_ros_1395505
/ros_gz_bridge
/ros_gz_container
```

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.