### PR TITLE
Minor optimization to avoid dynamic casting in Gazebo callbacks

### DIFF
--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -121,10 +121,14 @@ public:
     rclcpp::PublisherBase::SharedPtr ros_pub,
     bool override_timestamps_with_wall_time)
   {
+    auto pub = std::dynamic_pointer_cast<rclcpp::Publisher<ROS_T>>(ros_pub);
+    if (pub == nullptr) {
+      return;
+    }
     std::function<void(const GZ_T &)> subCb =
-      [this, ros_pub, override_timestamps_with_wall_time](const GZ_T & _msg)
+      [this, pub, override_timestamps_with_wall_time](const GZ_T & _msg)
       {
-        this->gz_callback(_msg, ros_pub, override_timestamps_with_wall_time);
+        this->gz_callback(_msg, pub, override_timestamps_with_wall_time);
       };
 
     // Ignore messages that are published from this bridge.
@@ -154,7 +158,7 @@ protected:
   static
   void gz_callback(
     const GZ_T & gz_msg,
-    rclcpp::PublisherBase::SharedPtr ros_pub,
+    std::shared_ptr<rclcpp::Publisher<ROS_T>> ros_pub,
     bool override_timestamps_with_wall_time)
   {
     ROS_T ros_msg;
@@ -168,11 +172,7 @@ protected:
         ros_msg.header.stamp.nanosec = ns - ros_msg.header.stamp.sec * 1e9;
       }
     }
-    std::shared_ptr<rclcpp::Publisher<ROS_T>> pub =
-      std::dynamic_pointer_cast<rclcpp::Publisher<ROS_T>>(ros_pub);
-    if (pub != nullptr) {
-      pub->publish(ros_msg);
-    }
+    ros_pub->publish(ros_msg);
   }
 
 public:


### PR DESCRIPTION
# 🎉 New feature

## Summary
The casting is done prior to creating the callback so it's done only once instead of in every invocation of the callback.

## Test it
Should be covered by existing tests.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
