### PR TITLE
Fixed Jazzy backport

### DIFF
--- a/ros_gz_sim/src/gzserver.cpp
+++ b/ros_gz_sim/src/gzserver.cpp
@@ -67,11 +67,11 @@ public:
       return;
     }
 
+    server_config.SetInitialSimTime(initial_sim_time);
     gz::sim::Server server(server_config);
     server.Run(true /*blocking*/, 0, false /*paused*/);
     rclcpp::shutdown();
   }
-  server_config.SetInitialSimTime(initial_sim_time);
 
 private:
   /// \brief We don't want to block the ROS thread.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #759

## Summary

@ahcorde This fixes #759 backport.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
