### PR TITLE
Add LogicalCameraImage support

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -39,6 +39,7 @@ The following message types can be bridged for topics:
 | ros_gz_interfaces/msg/GuiCamera                | gz.msgs.GUICamera                   |
 | ros_gz_interfaces/msg/JointWrench              | gz.msgs.JointWrench                 |
 | ros_gz_interfaces/msg/Light                    | gz.msgs.Light                       |
+| ros_gz_interfaces/msg/LogicalCameraImage       | gz.msgs.LogicalCameraImage          |
 | ros_gz_interfaces/msg/ParamVec                 | gz.msgs.Param                       |
 | ros_gz_interfaces/msg/ParamVec                 | gz.msgs.Param_V                     |
 | ros_gz_interfaces/msg/SensorNoise              | gz.msgs.SensorNoise                 |

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
@@ -26,6 +26,7 @@
 #include <gz/msgs/float_v.pb.h>
 #include <gz/msgs/gui_camera.pb.h>
 #include <gz/msgs/light.pb.h>
+#include <gz/msgs/logical_camera_image.pb.h>
 #include <gz/msgs/material_color.pb.h>
 #include <gz/msgs/param.pb.h>
 #include <gz/msgs/param_v.pb.h>
@@ -46,6 +47,7 @@
 #include <ros_gz_interfaces/msg/float32_array.hpp>
 #include <ros_gz_interfaces/msg/gui_camera.hpp>
 #include <ros_gz_interfaces/msg/light.hpp>
+#include <ros_gz_interfaces/msg/logical_camera_image.hpp>
 #include <ros_gz_interfaces/msg/material_color.hpp>
 #include <ros_gz_interfaces/msg/param_vec.hpp>
 #include <ros_gz_interfaces/msg/sensor_noise.hpp>
@@ -288,6 +290,18 @@ void
 convert_gz_to_ros(
   const gz::msgs::Float_V & gz_msg,
   ros_gz_interfaces::msg::Float32Array & ros_msg);
+
+template<>
+void
+convert_ros_to_gz(
+  const ros_gz_interfaces::msg::LogicalCameraImage & ros_msg,
+  gz::msgs::LogicalCameraImage & gz_msg);
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::LogicalCameraImage & gz_msg,
+  ros_gz_interfaces::msg::LogicalCameraImage & ros_msg);
 }  // namespace ros_gz_bridge
 
 #endif  // ROS_GZ_BRIDGE__CONVERT__ROS_GZ_INTERFACES_HPP_

--- a/ros_gz_bridge/ros_gz_bridge/mappings.py
+++ b/ros_gz_bridge/ros_gz_bridge/mappings.py
@@ -69,6 +69,7 @@ MAPPINGS = {
         Mapping('GuiCamera', 'GUICamera'),
         Mapping('JointWrench', 'JointWrench'),
         Mapping('Light', 'Light'),
+        Mapping('LogicalCameraImage', 'LogicalCameraImage'),
         Mapping('MaterialColor', 'MaterialColor'),
         Mapping('ParamVec', 'Param'),
         Mapping('ParamVec', 'Param_V'),

--- a/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
@@ -749,4 +749,39 @@ convert_gz_to_ros(
     ros_msg.data.push_back(p);
   }
 }
+
+template<>
+void
+convert_ros_to_gz(
+  const ros_gz_interfaces::msg::LogicalCameraImage & ros_msg,
+  gz::msgs::LogicalCameraImage & gz_msg)
+{
+  convert_ros_to_gz(ros_msg.header, *gz_msg.mutable_header());
+  convert_ros_to_gz(ros_msg.pose, *gz_msg.mutable_pose());
+
+  gz_msg.clear_model();
+  for(const auto & m : ros_msg.model) {
+    auto* model = gz_msg.add_model();
+    model->set_name(m.name);
+    convert_ros_to_gz(m.pose, *model->mutable_pose());
+  }
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::LogicalCameraImage & gz_msg,
+  ros_gz_interfaces::msg::LogicalCameraImage & ros_msg)
+{
+  convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+  convert_gz_to_ros(gz_msg.pose(), ros_msg.pose);
+
+  ros_msg.model.clear();
+  for (const auto & m : gz_msg.model()) {
+    ros_gz_interfaces::msg::LogicalCameraImageModel model;
+    model.name = m.name();
+    convert_gz_to_ros(m.pose(), model.pose);
+    ros_msg.model.push_back(model);
+  }
+}
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
@@ -761,7 +761,7 @@ convert_ros_to_gz(
 
   gz_msg.clear_model();
   for(const auto & m : ros_msg.model) {
-    auto* model = gz_msg.add_model();
+    auto * model = gz_msg.add_model();
     model->set_name(m.name);
     convert_ros_to_gz(m.pose, *model->mutable_pose());
   }

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -1706,7 +1706,7 @@ void createTestMsg(gz::msgs::LogicalCameraImage & _msg)
   createTestMsg(*_msg.mutable_pose());
 
   for (int i = 0; i < 4; ++i) {
-    auto* model = _msg.add_model();
+    auto * model = _msg.add_model();
     model->set_name("model_" + std::to_string(i));
     createTestMsg(*model->mutable_pose());
   }

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -1700,5 +1700,32 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::AnnotatedOriented3DBox_V> & 
   }
 }
 
+void createTestMsg(gz::msgs::LogicalCameraImage & _msg)
+{
+  createTestMsg(*_msg.mutable_header());
+  createTestMsg(*_msg.mutable_pose());
+
+  for (int i = 0; i < 4; ++i) {
+    auto* model = _msg.add_model();
+    model->set_name("model_" + std::to_string(i));
+    createTestMsg(*model->mutable_pose());
+  }
+}
+
+void compareTestMsg(const std::shared_ptr<gz::msgs::LogicalCameraImage> & _msg)
+{
+  gz::msgs::LogicalCameraImage expected_msg;
+  createTestMsg(expected_msg);
+
+  compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
+  compareTestMsg(std::make_shared<gz::msgs::Pose>(_msg->pose()));
+
+  ASSERT_EQ(expected_msg.model_size(), _msg->model_size());
+  for (int i = 0; i < _msg->model_size(); ++i) {
+    EXPECT_EQ(expected_msg.model(i).name(), _msg->model(i).name());
+    compareTestMsg(std::make_shared<gz::msgs::Pose>(_msg->model(i).pose()));
+  }
+}
+
 }  // namespace testing
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/test/utils/gz_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.hpp
@@ -43,6 +43,7 @@
 #include <gz/msgs/joy.pb.h>
 #include <gz/msgs/laserscan.pb.h>
 #include <gz/msgs/light.pb.h>
+#include <gz/msgs/logical_camera_image.pb.h>
 #include <gz/msgs/magnetometer.pb.h>
 #include <gz/msgs/material_color.pb.h>
 #include <gz/msgs/model.pb.h>
@@ -540,6 +541,14 @@ void createTestMsg(gz::msgs::AnnotatedOriented3DBox_V & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<gz::msgs::AnnotatedOriented3DBox_V> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(gz::msgs::LogicalCameraImage & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<gz::msgs::LogicalCameraImage> & _msg);
 
 }  // namespace testing
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -1631,10 +1631,10 @@ void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::LogicalCameraI
   compareTestMsg(std::make_shared<std_msgs::msg::Header>(_msg->header));
   compareTestMsg(std::make_shared<geometry_msgs::msg::Pose>(_msg->pose));
   
-  ASSERT_EQ(expected_msg.models.size(), _msg->models.size());
-  for (int i = 0; i < _msg->models.size(); ++i) {
-    EXPECT_EQ(expected_msg.models[i].name, _msg->models[i].name);
-    compareTestMsg(std::make_shared<geometry_msgs::msg::Pose>(_msg->models[i].pose));
+  ASSERT_EQ(expected_msg.model.size(), _msg->model.size());
+  for (int i = 0; i < _msg->model.size(); ++i) {
+    EXPECT_EQ(expected_msg.model[i].name, _msg->model[i].name);
+    compareTestMsg(std::make_shared<geometry_msgs::msg::Pose>(_msg->model[i].pose));
   }
 }
 

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -1605,5 +1605,38 @@ void compareTestMsg(const std::shared_ptr<vision_msgs::msg::Detection3DArray> & 
   }
 }
 
+void createTestMsg(ros_gz_interfaces::msg::LogicalCameraImage & _msg)
+{
+  std_msgs::msg::Header header_msg;
+  createTestMsg(header_msg);
+  _msg.header = header_msg;
+
+  geometry_msgs::msg::Pose pose_msg;
+  createTestMsg(pose_msg);
+  _msg.pose = pose_msg;
+  
+  for (int i = 0; i < 4; ++i) {
+    ros_gz_interfaces::msg::LogicalCameraImageModel model;
+    model.name = "model_" + std::to_string(i);
+    model.pose = pose_msg;
+    _msg.model.push_back(model);
+  }
+}
+
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::LogicalCameraImage> & _msg)
+{
+  ros_gz_interfaces::msg::LogicalCameraImage expected_msg;
+  createTestMsg(expected_msg);
+
+  compareTestMsg(std::make_shared<std_msgs::msg::Header>(_msg->header));
+  compareTestMsg(std::make_shared<geometry_msgs::msg::Pose>(_msg->pose));
+  
+  ASSERT_EQ(expected_msg.models.size(), _msg->models.size());
+  for (int i = 0; i < _msg->models.size(); ++i) {
+    EXPECT_EQ(expected_msg.models[i].name, _msg->models[i].name);
+    compareTestMsg(std::make_shared<geometry_msgs::msg::Pose>(_msg->models[i].pose));
+  }
+}
+
 }  // namespace testing
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -1614,7 +1614,7 @@ void createTestMsg(ros_gz_interfaces::msg::LogicalCameraImage & _msg)
   geometry_msgs::msg::Pose pose_msg;
   createTestMsg(pose_msg);
   _msg.pose = pose_msg;
-  
+
   for (int i = 0; i < 4; ++i) {
     ros_gz_interfaces::msg::LogicalCameraImageModel model;
     model.name = "model_" + std::to_string(i);
@@ -1630,7 +1630,7 @@ void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::LogicalCameraI
 
   compareTestMsg(std::make_shared<std_msgs::msg::Header>(_msg->header));
   compareTestMsg(std::make_shared<geometry_msgs::msg::Pose>(_msg->pose));
-  
+
   ASSERT_EQ(expected_msg.model.size(), _msg->model.size());
   for (int i = 0; i < _msg->model.size(); ++i) {
     EXPECT_EQ(expected_msg.model[i].name, _msg->model[i].name);

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -1632,7 +1632,7 @@ void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::LogicalCameraI
   compareTestMsg(std::make_shared<geometry_msgs::msg::Pose>(_msg->pose));
 
   ASSERT_EQ(expected_msg.model.size(), _msg->model.size());
-  for (int i = 0; i < _msg->model.size(); ++i) {
+  for (size_t i = 0; i < _msg->model.size(); ++i) {
     EXPECT_EQ(expected_msg.model[i].name, _msg->model[i].name);
     compareTestMsg(std::make_shared<geometry_msgs::msg::Pose>(_msg->model[i].pose));
   }

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -58,6 +58,7 @@
 #include <ros_gz_interfaces/msg/float32_array.hpp>
 #include <ros_gz_interfaces/msg/dataframe.hpp>
 #include <ros_gz_interfaces/msg/light.hpp>
+#include <ros_gz_interfaces/msg/logical_camera_image.hpp>
 #include <ros_gz_interfaces/msg/material_color.hpp>
 #include <ros_gz_interfaces/msg/param_vec.hpp>
 #include <ros_gz_interfaces/msg/sensor_noise.hpp>
@@ -661,6 +662,14 @@ void createTestMsg(vision_msgs::msg::Detection3D & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<vision_msgs::msg::Detection3D> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ros_gz_interfaces::msg::LogicalCameraImage & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::LogicalCameraImage> & _msg);
 
 }  // namespace testing
 }  // namespace ros_gz_bridge

--- a/ros_gz_interfaces/CMakeLists.txt
+++ b/ros_gz_interfaces/CMakeLists.txt
@@ -28,6 +28,8 @@ set(msg_files
   "msg/GuiCamera.msg"
   "msg/JointWrench.msg"
   "msg/Light.msg"
+  "msg/LogicalCameraImage.msg"
+  "msg/LogicalCameraImageModel.msg"
   "msg/MaterialColor.msg"
   "msg/ParamVec.msg"
   "msg/SensorNoise.msg"

--- a/ros_gz_interfaces/msg/LogicalCameraImage.msg
+++ b/ros_gz_interfaces/msg/LogicalCameraImage.msg
@@ -1,0 +1,8 @@
+# Optional header data.
+std_msgs/Header header
+
+# Logical camera pose
+geometry_msgs/Pose pose
+
+# Detected models
+LogicalCameraImageModel[] model

--- a/ros_gz_interfaces/msg/LogicalCameraImageModel.msg
+++ b/ros_gz_interfaces/msg/LogicalCameraImageModel.msg
@@ -1,0 +1,2 @@
+string name
+geometry_msgs/Pose pose


### PR DESCRIPTION
# 🎉 New feature

Closes #697

## Summary
`ros_gz_bridge` now supports `gz.msgs.LogicalCamera image` <-> `ros_gz_interfaces.msg.LogicalCameraImage`.

## Test it
### Test gz to ros conversion

**1:** Run `parameter_bridge` for `/logical_camera` between gz and ros
```
ros2 run ros_gz_bridge parameter_bridge /logical_camera_image@ros_gz_interfaces/msg/LogicalCameraImage@gz.msgs.LogicalCameraImage
```

**2:** In a new terminal, run 
```
ros2 topic echo /logical_camera
```

**3:** In another terminal, publish the message from gz
```
gz topic -t /logical_camera -m gz.msgs.LogicalCameraImage -p 'header: { stamp: { sec: 0, nsec: 0 }, data: [ { key: "frame_id", value: ["logical_camera"] } ] }, pose: { position: { x: 1.0, y: 2.0, z: 3.0 }, orientation: { x: 0.0, y: 0.0, z: 0.0, w: 1.0 } }, model: [ { name: "model_1", pose: { position: { x: 4.0, y: 5.0, z: 6.0 }, orientation: { x: 0.0, y: 0.0, z: 0.0, w: 1.0 } } },  { name: "model_2", pose: { position: { x: 7.0, y: 8.0, z: 9.0 }, orientation: { x: 0.0, y: 0.0, z: 0.0, w: 1.0 } } }]'
```

In the terminal listening to `/logical_camera`, the output should be
```
header:
  stamp:
    sec: 0
    nanosec: 0
  frame_id: logical_camera
pose:
  position:
    x: 1.0
    y: 2.0
    z: 3.0
  orientation:
    x: 0.0
    y: 0.0
    z: 0.0
    w: 1.0
model:
- name: model_1
  pose:
    position:
      x: 4.0
      y: 5.0
      z: 6.0
    orientation:
      x: 0.0
      y: 0.0
      z: 0.0
      w: 1.0
- name: model_2
  pose:
    position:
      x: 7.0
      y: 8.0
      z: 9.0
    orientation:
      x: 0.0
      y: 0.0
      z: 0.0
      w: 1.0
---
```
### Test ros to gz conversion

**1:** Run `parameter_bridge` for `/logical_camera` between gz and ros
```
ros2 run ros_gz_bridge parameter_bridge /logical_camera_image@ros_gz_interfaces/msg/LogicalCameraImage@gz.msgs.LogicalCameraImage
```

**2:** In another terminal, listen to the gz topic `/logical_camera`
```
gz topic -e -t /logical_camera
```

**3:**  Publish the ros message
```
ros2 topic pub /logical_camera ros_gz_interfaces/msg/LogicalCameraImage \
"{header: {stamp: {sec: 0, nanosec: 0}, frame_id: 'logical_camera'}, \
pose: {position: {x: 1.0, y: 2.0, z: 3.0}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}, \
model: [{name: 'model_1', pose: {position: {x: 4.0, y: 5.0, z: 6.0}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}, \
{name: 'model_2', pose: {position: {x: 7.0, y: 8.0, z: 9.0}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}]}" --once
```

In the terminal listening to `/logical_camera`, the output should be
```
header {
  stamp {
  }
  data {
    key: "frame_id"
    value: "logical_camera"
  }
}
pose {
  position {
    x: 1
    y: 2
    z: 3
  }
  orientation {
    w: 1
  }
}
model {
  name: "model_1"
  pose {
    position {
      x: 4
      y: 5
      z: 6
    }
    orientation {
      w: 1
    }
  }
}
model {
  name: "model_2"
  pose {
    position {
      x: 7
      y: 8
      z: 9
    }
    orientation {
      w: 1
    }
  }
}
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
