### PR TITLE
ros_gz_bridge: Allow setting QoS profile from YAML files and launch action.

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -284,12 +284,13 @@ bridge may be specified:
   gz_topic_name: "gz_chatter"
   ros_type_name: "std_msgs/msg/String"
   gz_type_name: "gz.msgs.StringMsg"
-  subscriber_queue: 5       # Default 10
-  publisher_queue: 6        # Default 10
+  subscriber_queue: 5       # Default 10 if qos_profile is empty, otherwise not set by default
+  publisher_queue: 6        # Default 10 if qos_profile is empty, otherwise not set by default
   lazy: true                # Default "false"
   direction: BIDIRECTIONAL  # Default "BIDIRECTIONAL" - Bridge both directions
                             # "GZ_TO_ROS" - Bridge Gz topic to ROS
                             # "ROS_TO_GZ" - Bridge ROS topic to Gz
+  qos_profile: SENSOR_DATA  # Default is a default-constructed QoS with appropriate queue size
 ```
 
 To run the bridge node with the above configuration:
@@ -309,7 +310,7 @@ Use tag `<ros_gz_bridge>` and add `<topic>` and `<service>` subelements, one for
   <ros_gz_bridge bridge_name="clock_bridge">
     <topic ros_topic_name="/clock" gz_topic_name="/clock"
            ros_type_name="rosgraph_msgs/msg/Clock" gz_type_name="gz.msgs.Clock"
-           lazy="False" direction="GZ_TO_ROS" />
+           lazy="False" direction="GZ_TO_ROS" qos_profile="CLOCK" />
     <service service_name="/world/$(var world_name)/control"
              ros_type_name="ros_gz_interfaces/srv/ControlWorld"
              gz_req_type_name="gz.msgs.WorldControl" gz_rep_type_name="gz.msgs.Boolean" />

--- a/ros_gz_bridge/include/ros_gz_bridge/bridge_config.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/bridge_config.hpp
@@ -15,8 +15,11 @@
 #ifndef ROS_GZ_BRIDGE__BRIDGE_CONFIG_HPP_
 #define ROS_GZ_BRIDGE__BRIDGE_CONFIG_HPP_
 
+#include <optional>
 #include <string>
 #include <vector>
+
+#include <rclcpp/qos.hpp>
 
 namespace ros_gz_bridge
 {
@@ -42,6 +45,12 @@ static constexpr bool kDefaultLazy = false;
 // \brief Default bridge connectivity
 static constexpr BridgeDirection kDefaultDirection = BridgeDirection::BIDIRECTIONAL;
 
+/// \brief Parse uppercase string into a predefined QoS profile.
+/// \param[in] qos_profile Uppercase string, e.g. "SENSOR_DATA".
+/// \return The corresponding QoS profile.
+/// \throws std::invalid_argument if the profile cannot be parsed.
+rclcpp::QoS parseQoS(const std::string & qos_profile);
+
 struct BridgeConfig
 {
   /// \brief The ROS message type (eg std_msgs/msg/String)
@@ -61,13 +70,23 @@ struct BridgeConfig
   BridgeDirection direction = kDefaultDirection;
 
   /// \brief Depth of the subscriber queue
-  size_t subscriber_queue_size = kDefaultSubscriberQueue;
+  std::optional<size_t> subscriber_queue_size;
 
   /// \brief Depth of the publisher queue
-  size_t publisher_queue_size = kDefaultPublisherQueue;
+  std::optional<size_t> publisher_queue_size;
 
   /// \brief Flag to change the "laziness" of the bridge
   bool is_lazy = kDefaultLazy;
+
+  /// \brief QoS profile (unresolved, might have wrong depth).
+  /// \note Use PublisherQoS() and SubscriberQoS() to get the final QoS.
+  std::optional<rclcpp::QoS> qos_profile;
+
+  /// \brief Get the resolved QoS for publishers. It does not reflect QoS overrides.
+  rclcpp::QoS PublisherQoS() const;
+
+  /// \brief Get the resolved QoS for subscribers. It does not reflect QoS overrides.
+  rclcpp::QoS SubscriberQoS() const;
 };
 
 /// \brief Generate a group of BridgeConfigs from a YAML String

--- a/ros_gz_bridge/launch/clock_bridge.launch
+++ b/ros_gz_bridge/launch/clock_bridge.launch
@@ -35,7 +35,7 @@ limitations under the License.
 
     <topic ros_topic_name="/clock" gz_topic_name="/clock"
            ros_type_name="rosgraph_msgs/msg/Clock" gz_type_name="gz.msgs.Clock"
-           lazy="False" direction="GZ_TO_ROS" />
+           lazy="False" direction="GZ_TO_ROS" qos_profile="CLOCK" />
 
   </ros_gz_bridge>
 </launch>

--- a/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
+++ b/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
@@ -197,6 +197,7 @@ class RosGzBridge(Action):
                 ('lazy', str),
                 ('publisher_queue', int),
                 ('subscriber_queue', int),
+                ('qos_profile', str),
             )
             for param, param_type in optional_params:
                 p = child.get_attr(param, data_type=param_type, optional=True)

--- a/ros_gz_bridge/src/bridge_config.cpp
+++ b/ros_gz_bridge/src/bridge_config.cpp
@@ -34,12 +34,35 @@ constexpr const char kGzTypeName[] = "gz_type_name";
 constexpr const char kDirection[] = "direction";
 constexpr const char kPublisherQueue[] = "publisher_queue";
 constexpr const char kSubscriberQueue[] = "subscriber_queue";
+constexpr const char kQosProfile[] = "qos_profile";
 constexpr const char kLazy[] = "lazy";
 
 // Comparison strings for bridge directions
 constexpr const char kBidirectional[] = "BIDIRECTIONAL";
 constexpr const char kGzToRos[] = "GZ_TO_ROS";
 constexpr const char kRosToGz[] = "ROS_TO_GZ";
+
+rclcpp::QoS parseQoS(const std::string & qos_profile)
+{
+  if (qos_profile == "CLOCK") {
+    return rclcpp::ClockQoS();
+  } else if (qos_profile == "SENSOR_DATA") {
+    return rclcpp::SensorDataQoS();
+  } else if (qos_profile == "PARAMETERS") {
+    return rclcpp::ParametersQoS();
+  } else if (qos_profile == "SERVICES") {
+    return rclcpp::ServicesQoS();
+  } else if (qos_profile == "PARAMETER_EVENTS") {
+    return rclcpp::ParameterEventsQoS();
+  } else if (qos_profile == "ROSOUT") {
+    return rclcpp::RosoutQoS();
+  } else if (qos_profile == "SYSTEM_DEFAULT") {
+    return rclcpp::SystemDefaultsQoS();
+  } else if (qos_profile == "BEST_AVAILABLE") {
+    return rclcpp::BestAvailableQoS();
+  }
+  throw std::invalid_argument(std::string("Invalid QoS profile '") + qos_profile + "'");
+}
 
 /// \brief Parse a single sequence entry into a BridgeConfig
 /// \param[in] yaml_node A node containing a map of bridge config params
@@ -132,11 +155,32 @@ std::optional<BridgeConfig> parseEntry(const YAML::Node & yaml_node)
   ret.gz_type_name = gz_type_name;
   ret.ros_type_name = ros_type_name;
 
+  if (yaml_node[kQosProfile]) {
+    const auto qos_profile_str = getValue(kQosProfile);
+    if (!qos_profile_str.empty()) {
+      try {
+        ret.qos_profile = parseQoS(qos_profile_str);
+      } catch (const std::invalid_argument & e) {
+        RCLCPP_ERROR(logger, "Could not parse entry: %s", e.what());
+        return {};
+      }
+    }
+  }
   if (yaml_node[kPublisherQueue]) {
-    ret.publisher_queue_size = yaml_node[kPublisherQueue].as<size_t>();
+    const auto queue_size_int = yaml_node[kPublisherQueue].as<int64_t>();
+    if (queue_size_int >= 0) {
+      ret.publisher_queue_size = static_cast<size_t>(queue_size_int);
+    } else if (!ret.qos_profile.has_value()) {
+      ret.publisher_queue_size = kDefaultPublisherQueue;
+    }
   }
   if (yaml_node[kSubscriberQueue]) {
-    ret.subscriber_queue_size = yaml_node[kSubscriberQueue].as<size_t>();
+    const auto queue_size_int = yaml_node[kSubscriberQueue].as<int64_t>();
+    if (queue_size_int >= 0) {
+      ret.subscriber_queue_size = static_cast<size_t>(queue_size_int);
+    } else if (!ret.qos_profile.has_value()) {
+      ret.subscriber_queue_size = kDefaultSubscriberQueue;
+    }
   }
   if (yaml_node[kLazy]) {
     ret.is_lazy = yaml_node[kLazy].as<bool>();
@@ -198,6 +242,34 @@ std::vector<BridgeConfig> readFromYamlFile(const std::string & filename)
 
   in.seekg(0, std::ios::beg);
   return readFromYaml(in);
+}
+
+rclcpp::QoS BridgeConfig::PublisherQoS() const
+{
+  const auto & queue_size = this->publisher_queue_size;
+  if (!this->qos_profile.has_value()) {
+    return rclcpp::QoS(rclcpp::KeepLast(queue_size.value_or(kDefaultPublisherQueue)));
+  }
+
+  auto qos = *this->qos_profile;
+  if (queue_size.has_value() && *queue_size > 0) {
+    qos.keep_last(*queue_size);
+  }
+  return qos;
+}
+
+rclcpp::QoS BridgeConfig::SubscriberQoS() const
+{
+  const auto & queue_size = this->subscriber_queue_size;
+  if (!this->qos_profile.has_value()) {
+    return rclcpp::QoS(rclcpp::KeepLast(queue_size.value_or(kDefaultSubscriberQueue)));
+  }
+
+  auto qos = *this->qos_profile;
+  if (queue_size.has_value() && *queue_size > 0) {
+    qos.keep_last(*queue_size);
+  }
+  return qos;
 }
 
 std::vector<BridgeConfig> readFromYamlString(const std::string & data)

--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
@@ -54,7 +54,7 @@ void BridgeHandleGzToRos::StartPublisher()
   this->ros_publisher_ = this->factory_->create_ros_publisher(
     this->ros_node_,
     this->config_.ros_topic_name,
-    this->config_.publisher_queue_size);
+    this->config_.PublisherQoS());
 }
 
 bool BridgeHandleGzToRos::HasSubscriber() const
@@ -69,7 +69,7 @@ void BridgeHandleGzToRos::StartSubscriber()
   this->factory_->create_gz_subscriber(
     this->gz_node_,
     this->config_.gz_topic_name,
-    this->config_.subscriber_queue_size,
+    this->config_.subscriber_queue_size.value_or(kDefaultSubscriberQueue),
     this->ros_publisher_,
     override_timestamps_with_wall_time_);
 

--- a/ros_gz_bridge/src/bridge_handle_ros_to_gz.cpp
+++ b/ros_gz_bridge/src/bridge_handle_ros_to_gz.cpp
@@ -48,7 +48,7 @@ void BridgeHandleRosToGz::StartPublisher()
   this->gz_publisher_ = this->factory_->create_gz_publisher(
     this->gz_node_,
     this->config_.gz_topic_name,
-    this->config_.publisher_queue_size);
+    this->config_.publisher_queue_size.value_or(kDefaultPublisherQueue));
 }
 
 bool BridgeHandleRosToGz::HasSubscriber() const
@@ -63,7 +63,7 @@ void BridgeHandleRosToGz::StartSubscriber()
   this->ros_subscriber_ = this->factory_->create_ros_subscriber(
     this->ros_node_,
     this->config_.ros_topic_name,
-    this->config_.subscriber_queue_size,
+    this->config_.SubscriberQoS(),
     this->gz_publisher_);
 }
 

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -59,7 +59,7 @@ public:
   create_ros_publisher(
     rclcpp::Node::SharedPtr ros_node,
     const std::string & topic_name,
-    size_t queue_size)
+    const rclcpp::QoS & qos)
   {
     // Allow QoS overriding
     auto options = rclcpp::PublisherOptions();
@@ -75,8 +75,7 @@ public:
     };
 
     std::shared_ptr<rclcpp::Publisher<ROS_T>> publisher =
-      ros_node->create_publisher<ROS_T>(
-      topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), options);
+      ros_node->create_publisher<ROS_T>(topic_name, qos, options);
     return publisher;
   }
 
@@ -93,7 +92,7 @@ public:
   create_ros_subscriber(
     rclcpp::Node::SharedPtr ros_node,
     const std::string & topic_name,
-    size_t queue_size,
+    const rclcpp::QoS & qos,
     gz::transport::Node::Publisher & gz_pub)
   {
     std::function<void(std::shared_ptr<const ROS_T>)> fn = std::bind(
@@ -108,8 +107,7 @@ public:
     options.qos_overriding_options =
       rclcpp::QosOverridingOptions::with_default_policies();
     std::shared_ptr<rclcpp::Subscription<ROS_T>> subscription =
-      ros_node->create_subscription<ROS_T>(
-      topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), fn, options);
+      ros_node->create_subscription<ROS_T>(topic_name, qos, fn, options);
     return subscription;
   }
 

--- a/ros_gz_bridge/src/factory_interface.hpp
+++ b/ros_gz_bridge/src/factory_interface.hpp
@@ -37,7 +37,7 @@ public:
   create_ros_publisher(
     rclcpp::Node::SharedPtr ros_node,
     const std::string & topic_name,
-    size_t queue_size) = 0;
+    const rclcpp::QoS & qos) = 0;
 
   virtual
   gz::transport::Node::Publisher
@@ -51,7 +51,7 @@ public:
   create_ros_subscriber(
     rclcpp::Node::SharedPtr ros_node,
     const std::string & topic_name,
-    size_t queue_size,
+    const rclcpp::QoS & qos,
     gz::transport::Node::Publisher & gz_pub) = 0;
 
   virtual

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -82,9 +82,12 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
         continue;
       }
       this->declare_parameter(prefix + "direction", "BIDIRECTIONAL");
-      this->declare_parameter(prefix + "publisher_queue", 10);
-      this->declare_parameter(prefix + "subscriber_queue", 10);
+      // Queue sizes default to 10 if qos_profile is not set.
+      // If it is defined, they are applied only if they are non-negative.
+      this->declare_parameter(prefix + "publisher_queue", -1);
+      this->declare_parameter(prefix + "subscriber_queue", -1);
       this->declare_parameter(prefix + "lazy", false);
+      this->declare_parameter(prefix + "qos_profile", "");
     } else {
       const auto gz_req_type = this->declare_parameter(prefix + "gz_req_type_name",
         PARAMETER_STRING);
@@ -157,15 +160,46 @@ void RosGzBridge::spin()
           continue;
         }
 
+        const auto qos_profile_str = this->get_parameter(prefix + "qos_profile").as_string();
+        std::optional<rclcpp::QoS> qos_profile;
+        if (!qos_profile_str.empty()) {
+          try {
+            qos_profile = parseQoS(qos_profile_str);
+          } catch (const std::invalid_argument & e) {
+            RCLCPP_ERROR(
+              this->get_logger(),
+              "Bridge %s defines unknown QoS profile %s.",
+              name.c_str(), qos_profile_str.c_str());
+            continue;
+          }
+        }
+
+        const auto pub_queue_size_int = this->get_parameter(prefix + "publisher_queue").as_int();
+        std::optional<size_t> pub_queue_size;
+        if (pub_queue_size_int >= 0) {
+          pub_queue_size = pub_queue_size_int;
+        } else if (!qos_profile.has_value()) {
+          pub_queue_size = kDefaultPublisherQueue;
+        }
+
+        const auto sub_queue_size_int = this->get_parameter(prefix + "subscriber_queue").as_int();
+        std::optional<size_t> sub_queue_size;
+        if (sub_queue_size_int >= 0) {
+          sub_queue_size = sub_queue_size_int;
+        } else if (!qos_profile.has_value()) {
+          sub_queue_size = kDefaultSubscriberQueue;
+        }
+
         BridgeConfig config {
           this->get_parameter(prefix + "ros_type_name").as_string(),
           this->get_parameter(prefix + "ros_topic_name").as_string(),
           this->get_parameter(prefix + "gz_type_name").as_string(),
           this->get_parameter(prefix + "gz_topic_name").as_string(),
           direction,
-          static_cast<size_t>(this->get_parameter(prefix + "publisher_queue").as_int()),
-          static_cast<size_t>(this->get_parameter(prefix + "subscriber_queue").as_int()),
+          pub_queue_size,
+          sub_queue_size,
           this->get_parameter(prefix + "lazy").as_bool(),
+          qos_profile,
         };
         if (expand_names) {
           config.gz_topic_name = rclcpp::expand_topic_or_service_name(

--- a/ros_gz_bridge/test/bridge_config.cpp
+++ b/ros_gz_bridge/test/bridge_config.cpp
@@ -79,9 +79,12 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ("chatter", config.gz_topic_name);
     EXPECT_EQ("std_msgs/msg/String", config.ros_type_name);
     EXPECT_EQ("ignition.msgs.StringMsg", config.gz_type_name);
-    EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
-    EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
+    EXPECT_FALSE(config.publisher_queue_size.has_value());
+    EXPECT_FALSE(config.subscriber_queue_size.has_value());
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_FALSE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
   }
   {
     auto config = results[1];
@@ -89,9 +92,12 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ("chatter_ros", config.gz_topic_name);
     EXPECT_EQ("std_msgs/msg/String", config.ros_type_name);
     EXPECT_EQ("ignition.msgs.StringMsg", config.gz_type_name);
-    EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
-    EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
+    EXPECT_FALSE(config.publisher_queue_size.has_value());
+    EXPECT_FALSE(config.subscriber_queue_size.has_value());
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_FALSE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
   }
   {
     auto config = results[2];
@@ -99,9 +105,12 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ("chatter_gz", config.gz_topic_name);
     EXPECT_EQ("std_msgs/msg/String", config.ros_type_name);
     EXPECT_EQ("ignition.msgs.StringMsg", config.gz_type_name);
-    EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
-    EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
+    EXPECT_FALSE(config.publisher_queue_size.has_value());
+    EXPECT_FALSE(config.subscriber_queue_size.has_value());
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_FALSE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
   }
   {
     auto config = results[3];
@@ -109,9 +118,12 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ("chatter_both_gz", config.gz_topic_name);
     EXPECT_EQ("std_msgs/msg/String", config.ros_type_name);
     EXPECT_EQ("ignition.msgs.StringMsg", config.gz_type_name);
-    EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
-    EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
+    EXPECT_FALSE(config.publisher_queue_size.has_value());
+    EXPECT_FALSE(config.subscriber_queue_size.has_value());
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_FALSE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
   }
 }
 
@@ -126,10 +138,13 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_EQ("gz_chatter", config.gz_topic_name);
     EXPECT_EQ("std_msgs/msg/String", config.ros_type_name);
     EXPECT_EQ("ignition.msgs.StringMsg", config.gz_type_name);
-    EXPECT_EQ(6u, config.publisher_queue_size);
-    EXPECT_EQ(5u, config.subscriber_queue_size);
+    EXPECT_EQ(6u, config.publisher_queue_size.value_or(0));
+    EXPECT_EQ(5u, config.subscriber_queue_size.value_or(0));
     EXPECT_EQ(true, config.is_lazy);
     EXPECT_EQ(ros_gz_bridge::BridgeDirection::ROS_TO_GZ, config.direction);
+    EXPECT_FALSE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(6u)), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(5u)), config.SubscriberQoS());
   }
 
   {
@@ -138,10 +153,51 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_EQ("gz_chatter", config.gz_topic_name);
     EXPECT_EQ("std_msgs/msg/String", config.ros_type_name);
     EXPECT_EQ("ignition.msgs.StringMsg", config.gz_type_name);
-    EXPECT_EQ(20u, config.publisher_queue_size);
-    EXPECT_EQ(10u, config.subscriber_queue_size);
+    EXPECT_EQ(20u, config.publisher_queue_size.value_or(0));
+    EXPECT_EQ(10u, config.subscriber_queue_size.value_or(0));
     EXPECT_EQ(false, config.is_lazy);
     EXPECT_EQ(ros_gz_bridge::BridgeDirection::GZ_TO_ROS, config.direction);
+    EXPECT_FALSE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(20u)), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
+  }
+}
+
+TEST_F(BridgeConfig, QoSFullGz)
+{
+  auto results = ros_gz_bridge::readFromYamlFile("test/config/qos.yaml");
+  EXPECT_EQ(2u, results.size());
+
+  {
+    auto config = results[0];
+    EXPECT_EQ("ros_chatter", config.ros_topic_name);
+    EXPECT_EQ("gz_chatter", config.gz_topic_name);
+    EXPECT_EQ("std_msgs/msg/String", config.ros_type_name);
+    EXPECT_EQ("ignition.msgs.StringMsg", config.gz_type_name);
+    EXPECT_FALSE(config.publisher_queue_size.has_value());
+    EXPECT_FALSE(config.subscriber_queue_size.has_value());
+    EXPECT_EQ(true, config.is_lazy);
+    EXPECT_EQ(ros_gz_bridge::BridgeDirection::ROS_TO_GZ, config.direction);
+    ASSERT_TRUE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::SensorDataQoS(), *config.qos_profile);
+    EXPECT_EQ(rclcpp::SensorDataQoS(), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::SensorDataQoS(), config.SubscriberQoS());
+  }
+
+  {
+    auto config = results[1];
+    EXPECT_EQ("ros_chatter", config.ros_topic_name);
+    EXPECT_EQ("gz_chatter", config.gz_topic_name);
+    EXPECT_EQ("std_msgs/msg/String", config.ros_type_name);
+    EXPECT_EQ("ignition.msgs.StringMsg", config.gz_type_name);
+    EXPECT_EQ(20u, config.publisher_queue_size.value_or(0));
+    EXPECT_FALSE(config.subscriber_queue_size.has_value());
+    EXPECT_EQ(false, config.is_lazy);
+    EXPECT_EQ(ros_gz_bridge::BridgeDirection::GZ_TO_ROS, config.direction);
+    ASSERT_TRUE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::ClockQoS(), *config.qos_profile);
+    EXPECT_EQ(rclcpp::ClockQoS().keep_last(20u), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::ClockQoS(), config.SubscriberQoS());
   }
 }
 
@@ -271,6 +327,15 @@ TEST_F(BridgeConfig, InvalidTopLevel)
   EXPECT_EQ(0u, results.size());
   EXPECT_EQ(
     "Could not parse config: top level must be a YAML sequence",
+    g_last_log_event.message);
+}
+
+TEST_F(BridgeConfig, InvalidQoS)
+{
+  auto results = ros_gz_bridge::readFromYamlFile("test/config/invalid_qos.yaml");
+  EXPECT_EQ(0u, results.size());
+  EXPECT_EQ(
+    "Could not parse entry: Invalid QoS profile 'UNKNOWN'",
     g_last_log_event.message);
 }
 

--- a/ros_gz_bridge/test/config/invalid_qos.yaml
+++ b/ros_gz_bridge/test/config/invalid_qos.yaml
@@ -1,0 +1,7 @@
+- ros_topic_name: "ros_chatter"
+  gz_topic_name: "gz_chatter"
+  ros_type_name: "std_msgs/msg/String"
+  gz_type_name: "ignition.msgs.StringMsg"
+  lazy: true
+  direction: ROS_TO_GZ
+  qos_profile: UNKNOWN

--- a/ros_gz_bridge/test/config/qos.yaml
+++ b/ros_gz_bridge/test/config/qos.yaml
@@ -1,0 +1,17 @@
+# Full set of configurations
+- ros_topic_name: "ros_chatter"
+  gz_topic_name: "gz_chatter"
+  ros_type_name: "std_msgs/msg/String"
+  gz_type_name: "ignition.msgs.StringMsg"
+  lazy: true
+  qos_profile: SENSOR_DATA
+  direction: ROS_TO_GZ
+
+- ros_topic_name: "ros_chatter"
+  gz_topic_name: "gz_chatter"
+  ros_type_name: "std_msgs/msg/String"
+  gz_type_name: "ignition.msgs.StringMsg"
+  publisher_queue: 20
+  lazy: false
+  qos_profile: CLOCK
+  direction: GZ_TO_ROS

--- a/ros_gz_bridge/test/launch/test_launch_action.launch
+++ b/ros_gz_bridge/test/launch/test_launch_action.launch
@@ -19,7 +19,7 @@ limitations under the License.
     <ros_gz_bridge bridge_name="test_bridge">
         <topic ros_topic_name="/boolean_std_msgs_bool" gz_topic_name="/boolean_std_msgs_bool"
                ros_type_name="std_msgs/msg/Bool" gz_type_name="gz.msgs.Boolean"
-               lazy="False" direction="GZ_TO_ROS" />
+               lazy="False" direction="GZ_TO_ROS" qos_profile="SYSTEM_DEFAULT" />
         <topic ros_topic_name="/imu_sensor_msgs_imu" gz_topic_name="/imu_sensor_msgs_imu"
                ros_type_name="sensor_msgs/msg/Imu" gz_type_name="gz.msgs.IMU"
                lazy="False" direction="GZ_TO_ROS" publisher_queue_size="1" subscriber_queue_size="1" />


### PR DESCRIPTION

# 🎉 New feature

## Summary
This PR adds support for setting QoS profile of ROS publishers and subscribers in a ROS-Gz bridge.

The previous default behavior is retained, i.e. when `qos_profile` is not specified, the subscriptions and publications default to `QoS(KeepLast(queue_size))`.

This PR changes API and ABI of the `BridgeConfig` struct so that it can encompass the new QoS-related config. Compiling existing code against the new struct definition should work, but the queue sizes were changed from `size_t` to `std::optional<size_t>`, so there might be minor problems in more advanced cases, or in cases when a part of code not only writes these values, but also reads them and compares them to something else.

## Test it
Just add a `qos_profile="SENSOR_DATA"` to a bridge XML launch file or `qos_profile: SENSOR_DATA` to a bridge YAML config.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: JetBrains Full Line Code Completion 252.19874.12

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.