### PR TITLE
use target_link_libraries instead of ament_target_dependencies

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -101,15 +101,23 @@ target_link_libraries(${bridge_lib}
   PUBLIC
     gz-msgs::core
     gz-transport::core
+    rclcpp::rclcpp
+    rclcpp_components::component
+    ${builtin_interfaces_TARGETS}
+    ${actuator_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    ${gps_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${rcl_interfaces_TARGETS}
+    ${ros_gz_interfaces_TARGETS}
+    ${rosgraph_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${tf2_msgs_TARGETS}
+    ${trajectory_msgs_TARGETS}
+    ${vision_msgs_TARGETS}
   PRIVATE
     yaml-cpp::yaml-cpp
-)
-
-ament_target_dependencies(${bridge_lib}
-  PUBLIC
-    rclcpp
-    rclcpp_components
-    ${BRIDGE_MESSAGE_TYPES}
 )
 
 target_include_directories(${bridge_lib}
@@ -153,10 +161,7 @@ foreach(bridge ${bridge_executables})
   )
   target_link_libraries(${bridge}
     ${bridge_lib}
-  )
-  ament_target_dependencies(${bridge}
-    "rclcpp"
-    ${BRIDGE_MESSAGE_TYPES}
+    rclcpp::rclcpp
   )
   install(TARGETS ${bridge}
     RUNTIME DESTINATION lib/${PROJECT_NAME}
@@ -213,17 +218,20 @@ if(BUILD_TESTING)
     ${GTEST_LIBRARIES}
     gz-msgs::core
     gz-transport::core
-  )
-  ament_target_dependencies(test_utils
-    rclcpp
-    ${BRIDGE_MESSAGE_TYPES}
-    ros_gz_interfaces
-    rosgraph_msgs
-    sensor_msgs
-    std_msgs
-    tf2_msgs
-    trajectory_msgs
-    vision_msgs
+    rclcpp::rclcpp
+    ${builtin_interfaces_TARGETS}
+    ${actuator_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    ${gps_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${rcl_interfaces_TARGETS}
+    ${ros_gz_interfaces_TARGETS}
+    ${rosgraph_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${tf2_msgs_TARGETS}
+    ${trajectory_msgs_TARGETS}
+    ${vision_msgs_TARGETS}
   )
 
   set(generated_path "${CMAKE_BINARY_DIR}/generated/test")
@@ -309,9 +317,7 @@ if(BUILD_TESTING)
   ament_add_gtest(${PROJECT_NAME}_bridge_config test/bridge_config.cpp
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   target_include_directories(${PROJECT_NAME}_bridge_config PRIVATE src)
-  ament_target_dependencies(${PROJECT_NAME}_bridge_config rclcpp)
-  target_link_libraries(${PROJECT_NAME}_bridge_config ${bridge_lib})
-
+  target_link_libraries(${PROJECT_NAME}_bridge_config rclcpp::rclcpp ${bridge_lib})
 endif()
 
 # Export old-style CMake variables

--- a/ros_gz_image/CMakeLists.txt
+++ b/ros_gz_image/CMakeLists.txt
@@ -33,15 +33,12 @@ add_executable(${executable}
 )
 
 target_link_libraries(${executable}
+  ${std_msgs_TARGETS}
+  image_transport::image_transport
+  ros_gz_bridge::ros_gz_bridge
+  rclcpp::rclcpp
   gz-msgs::core
   gz-transport::core
-)
-
-ament_target_dependencies(${executable}
-  "image_transport"
-  "ros_gz_bridge"
-  "rclcpp"
-  "sensor_msgs"
 )
 
 install(TARGETS ${executable}

--- a/ros_gz_sim/CMakeLists.txt
+++ b/ros_gz_sim/CMakeLists.txt
@@ -39,32 +39,28 @@ find_package(std_msgs REQUIRED)
 ament_python_install_package(${PROJECT_NAME})
 
 add_executable(create src/create.cpp)
-ament_target_dependencies(create
-  rclcpp
-  std_msgs
-)
 target_link_libraries(create
   gflags
   gz-math::core
   gz-msgs::core
   gz-transport::core
+  rclcpp::rclcpp
   rcpputils::rcpputils
+  ${std_msgs_TARGETS}
 )
 
 add_executable(remove src/remove.cpp)
-ament_target_dependencies(remove
-  rclcpp
-  std_msgs
-)
 
 target_link_libraries(remove
   gz-msgs::core
   gz-transport::core
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS}
 )
 
 add_library(${PROJECT_NAME} SHARED src/Stopwatch.cpp)
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
+target_link_libraries(${PROJECT_NAME}
+  rclcpp::rclcpp
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -78,15 +74,14 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 add_library(gzserver_component SHARED src/gzserver.cpp)
 rclcpp_components_register_nodes(gzserver_component "ros_gz_sim::GzServer")
-ament_target_dependencies(gzserver_component
-  rclcpp
-  rclcpp_components
-  std_msgs
-)
-target_link_libraries(gzserver_component
+target_link_libraries(gzserver_component PUBLIC
+  ${std_msgs_TARGETS}
   gz-sim::core
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
 )
-ament_target_dependencies(gzserver_component std_msgs)
+
 rclcpp_components_register_node(
   gzserver_component
   PLUGIN "ros_gz_sim::GzServer"
@@ -175,8 +170,6 @@ if(BUILD_TESTING)
     test/test_remove.cpp
   )
 
-  ament_target_dependencies(test_stopwatch rclcpp)
-
   target_include_directories(test_stopwatch PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
@@ -184,6 +177,7 @@ if(BUILD_TESTING)
 
   target_link_libraries(test_stopwatch
     ${PROJECT_NAME}
+    rclcpp::rclcpp
   )
   target_link_libraries(test_create
     gz-transport::core


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

`ament_target_dependencies` is deprecated

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
