### PR TITLE
Improve argument parsing in Actions

### DIFF
--- a/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
+++ b/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
@@ -64,19 +64,26 @@ class RosGzBridge(Action):
         self.__container_name = container_name
         self.__namespace = namespace
 
-        # This is here to allow using strings or booleans as values for boolean variables when the Action is used from Python
-        # i.e., this allows users to do:
+        # This is here to allow using strings or booleans as values for boolean variables when
+        # the Action is used from Python i.e., this allows users to do:
         #   RosGzBridge(bridge_name='bridge1', use_composition='true', create_own_container=True)
-        # Note that use_composition is set to a string while create_own_container is set to a boolean. The reverse would also work.
-        # At some point, we might want to deprecate this and only allow setting booleans since that's
-        # what users would expect when calling this from Python
+        # Note that use_composition is set to a string while create_own_container is set to a
+        # boolean. The reverse would also work.
+        # At some point, we might want to deprecate this and only allow setting booleans since
+        # that's what users would expect when calling this from Python
         if isinstance(create_own_container, str):
-            self.__create_own_container = normalize_typed_substitution(TextSubstitution(text=create_own_container), bool)
+            self.__create_own_container = normalize_typed_substitution(
+                TextSubstitution(text=create_own_container), bool
+            )
         else:
-            self.__create_own_container = normalize_typed_substitution(create_own_container, bool)
+            self.__create_own_container = normalize_typed_substitution(
+                create_own_container, bool
+            )
 
         if isinstance(use_composition, str):
-            self.__use_composition = normalize_typed_substitution(TextSubstitution(text=use_composition), bool)
+            self.__use_composition = normalize_typed_substitution(
+                TextSubstitution(text=use_composition), bool
+            )
         else:
             self.__use_composition = normalize_typed_substitution(use_composition, bool)
 
@@ -87,7 +94,7 @@ class RosGzBridge(Action):
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
         """Parse ros_gz_bridge."""
-        kwargs:Dict = super().parse(entity, parser)[1]
+        kwargs: Dict = super().parse(entity, parser)[1]
 
         bridge_name = entity.get_attr(
             'bridge_name', data_type=str,
@@ -183,8 +190,12 @@ class RosGzBridge(Action):
             bridge_params_pairs = simplified_bridge_params.split(',')
             parsed_bridge_params = dict(pair.split(':') for pair in bridge_params_pairs)
 
-        use_composition_eval = perform_typed_substitution(context, self.__use_composition, bool)
-        create_own_container_eval = perform_typed_substitution(context, self.__create_own_container, bool)
+        use_composition_eval = perform_typed_substitution(
+            context, self.__use_composition, bool
+        )
+        create_own_container_eval = perform_typed_substitution(
+            context, self.__create_own_container, bool
+        )
 
         launch_descriptions: List[Action] = []
 

--- a/ros_gz_sim/ros_gz_sim/actions/gzserver.py
+++ b/ros_gz_sim/ros_gz_sim/actions/gzserver.py
@@ -114,23 +114,28 @@ class GzServer(Action):
         self.__world_sdf_string = world_sdf_string
         self.__container_name = container_name
 
-
-        # This is here to allow using strings or booleans as values for boolean variables when the Action is used from Python
-        # See the RosGzBridge.__init__ function for more details.
+        # This is here to allow using strings or booleans as values for boolean variables when
+        # the Action is used from Python See the RosGzBridge.__init__ function for more details.
         if isinstance(create_own_container, str):
-            self.__create_own_container = normalize_typed_substitution(TextSubstitution(text=create_own_container), bool)
+            self.__create_own_container = normalize_typed_substitution(
+                TextSubstitution(text=create_own_container), bool
+            )
         else:
-            self.__create_own_container = normalize_typed_substitution(create_own_container, bool)
+            self.__create_own_container = normalize_typed_substitution(
+                create_own_container, bool
+            )
 
         if isinstance(use_composition, str):
-            self.__use_composition = normalize_typed_substitution(TextSubstitution(text=use_composition), bool)
+            self.__use_composition = normalize_typed_substitution(
+                TextSubstitution(text=use_composition), bool
+            )
         else:
             self.__use_composition = normalize_typed_substitution(use_composition, bool)
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
         """Parse gz_server."""
-        kwargs:Dict = super().parse(entity, parser)[1]
+        kwargs: Dict = super().parse(entity, parser)[1]
 
         world_sdf_file = entity.get_attr(
             'world_sdf_file', data_type=str,
@@ -177,7 +182,6 @@ class GzServer(Action):
 
     def execute(self, context: LaunchContext) -> Optional[List[Action]]:
         """Execute the action."""
-
         launch_descriptions: List[Action] = []
 
         model_paths, plugin_paths = GazeboRosPaths.get_paths()
@@ -195,8 +199,12 @@ class GzServer(Action):
                 model_paths,
             ])))
 
-        use_composition_eval = perform_typed_substitution(context, self.__use_composition, bool)
-        create_own_container_eval = perform_typed_substitution(context, self.__create_own_container, bool)
+        use_composition_eval = perform_typed_substitution(
+            context, self.__use_composition, bool
+        )
+        create_own_container_eval = perform_typed_substitution(
+            context, self.__create_own_container, bool
+        )
         if not use_composition_eval:
             # Standard node configuration
             launch_descriptions.append(Node(

--- a/ros_gz_sim/ros_gz_sim/actions/gzserver.py
+++ b/ros_gz_sim/ros_gz_sim/actions/gzserver.py
@@ -15,18 +15,17 @@
 """Module for the GzServer action."""
 
 import os
-from typing import List
-from typing import Optional
+from typing import Dict, List, Optional, Union
 
 from ament_index_python.packages import get_package_share_directory
 from catkin_pkg.package import InvalidPackage, PACKAGE_MANIFEST_FILENAME, parse_package
 from launch.action import Action
-from launch.actions import GroupAction, SetEnvironmentVariable
-from launch.conditions import IfCondition
+from launch.actions import SetEnvironmentVariable
 from launch.frontend import Entity, expose_action, Parser
 from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
-from launch.substitutions import PythonExpression
+from launch.substitutions import TextSubstitution
+from launch.utilities.type_utils import normalize_typed_substitution, perform_typed_substitution
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
 from ros2pkg.api import get_package_names
@@ -91,11 +90,11 @@ class GzServer(Action):
     def __init__(
         self,
         *,
-        world_sdf_file: Optional[SomeSubstitutionsType] = '',
-        world_sdf_string: Optional[SomeSubstitutionsType] = '',
-        container_name: Optional[SomeSubstitutionsType] = 'ros_gz_container',
-        create_own_container: Optional[SomeSubstitutionsType] = 'False',
-        use_composition: Optional[SomeSubstitutionsType] = 'False',
+        world_sdf_file: SomeSubstitutionsType = '',
+        world_sdf_string: SomeSubstitutionsType = '',
+        container_name: SomeSubstitutionsType = 'ros_gz_container',
+        create_own_container: Union[bool, SomeSubstitutionsType] = False,
+        use_composition: Union[bool, SomeSubstitutionsType] = False,
         **kwargs
     ) -> None:
         """
@@ -114,13 +113,24 @@ class GzServer(Action):
         self.__world_sdf_file = world_sdf_file
         self.__world_sdf_string = world_sdf_string
         self.__container_name = container_name
-        self.__create_own_container = create_own_container
-        self.__use_composition = use_composition
+
+
+        # This is here to allow using strings or booleans as values for boolean variables when the Action is used from Python
+        # See the RosGzBridge.__init__ function for more details.
+        if isinstance(create_own_container, str):
+            self.__create_own_container = normalize_typed_substitution(TextSubstitution(text=create_own_container), bool)
+        else:
+            self.__create_own_container = normalize_typed_substitution(create_own_container, bool)
+
+        if isinstance(use_composition, str):
+            self.__use_composition = normalize_typed_substitution(TextSubstitution(text=use_composition), bool)
+        else:
+            self.__use_composition = normalize_typed_substitution(use_composition, bool)
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
         """Parse gz_server."""
-        _, kwargs = super().parse(entity, parser)
+        kwargs:Dict = super().parse(entity, parser)[1]
 
         world_sdf_file = entity.get_attr(
             'world_sdf_file', data_type=str,
@@ -167,87 +177,70 @@ class GzServer(Action):
 
     def execute(self, context: LaunchContext) -> Optional[List[Action]]:
         """Execute the action."""
-        if isinstance(self.__use_composition, list):
-            self.__use_composition = self.__use_composition[0]
 
-        if isinstance(self.__create_own_container, list):
-            self.__create_own_container = self.__create_own_container[0]
+        launch_descriptions: List[Action] = []
 
         model_paths, plugin_paths = GazeboRosPaths.get_paths()
-        system_plugin_path_env = SetEnvironmentVariable(
+        launch_descriptions.append(SetEnvironmentVariable(
             'GZ_SIM_SYSTEM_PLUGIN_PATH',
             os.pathsep.join([
                 os.environ.get('GZ_SIM_SYSTEM_PLUGIN_PATH', default=''),
                 os.environ.get('LD_LIBRARY_PATH', default=''),
                 plugin_paths,
-            ]))
-        resource_path_env = SetEnvironmentVariable(
+            ])))
+        launch_descriptions.append(SetEnvironmentVariable(
             'GZ_SIM_RESOURCE_PATH',
             os.pathsep.join([
                 os.environ.get('GZ_SIM_RESOURCE_PATH', default=''),
                 model_paths,
-            ]))
+            ])))
 
-        # Standard node configuration
-        load_nodes = GroupAction(
-            condition=IfCondition(PythonExpression(['not ', self.__use_composition])),
-            actions=[
-                Node(
-                    package='ros_gz_sim',
-                    executable='gzserver',
-                    output='screen',
-                    parameters=[{'world_sdf_file': self.__world_sdf_file,
-                                 'world_sdf_string': self.__world_sdf_string}],
-                ),
-            ],
-        )
+        use_composition_eval = perform_typed_substitution(context, self.__use_composition, bool)
+        create_own_container_eval = perform_typed_substitution(context, self.__create_own_container, bool)
+        if not use_composition_eval:
+            # Standard node configuration
+            launch_descriptions.append(Node(
+                package='ros_gz_sim',
+                executable='gzserver',
+                output='screen',
+                parameters=[{'world_sdf_file': self.__world_sdf_file,
+                             'world_sdf_string': self.__world_sdf_string}],
+                ))
 
         # Composable node with container configuration
-        load_composable_nodes_with_container = ComposableNodeContainer(
-            condition=IfCondition(
-                PythonExpression([self.__use_composition, ' and ', self.__create_own_container])
-            ),
-            name=self.__container_name,
-            namespace='',
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                ComposableNode(
-                    package='ros_gz_sim',
-                    plugin='ros_gz_sim::GzServer',
-                    name='gz_server',
-                    parameters=[{'world_sdf_file': self.__world_sdf_file,
-                                 'world_sdf_string': self.__world_sdf_string}],
-                    extra_arguments=[{'use_intra_process_comms': True}],
-                ),
-            ],
-            output='screen',
-        )
+        if use_composition_eval and create_own_container_eval:
+            launch_descriptions.append(ComposableNodeContainer(
+                name=self.__container_name,
+                namespace='',
+                package='rclcpp_components',
+                executable='component_container',
+                composable_node_descriptions=[
+                    ComposableNode(
+                        package='ros_gz_sim',
+                        plugin='ros_gz_sim::GzServer',
+                        name='gz_server',
+                        parameters=[{'world_sdf_file': self.__world_sdf_file,
+                                     'world_sdf_string': self.__world_sdf_string}],
+                        extra_arguments=[{'use_intra_process_comms': True}],
+                        ),
+                    ],
+                output='screen',
+                ))
 
         # Composable node without container configuration
-        load_composable_nodes_without_container = LoadComposableNodes(
-            condition=IfCondition(
-                PythonExpression(
-                    [self.__use_composition, ' and not ', self.__create_own_container]
-                )
-            ),
-            target_container=self.__container_name,
-            composable_node_descriptions=[
-                ComposableNode(
-                    package='ros_gz_sim',
-                    plugin='ros_gz_sim::GzServer',
-                    name='gz_server',
-                    parameters=[{'world_sdf_file': self.__world_sdf_file,
-                                 'world_sdf_string': self.__world_sdf_string}],
-                    extra_arguments=[{'use_intra_process_comms': True}],
-                ),
-            ],
-        )
+        if use_composition_eval and not create_own_container_eval:
+            launch_descriptions.append(LoadComposableNodes(
+                target_container=self.__container_name,
+                composable_node_descriptions=[
+                    ComposableNode(
+                        package='ros_gz_sim',
+                        plugin='ros_gz_sim::GzServer',
+                        name='gz_server',
+                        parameters=[{'world_sdf_file': self.__world_sdf_file,
+                                     'world_sdf_string': self.__world_sdf_string}],
+                        extra_arguments=[{'use_intra_process_comms': True}],
+                        ),
+                    ],
+                ))
 
-        return [
-            system_plugin_path_env,
-            resource_path_env,
-            load_nodes,
-            load_composable_nodes_with_container,
-            load_composable_nodes_without_container
-        ]
+        return launch_descriptions


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The `RosGzBridge` and `GzServer` now support different spellings for boolean arguments (`True`, `true`). This also simplifies how conditionals are used to create composable nodes by evaluating the conditionals and using them as regular Python booleans instead of relying on `PythonExpression`. It was actually the `PythonExpression` that was preventing support of boolean arguments spelled `true`/`false`.

This came up in https://github.com/gazebosim/ros_gz/pull/632
The launch file in XML can now use lower case boolean strings:
https://github.com/gazebosim/ros_gz/blob/25b6644b644183e09f517170ce41b5dc6f16d6b8/ros_gz_sim_demos/launch/air_pressure.launch.xml#L1C1-L15C10

The equivalent python launch file for just gzserver and the bridge would be:
```python
from launch import LaunchDescription
from launch_ros.substitutions import FindPackageShare
from ros_gz_sim.actions import GzServer
from ros_gz_bridge.actions import RosGzBridge

def generate_launch_description():

    return LaunchDescription([
        GzServer(world_sdf_file='sensors.sdf', use_composition=True, create_own_container=True),
        RosGzBridge(bridge_name='bridge1', 
                    config_file=[FindPackageShare('ros_gz_sim_demos'), '/config/air_pressure.yaml'],
                    use_composition='true'
                    )
    ])

```

Note the `use_composition` argument can be a python boolean or a string (`True` or `true`). We should probably deprecate the string input at some point since that's not very Pythonic

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.