### PR TITLE
Add Windows support for ros_gz_bridge and ros_gz_sim

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -128,6 +129,10 @@ target_include_directories(${bridge_lib}
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>"
 )
+
+if(MSVC)
+  target_compile_options(${bridge_lib} PRIVATE "/bigobj")
+endif()
 
 rclcpp_components_register_node(
   ${bridge_lib}

--- a/ros_gz_sim/CMakeLists.txt
+++ b/ros_gz_sim/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 find_package(CLI11 REQUIRED)
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
# 🦟 Bug fix

This PR upstreams the patches we have been using in [RoboStack](https://robostack.github.io/) to compile `ros_gz_bridge` and `ros_gz_sim` on Windows.

## Summary

The changes are described in the following

### Ensure that `ros_gz_bridge` and `ros_gz_sim` libraries export their symbols on Windows when compiled as shared library

The  `ros_gz_bridge` and `ros_gz_sim` package compiles shared libraries, but does not expose any symbol on Windows, so if the CMake project is compiled on Windows, no import library `.lib` is actually generated.

On Linux and macOS, everything compiles fine as by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable, so this PR sets the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` variable to `ON`, to ensure that the compilation works fine on Windows. While some other ROS 2 projects use visibility macros to achieve the same, using `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` seems consistent with what is done on Linux and macOS, and fixes the Windows support as soon as possible, while still leaving the possibility for anyone that is interested in adding visibility header support to do that in the future.

### Add `/bigobj` when compiling `ros_gz_bridge` library

The library `ros_gz_bridge` is big, so with default settings its compilation on MSVC fails with error:

~~~
2025-07-09T00:38:16.4319260Z  │ │ %SRC_DIR%\build\generated\factories\geometry_msgs.cpp(1,1): error C1128: number of sections exceeded object file format limit: compile with /bigobj [%SRC_DIR%\build\ros_gz_bridge.vcxproj]
2025-07-09T00:38:16.6027303Z  │ │ %SRC_DIR%\build>if errorlevel 1 exit 1 
~~~

See https://learn.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-170 for a reference for the `/bigobj` option, that anyhow does not change the ABI so it is safe to use.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

