### PR TITLE
Move gzserver logic to its action

### DIFF
--- a/ros_gz_sim/launch/ros_gz_sim.launch.py
+++ b/ros_gz_sim/launch/ros_gz_sim.launch.py
@@ -20,6 +20,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, TextSubstitution
 from launch_ros.substitutions import FindPackageShare
 from ros_gz_bridge.actions import RosGzBridge
+from ros_gz_sim.actions import GzServer
 
 
 def generate_launch_description():
@@ -89,16 +90,13 @@ def generate_launch_description():
         description='SDF world string'
     )
 
-    gz_server_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
-                                   'launch',
-                                   'gz_server.launch.py'])]),
-        launch_arguments=[('world_sdf_file', world_sdf_file),
-                          ('world_sdf_string', world_sdf_string),
-                          ('container_name', container_name),
-                          ('create_own_container', create_own_container),
-                          ('use_composition', use_composition), ])
+    gz_server_action = GzServer(
+        world_sdf_file=LaunchConfiguration('world_sdf_file'),
+        world_sdf_string=LaunchConfiguration('world_sdf_string'),
+        container_name=LaunchConfiguration('container_name'),
+        create_own_container=LaunchConfiguration('create_own_container'),
+        use_composition=LaunchConfiguration('use_composition'),
+    )
 
     ros_gz_bridge_action = RosGzBridge(
         bridge_name=bridge_name,
@@ -128,7 +126,7 @@ def generate_launch_description():
     ld.add_action(declare_world_sdf_file_cmd)
     ld.add_action(declare_world_sdf_string_cmd)
     # Add the actions to launch all of the bridge + gz_server nodes
-    ld.add_action(gz_server_description)
+    ld.add_action(gz_server_action)
     ld.add_action(ros_gz_bridge_action)
 
     return ld

--- a/ros_gz_sim/launch/ros_gz_sim.launch.py
+++ b/ros_gz_sim/launch/ros_gz_sim.launch.py
@@ -15,28 +15,13 @@
 """Launch gzsim + ros_gz_bridge in a component container."""
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, TextSubstitution
-from launch_ros.substitutions import FindPackageShare
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, TextSubstitution
 from ros_gz_bridge.actions import RosGzBridge
 from ros_gz_sim.actions import GzServer
 
 
 def generate_launch_description():
-
-    bridge_name = LaunchConfiguration('bridge_name')
-    config_file = LaunchConfiguration('config_file')
-    container_name = LaunchConfiguration('container_name')
-    create_own_container = LaunchConfiguration('create_own_container')
-    namespace = LaunchConfiguration('namespace')
-    use_composition = LaunchConfiguration('use_composition')
-    use_respawn = LaunchConfiguration('use_respawn')
-    bridge_log_level = LaunchConfiguration('bridge_log_level')
-    bridge_params = LaunchConfiguration('bridge_params')
-
-    world_sdf_file = LaunchConfiguration('world_sdf_file')
-    world_sdf_string = LaunchConfiguration('world_sdf_string')
 
     declare_bridge_name_cmd = DeclareLaunchArgument(
         'bridge_name', description='Name of the bridge'
@@ -99,15 +84,15 @@ def generate_launch_description():
     )
 
     ros_gz_bridge_action = RosGzBridge(
-        bridge_name=bridge_name,
-        config_file=config_file,
-        container_name=container_name,
+        bridge_name=LaunchConfiguration('bridge_name'),
+        config_file=LaunchConfiguration('config_file'),
+        container_name=LaunchConfiguration('container_name'),
         create_own_container=str(False),
-        namespace=namespace,
-        use_composition=use_composition,
-        use_respawn=use_respawn,
-        log_level=bridge_log_level,
-        bridge_params=bridge_params,
+        namespace=LaunchConfiguration('namespace'),
+        use_composition=LaunchConfiguration('use_composition'),
+        use_respawn=LaunchConfiguration('use_respawn'),
+        log_level=LaunchConfiguration('bridge_log_level'),
+        bridge_params=LaunchConfiguration('bridge_params'),
     )
 
     # Create the launch description and populate


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

In a similar way of #628, this patch refactors the way we are launching gzserver. Now the logic lives in the action and all the launch files use this action.

How to test it?

You can try checking these launch files:

```
ros2 launch ros_gz_sim gz_server.launch.py world_sdf_file:=shapes.sdf use_composition:=True create_own_container:=True
```

```
ros2 launch ros_gz_sim gz_server.launch world_sdf_file:=shapes.sdf use_composition:=True create_own_container:=True
```

```
ros2 launch ros_gz_sim ros_gz_sim.launch.py bridge_name:=ros_gz_bridge config_file:=/home/caguero/ros_gz_ws/src/ros_gz/ros_gz_bridge/test/config/full.yaml world_sdf_file:=empty.sdf use_composition:=True create_own_container:=True
```

```
ros2 launch ros_gz_sim ros_gz_sim.launch bridge_name:=ros_gz_bridge config_file:=/home/caguero/ros_gz_ws/src/ros_gz/ros_gz_bridge/test/config/full.yaml world_sdf_file:=empty.sdf use_composition:=True create_own_container:=True
```

And check that there are no errors during launch.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

