### PR TITLE
Update README.md to include Ionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Iron | Garden | [humble](https://github.com/gazebosim/ros_gz/tree/iron) | only f
 Iron | Harmonic | [humble](https://github.com/gazebosim/ros_gz/tree/iron) | only from source
 Jazzy | Garden | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source [^2]
 Jazzy | Harmonic | [jazzy](https://github.com/gazebosim/ros_gz/tree/jazzy) | https://packages.ros.org
-Rolling | Fortress | [humble](https://github.com/gazebosim/ros_gz/tree/humble) | https://packages.ros.org
 Rolling | Garden | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source [^2]
 Rolling | Harmonic | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | only from source
+Rolling | Ionic | [ros2](https://github.com/gazebosim/ros_gz/tree/ros2) | https://packages.ros.org
 
 [^1]: Binaries for these pairings are provided from the packages.osrfoundation.org repository. Refer to https://gazebosim.org/docs/latest/ros_installation for installation instructions.
 [^2]: Note that the Gazebo version on this row has reached end-of-life.


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092
Rolling is now paired with Ionic through the gz_vendor packages.