### PR TITLE
Allow to set boolean params with ros_gz_bridge xml

### DIFF
--- a/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
+++ b/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
@@ -178,6 +178,12 @@ class RosGzBridge(Action):
         if isinstance(self.__use_respawn, list):
             self.__use_respawn = self.__use_respawn[0]
 
+        for key, value in parsed_bridge_params.items():
+            if value == 'True' or value == 'true':
+                parsed_bridge_params[key] = True
+            if value == 'False' or value == 'false':
+                parsed_bridge_params[key] = False
+
         # Standard node configuration
         load_nodes = GroupAction(
             condition=IfCondition(PythonExpression(['not ', self.__use_composition])),


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

I was not able to set 

```
    bridge_params="'qos_overrides./air_pressure.publisher.reliability': 'best_effort', 'use_sim_time': True"/>
```

because the true internally is a string, this should convert the string in a bool type

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
