### PR TITLE
ros_gz_sim: Added support for passing initial_sim_time to Gazebo.

### DIFF
--- a/ros_gz_sim/ros_gz_sim/actions/gzserver.py
+++ b/ros_gz_sim/ros_gz_sim/actions/gzserver.py
@@ -95,6 +95,7 @@ class GzServer(Action):
         container_name: SomeSubstitutionsType = 'ros_gz_container',
         create_own_container: Union[bool, SomeSubstitutionsType] = False,
         use_composition: Union[bool, SomeSubstitutionsType] = False,
+        initial_sim_time: Union[float, SomeSubstitutionsType] = 0.0,
         **kwargs
     ) -> None:
         """
@@ -132,6 +133,13 @@ class GzServer(Action):
         else:
             self.__use_composition = normalize_typed_substitution(use_composition, bool)
 
+        if isinstance(initial_sim_time, str):
+            self.__initial_sim_time = normalize_typed_substitution(
+                TextSubstitution(text=initial_sim_time), float
+            )
+        else:
+            self.__initial_sim_time = normalize_typed_substitution(initial_sim_time, float)
+
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
         """Parse gz_server."""
@@ -157,6 +165,10 @@ class GzServer(Action):
             'use_composition', data_type=str,
             optional=True)
 
+        initial_sim_time = entity.get_attr(
+            'initial_sim_time', data_type=str,
+            optional=True)
+
         if isinstance(world_sdf_file, str):
             world_sdf_file = parser.parse_substitution(world_sdf_file)
             kwargs['world_sdf_file'] = world_sdf_file
@@ -177,6 +189,10 @@ class GzServer(Action):
         if isinstance(use_composition, str):
             use_composition = parser.parse_substitution(use_composition)
             kwargs['use_composition'] = use_composition
+
+        if isinstance(initial_sim_time, str):
+            initial_sim_time = parser.parse_substitution(initial_sim_time)
+            kwargs['initial_sim_time'] = initial_sim_time
 
         return cls, kwargs
 
@@ -212,7 +228,8 @@ class GzServer(Action):
                 executable='gzserver',
                 output='screen',
                 parameters=[{'world_sdf_file': self.__world_sdf_file,
-                             'world_sdf_string': self.__world_sdf_string}],
+                             'world_sdf_string': self.__world_sdf_string,
+                             'initial_sim_time': self.__initial_sim_time}],
                 ))
 
         # Composable node with container configuration
@@ -228,7 +245,8 @@ class GzServer(Action):
                         plugin='ros_gz_sim::GzServer',
                         name='gz_server',
                         parameters=[{'world_sdf_file': self.__world_sdf_file,
-                                     'world_sdf_string': self.__world_sdf_string}],
+                                     'world_sdf_string': self.__world_sdf_string,
+                                     'initial_sim_time': self.__initial_sim_time}],
                         extra_arguments=[{'use_intra_process_comms': True}],
                         ),
                     ],
@@ -245,7 +263,8 @@ class GzServer(Action):
                         plugin='ros_gz_sim::GzServer',
                         name='gz_server',
                         parameters=[{'world_sdf_file': self.__world_sdf_file,
-                                     'world_sdf_string': self.__world_sdf_string}],
+                                     'world_sdf_string': self.__world_sdf_string,
+                                     'initial_sim_time': self.__initial_sim_time}],
                         extra_arguments=[{'use_intra_process_comms': True}],
                         ),
                     ],

--- a/ros_gz_sim/src/gzserver.cpp
+++ b/ros_gz_sim/src/gzserver.cpp
@@ -53,6 +53,8 @@ void GzServer::OnStart()
 {
   auto world_sdf_file = this->declare_parameter("world_sdf_file", "");
   auto world_sdf_string = this->declare_parameter("world_sdf_string", "");
+  auto initial_sim_time = this->declare_parameter("initial_sim_time", 0.0);
+
 
   gz::common::Console::SetVerbosity(4);
   gz::sim::ServerConfig server_config;
@@ -68,6 +70,7 @@ void GzServer::OnStart()
     rclcpp::shutdown();
     return;
   }
+  server_config.SetInitialSimTime(initial_sim_time);
 
   gz::sim::Server server(server_config);
   server.Run(true /*blocking*/, 0, false /*paused*/);


### PR DESCRIPTION

# 🎉 New feature

## Summary

ros_gz_sim: Added support for passing initial_sim_time to Gazebo via the launch action and gzserver node.

## Test it

     ros2 run ros_gz_sim gzserver --ros-args -p initial_sim_time:=1000.0 -p world_sdf_file:=empty.sdf
     gz topic -e -t /clock
     # observe sim time values larger than 1000 right after start

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.