### PR TITLE
gz_topic_name in cli to param_bridge

### DIFF
--- a/ros_gz_bridge/src/parameter_bridge.cpp
+++ b/ros_gz_bridge/src/parameter_bridge.cpp
@@ -28,7 +28,7 @@
 void usage()
 {
   std::cout << "Bridge a collection of ROS2 and Gazebo Transport topics and services.\n\n" <<
-    "  parameter_bridge [<topic@ROS2_type@Ign_type> ..] " <<
+    "  parameter_bridge [<topic@ROS2_type@Ign_type@gz_topic> ..] " <<
     " [<service@ROS2_srv_type[@Ign_req_type@Ign_rep_type]> ..]\n\n" <<
     "Topics: The first @ symbol delimits the topic name from the message types.\n" <<
     "Following the first @ symbol is the ROS message type.\n" <<
@@ -54,6 +54,9 @@ void usage()
     "A bridge from ROS to Gazebo example:\n" <<
     "    parameter_bridge /chatter@std_msgs/String]ignition.msgs" <<
     ".StringMsg\n" <<
+    "A bidirectional bridge example with gz_topic name:\n" <<
+    "    parameter_bridge /ros/chatter@std_msgs/String@gz.msgs@/gz/chatter" <<
+    ".StringMsg\n\n" <<
     "A service bridge:\n" <<
     "    parameter_bridge /world/default/control@ros_gz_interfaces/srv/ControlWorld\n" <<
     "Or equivalently:\n" <<
@@ -106,13 +109,13 @@ int main(int argc, char * argv[])
     //   @ == bidirectional, or
     //   [ == only from GZ to ROS, or
     //   ] == only from ROS to GZ.
-    delimPos = arg.find(delim);
-    config.direction = BridgeDirection::BIDIRECTIONAL;
+    delimPos = arg.find(delimROSToGz);
+    config.direction = BridgeDirection::ROS_TO_GZ;
 
     if (delimPos == std::string::npos || delimPos == 0) {
       delimPos = arg.find(delimGzToROS);
       if (delimPos == std::string::npos || delimPos == 0) {
-        delimPos = arg.find(delimROSToGz);
+        delimPos = arg.find(delim);
         if (delimPos == 0) {
           usage();
           return -1;
@@ -120,7 +123,7 @@ int main(int argc, char * argv[])
           // Fall through, to parse for services
           config.direction = BridgeDirection::NONE;
         } else {
-          config.direction = BridgeDirection::ROS_TO_GZ;
+          config.direction = BridgeDirection::BIDIRECTIONAL;
         }
       } else {
         config.direction = BridgeDirection::GZ_TO_ROS;
@@ -158,6 +161,13 @@ int main(int argc, char * argv[])
         std::cerr << e.what() << std::endl;
       }
       continue;
+    }
+
+    // Get the GZ Topic type name if available
+    delimPos = arg.find(delim);
+    if (delimPos != std::string::npos && delimPos != 0) {
+      config.gz_topic_name = arg.substr(delimPos+1, arg.size());
+      arg.erase(delimPos, arg.size());
     }
 
     delimPos = arg.find(delim);


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

A quick feature that I needed, so here it is, in case it seem useful to the audience,

It adds the possibility of considering `gz_topic_name` through CLI/launch arguments if it differs from the `ros_topic_name` or vice-versa.

The syntax is `/ROS2_TOPIC@ROS_MSG@GZ_MSG@/GZ_TOPIC`, such that ROS2_TOPIC is the name of the ROS 2 topic,  GZ_TOPIC is the Gazebo internal topic, ROS_MSG is the ROS message type for this topic, and GZ_MSG is the Gazebo message type.

It is optional if ROS 2 and GZ topic names are the same and can be neglected.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

`ros2 run ros_gz_bridge parameter_bridge /ros/chatter@std_msgs/msg/String@gz.msgs.StringMsg@/gz/chatter`
OR
`ros2 run ros_gz_bridge parameter_bridge /ros/chatter@std_msgs/msg/String]gz.msgs.StringMsg@/gz/chatter`
OR
`ros2 run ros_gz_bridge parameter_bridge /ros/chatter@std_msgs/msg/String[gz.msgs.StringMsg@/gz/chatter`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
