### PR TITLE
Fix missing child_frame_id in TF2 message conversion

### DIFF
--- a/ros_gz_bridge/src/convert/tf2_msgs.cpp
+++ b/ros_gz_bridge/src/convert/tf2_msgs.cpp
@@ -27,6 +27,7 @@ convert_ros_to_gz(
   gz_msg.clear_pose();
   for (auto const & t : ros_msg.transforms) {
     auto p = gz_msg.add_pose();
+    p->set_name(t.child_frame_id);
     convert_ros_to_gz(t, *p);
   }
 
@@ -46,6 +47,7 @@ convert_gz_to_ros(
   ros_msg.transforms.clear();
   for (auto const & p : gz_msg.pose()) {
     geometry_msgs::msg::TransformStamped tf;
+    tf.set__child_frame_id(p.name());
     convert_gz_to_ros(p, tf);
     ros_msg.transforms.push_back(tf);
   }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1

## Summary
This PR fixes an issue in the TF2 message conversion where the child_frame_id was not being preserved when bridging between ROS 2 and Gazebo. The current implementation in TF2_msg.cpp only transfers the transform data and header information, but fails to maintain the frame relationship information stored in child_frame_id.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
