### PR TITLE
Added LaserScan-Range bridge

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -63,6 +63,7 @@ The following message types can be bridged for topics:
 | sensor_msgs/msg/MagneticField               | ignition::msgs::Magnetometer                |
 | sensor_msgs/msg/NavSatFix                   | ignition::msgs::NavSat                      |
 | sensor_msgs/msg/PointCloud2                 | ignition::msgs::PointCloudPacked            |
+| sensor_msgs/msg/Range                       | ignition::msgs::LaserScan                   |
 | tf2_msgs/msg/TFMessage                      | ignition::msgs::Pose_V                      |
 | trajectory_msgs/msg/JointTrajectory         | ignition::msgs::JointTrajectory             |
 | vision_msgs/msg/Detection3D                 | ignition::msgs::AnnotatedOriented3DBox      |

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/sensor_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/sensor_msgs.hpp
@@ -37,10 +37,10 @@
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
-#include <sensor_msgs/msg/range.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/range.hpp>
 
 #include <ros_gz_bridge/convert_decl.hpp>
 

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/sensor_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/sensor_msgs.hpp
@@ -37,6 +37,7 @@
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <sensor_msgs/msg/range.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>

--- a/ros_gz_bridge/ros_gz_bridge/mappings.py
+++ b/ros_gz_bridge/ros_gz_bridge/mappings.py
@@ -90,6 +90,7 @@ MAPPINGS = {
         Mapping('MagneticField', 'Magnetometer'),
         Mapping('NavSatFix', 'NavSat'),
         Mapping('PointCloud2', 'PointCloudPacked'),
+        Mapping('Range', 'LaserScan'),
     ],
     'std_msgs': [
         Mapping('Bool', 'Boolean'),

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -474,6 +474,7 @@ convert_ros_to_gz(
   const sensor_msgs::msg::Range & ros_msg,
   gz::msgs::LaserScan & gz_msg)
 {
+  const unsigned int num_readings = 1u;
   const float half_fov = ros_msg.field_of_view / 2.0;
 
   convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
@@ -485,13 +486,13 @@ convert_ros_to_gz(
   // Not supported in sensor_msgs::msg::Range.
   gz_msg.set_angle_min(-half_fov);
   gz_msg.set_angle_max(half_fov);
-  gz_msg.set_angle_step(ros_msg.field_of_view);
-  gz_msg.set_count(1u);
+  gz_msg.set_angle_step(ros_msg.field_of_view / num_readings);
+  gz_msg.set_count(num_readings);
 
-  gz_msg.set_vertical_angle_min(0);
-  gz_msg.set_vertical_angle_max(0);
-  gz_msg.set_vertical_angle_step(0);
-  gz_msg.set_vertical_count(0);
+  gz_msg.set_vertical_angle_min(-half_fov);
+  gz_msg.set_vertical_angle_max(half_fov);
+  gz_msg.set_vertical_angle_step(ros_msg.field_of_view / num_readings);
+  gz_msg.set_vertical_count(num_readings);
 
   gz_msg.add_intensities(1.0);
 }
@@ -514,10 +515,10 @@ convert_gz_to_ros(
   ros_msg.min_range = gz_msg.range_min();
   ros_msg.max_range = gz_msg.range_max();
 
-  // Set range to the minimum of the ray ranges
-  // For single rays, this will just be the range of the ray
   ros_msg.range = ros_msg.max_range + 1.0;
 
+  // Set range to the minimum of the ray ranges
+  // For single rays, this will just be the range of the ray
   for (double range : gz_msg.ranges()) {
     if (range < ros_msg.range) {
       ros_msg.range = range;

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -471,6 +471,63 @@ convert_gz_to_ros(
 template<>
 void
 convert_ros_to_gz(
+  const sensor_msgs::msg::Range & ros_msg,
+  gz::msgs::LaserScan & gz_msg)
+{
+  const float half_fov = ros_msg.field_of_view / 2.0;
+
+  convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
+  gz_msg.set_frame(ros_msg.header.frame_id);
+  gz_msg.set_range_min(ros_msg.min_range);
+  gz_msg.set_range_max(ros_msg.max_range);
+  gz_msg.add_ranges(ros_msg.range);
+
+  // Not supported in sensor_msgs::msg::Range.
+  gz_msg.set_angle_min(-half_fov);
+  gz_msg.set_angle_max(half_fov);
+  gz_msg.set_angle_step(ros_msg.field_of_view);
+  gz_msg.set_count(1u);
+
+  gz_msg.set_vertical_angle_min(0);
+  gz_msg.set_vertical_angle_max(0);
+  gz_msg.set_vertical_angle_step(0);
+  gz_msg.set_vertical_count(0);
+
+  gz_msg.add_intensities(1.0);
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::LaserScan & gz_msg,
+  sensor_msgs::msg::Range & ros_msg)
+{
+  convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+  ros_msg.header.frame_id = frame_id_gz_to_ros(gz_msg.frame());
+
+  ros_msg.radiation_type = sensor_msgs::msg::Range::INFRARED;
+
+  double horizontal_fov = gz_msg.angle_max() - gz_msg.angle_min();
+  double vertical_fov = gz_msg.vertical_angle_max() - gz_msg.vertical_angle_min();
+  ros_msg.field_of_view = std::max(horizontal_fov, vertical_fov);
+
+  ros_msg.min_range = gz_msg.range_min();
+  ros_msg.max_range = gz_msg.range_max();
+
+  // Set range to the minimum of the ray ranges
+  // For single rays, this will just be the range of the ray
+  ros_msg.range = ros_msg.max_range + 1.0;
+
+  for (double range : gz_msg.ranges()) {
+    if (range < ros_msg.range) {
+      ros_msg.range = range;
+    }
+  }
+}
+
+template<>
+void
+convert_ros_to_gz(
   const sensor_msgs::msg::MagneticField & ros_msg,
   gz::msgs::Magnetometer & gz_msg)
 {

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -959,12 +959,12 @@ void createTestMsg(gz::msgs::LaserScan & _msg)
   gz::msgs::Header header_msg;
   createTestMsg(header_msg);
 
-  const unsigned int num_readings = 1u;
+  const unsigned int num_readings = 100u;
   _msg.mutable_header()->CopyFrom(header_msg);
   _msg.set_frame("frame_id_value");
-  _msg.set_angle_min(-0.01);
-  _msg.set_angle_max(0.01);
-  _msg.set_angle_step(0.02 / num_readings);
+  _msg.set_angle_min(-1.57);
+  _msg.set_angle_max(1.57);
+  _msg.set_angle_step(3.14 / num_readings);
   _msg.set_range_min(1);
   _msg.set_range_max(2);
   _msg.set_count(num_readings);
@@ -974,15 +974,46 @@ void createTestMsg(gz::msgs::LaserScan & _msg)
   _msg.set_vertical_count(0);
 
   for (auto i = 0u; i < _msg.count(); ++i) {
-    _msg.add_ranges(1.5);
+    _msg.add_ranges(0);
     _msg.add_intensities(1);
+  }
+}
+
+void createTestMsgRange(gz::msgs::LaserScan & _msg)
+{
+  gz::msgs::Header header_msg;
+  createTestMsg(header_msg);
+
+  const unsigned int num_readings = 1u;
+  const float fov = 3.14;
+  _msg.mutable_header()->CopyFrom(header_msg);
+  _msg.set_frame("frame_id_value");
+  _msg.set_angle_min(-fov / 2.0);
+  _msg.set_angle_max(fov / 2.0);
+  _msg.set_angle_step(fov / num_readings);
+  _msg.set_range_min(1.0);
+  _msg.set_range_max(2.0);
+  _msg.set_count(num_readings);
+  _msg.set_vertical_angle_min(-fov / 2.0);
+  _msg.set_vertical_angle_max(fov / 2.0);
+  _msg.set_vertical_angle_step(fov / num_readings);
+  _msg.set_vertical_count(num_readings);
+
+  for (auto i = 0u; i < _msg.count(); ++i) {
+    _msg.add_ranges(0.0);
+    _msg.add_intensities(1.0);
   }
 }
 
 void compareTestMsg(const std::shared_ptr<gz::msgs::LaserScan> & _msg)
 {
   gz::msgs::LaserScan expected_msg;
-  createTestMsg(expected_msg);
+
+  if (_msg->count() > 1) {
+    createTestMsg(expected_msg);
+  } else {
+    createTestMsgRange(expected_msg);
+  }
 
   compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
   EXPECT_FLOAT_EQ(expected_msg.angle_min(), _msg->angle_min());

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -959,12 +959,12 @@ void createTestMsg(gz::msgs::LaserScan & _msg)
   gz::msgs::Header header_msg;
   createTestMsg(header_msg);
 
-  const unsigned int num_readings = 100u;
+  const unsigned int num_readings = 1u;
   _msg.mutable_header()->CopyFrom(header_msg);
   _msg.set_frame("frame_id_value");
-  _msg.set_angle_min(-1.57);
-  _msg.set_angle_max(1.57);
-  _msg.set_angle_step(3.14 / num_readings);
+  _msg.set_angle_min(-0.01);
+  _msg.set_angle_max(0.01);
+  _msg.set_angle_step(0.02 / num_readings);
   _msg.set_range_min(1);
   _msg.set_range_max(2);
   _msg.set_count(num_readings);
@@ -974,7 +974,7 @@ void createTestMsg(gz::msgs::LaserScan & _msg)
   _msg.set_vertical_count(0);
 
   for (auto i = 0u; i < _msg.count(); ++i) {
-    _msg.add_ranges(0);
+    _msg.add_ranges(1.5);
     _msg.add_intensities(1);
   }
 }

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -1216,19 +1216,19 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Joy> & _msg)
 
 void createTestMsg(sensor_msgs::msg::LaserScan & _msg)
 {
-  const unsigned int num_readings = 1u;
+  const unsigned int num_readings = 100u;
 
   std_msgs::msg::Header header_msg;
   createTestMsg(header_msg);
 
   _msg.header = header_msg;
-  _msg.angle_min = -0.01;
-  _msg.angle_max = 0.01;
-  _msg.angle_increment = 0.02 / num_readings;
+  _msg.angle_min = -1.57;
+  _msg.angle_max = 1.57;
+  _msg.angle_increment = 3.14 / num_readings;
   _msg.scan_time = 0;
   _msg.range_min = 1;
   _msg.range_max = 2;
-  _msg.ranges.resize(num_readings, 1.5);
+  _msg.ranges.resize(num_readings, 0);
   _msg.intensities.resize(num_readings, 1);
 }
 
@@ -1259,11 +1259,11 @@ void createTestMsg(sensor_msgs::msg::Range & _msg)
   createTestMsg(header_msg);
 
   _msg.header = header_msg;
-  _msg.radiation_type = 1;
-  _msg.field_of_view = 0.02;
+  _msg.radiation_type = sensor_msgs::msg::Range::INFRARED;
+  _msg.field_of_view = 3.14;
   _msg.min_range = 1.0;
   _msg.max_range = 2.0;
-  _msg.range = 1.5;
+  _msg.range = 0.0;
 }
 
 void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Range> & _msg)

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -1216,19 +1216,19 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Joy> & _msg)
 
 void createTestMsg(sensor_msgs::msg::LaserScan & _msg)
 {
-  const unsigned int num_readings = 100u;
+  const unsigned int num_readings = 1u;
 
   std_msgs::msg::Header header_msg;
   createTestMsg(header_msg);
 
   _msg.header = header_msg;
-  _msg.angle_min = -1.57;
-  _msg.angle_max = 1.57;
-  _msg.angle_increment = 3.14 / num_readings;
+  _msg.angle_min = -0.01;
+  _msg.angle_max = 0.01;
+  _msg.angle_increment = 0.02 / num_readings;
   _msg.scan_time = 0;
   _msg.range_min = 1;
   _msg.range_max = 2;
-  _msg.ranges.resize(num_readings, 0);
+  _msg.ranges.resize(num_readings, 1.5);
   _msg.intensities.resize(num_readings, 1);
 }
 
@@ -1251,6 +1251,32 @@ void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::LaserScan> & _msg)
     EXPECT_FLOAT_EQ(expected_msg.ranges[i], _msg->ranges[i]);
     EXPECT_FLOAT_EQ(expected_msg.intensities[i], _msg->intensities[i]);
   }
+}
+
+void createTestMsg(sensor_msgs::msg::Range & _msg)
+{
+  std_msgs::msg::Header header_msg;
+  createTestMsg(header_msg);
+
+  _msg.header = header_msg;
+  _msg.radiation_type = 1;
+  _msg.field_of_view = 0.02;
+  _msg.min_range = 1.0;
+  _msg.max_range = 2.0;
+  _msg.range = 1.5;
+}
+
+void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Range> & _msg)
+{
+  sensor_msgs::msg::Range expected_msg;
+  createTestMsg(expected_msg);
+
+  compareTestMsg(_msg->header);
+  EXPECT_EQ(expected_msg.radiation_type, _msg->radiation_type);
+  EXPECT_FLOAT_EQ(expected_msg.field_of_view, _msg->field_of_view);
+  EXPECT_FLOAT_EQ(expected_msg.min_range, _msg->min_range);
+  EXPECT_FLOAT_EQ(expected_msg.max_range, _msg->max_range);
+  EXPECT_FLOAT_EQ(expected_msg.range, _msg->range);
 }
 
 void createTestMsg(sensor_msgs::msg::MagneticField & _msg)

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -77,6 +77,7 @@
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <sensor_msgs/msg/range.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -77,11 +77,11 @@
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
-#include <sensor_msgs/msg/range.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
+#include <sensor_msgs/msg/range.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
 #include <rcl_interfaces/msg/parameter_value.hpp>
@@ -576,6 +576,14 @@ void createTestMsg(sensor_msgs::msg::LaserScan & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::LaserScan> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(sensor_msgs::msg::Range & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<sensor_msgs::msg::Range> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.


### PR DESCRIPTION
# 🎉 New feature

Closes #586

## Summary
Added LaserScan-Range bridge

## Test it
Example in bridge.yaml:

```
- ros_topic_name: "/mavros/rangefinder_sub"
  gz_topic_name: "/range_sensor"
  ros_type_name: "sensor_msgs/msg/Range"
  gz_type_name: "gz.msgs.LaserScan"
  direction: GZ_TO_ROS
```


Example in model.sdf:

```
<sensor name='range_sensor' type='gpu_lidar'>"
  <topic>range_sensor</topic>
  <update_rate>100</update_rate>
  <ray>
    <scan>
      <horizontal>
        <samples>5</samples> <!-- About 1 sample/fov_degree, and choose uneven number to get a ray in the middle -->
        <min_angle>-0.02</min_angle>
        <max_angle>0.02</max_angle>
      </horizontal>
      <vertical>
        <samples>5</samples> <!-- About 1 sample/fov_degree, and choose uneven number to get a ray in the middle -->
        <min_angle>-0.02</min_angle>
        <max_angle>0.02</max_angle>
      </vertical>
    </scan>
    <range>
      <min>0.1</min>
      <max>14.0</max>
      <resolution>0.01</resolution>
    </range>
  </ray>
  <always_on>1</always_on>
  <visualize>true</visualize>
</sensor>
```


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
