### PR TITLE
OS agnostic 'which' command

### DIFF
--- a/ros_gz_sim/launch/gz_sim.launch.py.in
+++ b/ros_gz_sim/launch/gz_sim.launch.py.in
@@ -16,6 +16,7 @@
 
 import os
 from os import environ
+import shutil
 
 from ament_index_python.packages import get_package_share_directory
 from catkin_pkg.package import InvalidPackage, PACKAGE_MANIFEST_FILENAME, parse_package
@@ -77,6 +78,11 @@ class GazeboRosPaths:
 
         return gazebo_model_path, gazebo_plugin_path
 
+
+def get_executable_path(command):
+    return os.path.splitext(shutil.which(command))[0]
+
+
 def launch_gz(context, *args, **kwargs):
     model_paths, plugin_paths = GazeboRosPaths.get_paths()
 
@@ -111,12 +117,12 @@ def launch_gz(context, *args, **kwargs):
         exec_args = gz_args
 
     if len(ign_version) or (ign_version == '' and int(gz_version) < 7):
-        exec = 'ruby $(which ign) gazebo'
+        exec = 'ruby ' + get_executable_path('ign') + ' gazebo'
 
         if len(ign_version):
             gz_version = ign_version
     else:
-        exec = 'ruby $(which gz) sim'
+        exec = 'ruby ' + get_executable_path('gz') + ' sim'
 
     if debugger != 'false':
         debug_prefix = 'x-terminal-emulator -e gdb -ex run --args'

--- a/ros_gz_sim/launch/gz_sim.launch.py.in
+++ b/ros_gz_sim/launch/gz_sim.launch.py.in
@@ -78,10 +78,11 @@ class GazeboRosPaths:
 
         return gazebo_model_path, gazebo_plugin_path
 
-
 def get_executable_path(command):
-    return os.path.splitext(shutil.which(command))[0]
-
+    path = shutil.which(command)
+    if path.lower().endswith('.bat'):
+        return os.path.splitext(path)[0]
+    return path
 
 def launch_gz(context, *args, **kwargs):
     model_paths, plugin_paths = GazeboRosPaths.get_paths()


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
When running these launch files from windows installed through [pixi/robostack](https://robostack.github.io/GettingStarted.html) . The launch files fails

```
(robostack:jazzy) C:\Users\tabor\turtlebot3_ws>ros2 launch ros_gz_sim gz_sim.launch.py gz_args:=empty.sdf
[INFO] [launch]: All log files can be found below C:\Users\tabor\.ros\log\2025-06-10-12-26-07-927172-tabor-19628
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [gazebo-1]: process started with pid [17760]
[gazebo-1] ruby: No such file or directory -- $(which (LoadError)
[ERROR] [gazebo-1]: process has died [pid 17760, exit code 1, cmd 'ruby $(which gz) sim empty.sdf --force-version 8'].

(robostack:jazzy) C:\Users\tabor\turtlebot3_ws>
```
because the 'which' command is unix only. Instead, I switch to shutil.which . On windows this returns "C:/Users/tabor/robostack/.pixi/envs/jazzy/Library/bin/gz.BAT" so I strip the file extension out.


@j-rivero  asked to be tagged for PR review



## Checklist
- [+ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

