### PR TITLE
Cssb 132

### DIFF
--- a/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
@@ -21,6 +21,7 @@
 #include <gz/msgs/entity_factory.pb.h>
 #include <gz/msgs/entity_wrench.pb.h>
 #include <gz/msgs/joint_wrench.pb.h>
+#include <gz/msgs/clock.pb.h>
 #include <gz/msgs/contact.pb.h>
 #include <gz/msgs/contacts.pb.h>
 #include <gz/msgs/dataframe.pb.h>
@@ -43,6 +44,7 @@
 #include <ros_gz_interfaces/msg/entity_factory.hpp>
 #include <ros_gz_interfaces/msg/entity_wrench.hpp>
 #include <ros_gz_interfaces/msg/joint_wrench.hpp>
+#include <ros_gz_interfaces/msg/clock.hpp>
 #include <ros_gz_interfaces/msg/contact.hpp>
 #include <ros_gz_interfaces/msg/contacts.hpp>
 #include <ros_gz_interfaces/msg/dataframe.hpp>
@@ -131,6 +133,18 @@ void
 convert_gz_to_ros(
   const gz::msgs::EntityWrench & gz_msg,
   ros_gz_interfaces::msg::EntityWrench & ros_msg);
+
+template<>
+void
+convert_ros_to_gz(
+  const ros_gz_interfaces::msg::Clock & ros_msg,
+  gz::msgs::Clock & gz_msg);
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Clock & gz_msg,
+  ros_gz_interfaces::msg::Clock & ros_msg);
 
 template<>
 void

--- a/ros_gz_bridge/ros_gz_bridge/mappings.py
+++ b/ros_gz_bridge/ros_gz_bridge/mappings.py
@@ -78,6 +78,7 @@ MAPPINGS = {
         Mapping('StringVec', 'StringMsg_V'),
         Mapping('TrackVisual', 'TrackVisual'),
         Mapping('VideoRecord', 'VideoRecord'),
+        Mapping('Clock', 'Clock'),
     ],
     'rosgraph_msgs': [
         Mapping('Clock', 'Clock'),

--- a/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <rclcpp/time.hpp>
+
 #include "ros_gz_bridge/convert/ros_gz_interfaces.hpp"
 
 namespace ros_gz_bridge
@@ -223,6 +225,37 @@ convert_gz_to_ros(
   convert_gz_to_ros(gz_msg.header(), ros_msg.header);
   convert_gz_to_ros(gz_msg.entity(), ros_msg.entity);
   convert_gz_to_ros(gz_msg.wrench(), ros_msg.wrench);
+}
+
+template<>
+void
+convert_ros_to_gz(
+  const ros_gz_interfaces::msg::Clock & ros_msg,
+  gz::msgs::Clock & gz_msg)
+{
+  convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
+
+  gz_msg.mutable_system()->set_sec(ros_msg.system.sec);
+  gz_msg.mutable_system()->set_nsec(ros_msg.system.nanosec);
+
+  gz_msg.mutable_real()->set_sec(ros_msg.real.sec);
+  gz_msg.mutable_real()->set_nsec(ros_msg.real.nanosec);
+
+  gz_msg.mutable_sim()->set_sec(ros_msg.sim.sec);
+  gz_msg.mutable_sim()->set_nsec(ros_msg.sim.nanosec);
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::Clock & gz_msg,
+  ros_gz_interfaces::msg::Clock & ros_msg)
+{
+  convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+
+  ros_msg.system = rclcpp::Time(gz_msg.system().sec(), gz_msg.system().nsec());
+  ros_msg.real = rclcpp::Time(gz_msg.real().sec(), gz_msg.real().nsec());
+  ros_msg.sim = rclcpp::Time(gz_msg.sim().sec(), gz_msg.sim().nsec());
 }
 
 template<>

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -897,6 +897,24 @@ void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::EntityWrench> 
   compareTestMsg(std::make_shared<geometry_msgs::msg::Wrench>(_msg->wrench));
 }
 
+
+void createTestMsg(ros_gz_interfaces::msg::Clock & _msg) {
+  createTestMsg(_msg.header);
+  createTestMsg(_msg.system);
+  createTestMsg(_msg.real);
+  createTestMsg(_msg.sim);
+}
+
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::Clock> & _msg) {
+  ros_gz_interfaces::msg::Clock expected_clock;
+  createTestMsg(expected_clock);
+
+  compareTestMsg(std::make_shared<std_msgs::msg::Header>(_msg->header));
+  compareTestMsg(std::make_shared<builtin_interfaces::msg::Time>(_msg->system));
+  compareTestMsg(std::make_shared<builtin_interfaces::msg::Time>(_msg->real));
+  compareTestMsg(std::make_shared<builtin_interfaces::msg::Time>(_msg->sim);
+}
+
 void createTestMsg(ros_gz_interfaces::msg::Contact & _msg)
 {
   createTestMsg(_msg.collision1);

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -912,7 +912,7 @@ void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::Clock> & _msg)
   compareTestMsg(std::make_shared<std_msgs::msg::Header>(_msg->header));
   compareTestMsg(std::make_shared<builtin_interfaces::msg::Time>(_msg->system));
   compareTestMsg(std::make_shared<builtin_interfaces::msg::Time>(_msg->real));
-  compareTestMsg(std::make_shared<builtin_interfaces::msg::Time>(_msg->sim);
+  compareTestMsg(std::make_shared<builtin_interfaces::msg::Time>(_msg->sim));
 }
 
 void createTestMsg(ros_gz_interfaces::msg::Contact & _msg)

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -54,6 +54,7 @@
 #include <ros_gz_interfaces/msg/entity_wrench.hpp>
 #include <ros_gz_interfaces/msg/gui_camera.hpp>
 #include <ros_gz_interfaces/msg/joint_wrench.hpp>
+#include <ros_gz_interfaces/msg/clock.hpp>
 #include <ros_gz_interfaces/msg/contact.hpp>
 #include <ros_gz_interfaces/msg/contacts.hpp>
 #include <ros_gz_interfaces/msg/float32_array.hpp>
@@ -443,6 +444,14 @@ void createTestMsg(ros_gz_interfaces::msg::EntityWrench & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::EntityWrench> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ros_gz_interfaces::msg::Clock & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::Clock> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_gz_interfaces/CMakeLists.txt
+++ b/ros_gz_interfaces/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
   "msg/Altimeter.msg"
+  "msg/Clock.msg"
   "msg/Contact.msg"
   "msg/Contacts.msg"
   "msg/Dataframe.msg"

--- a/ros_gz_interfaces/msg/Clock.msg
+++ b/ros_gz_interfaces/msg/Clock.msg
@@ -1,0 +1,9 @@
+# A message for a clock.
+
+# Optional header data.
+std_msgs/Header header
+
+# System, real and simulation time.
+builtin_interfaces/Time system
+builtin_interfaces/Time real
+builtin_interfaces/Time sim


### PR DESCRIPTION
## What?
1. Add the `ros_gz_interfaces/msg/Clock` message that fully corresponds to the Gazeo `gz.msgs.Clock`
2. Implement converters between the `gz.msgs.Clock` and the `ros_gz_interfaces/msg/Clock`
3. Update tests

## Why?
To get the absolute UNIX timestamp of the image obtained from the `/world/{world_name}/model/{vehicle_name}/link/camera_link/sensor/camera/image` topic. This is required to know the video latency during the simulation. See the corresponding [pull request](https://github.com/gtakontur/we-white-eagle/pull/97) in the `we-white-eagle`