### PR TITLE
add bayer image two way convertion  from sensor msgs to gz msgs

### DIFF
--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -98,6 +98,22 @@ convert_ros_to_gz(
     gz_msg.set_pixel_format_type(gz::msgs::PixelFormatType::R_FLOAT32);
     num_channels = 1;
     octets_per_channel = 4u;
+  } else if (ros_msg.encoding == "bayer_rggb8") {
+    gz_msg.set_pixel_format_type(gz::msgs::PixelFormatType::BAYER_RGGB8);
+    num_channels = 1;
+    octets_per_channel = 1u;
+  } else if (ros_msg.encoding == "bayer_bggr8") {
+    gz_msg.set_pixel_format_type(gz::msgs::PixelFormatType::BAYER_BGGR8);
+    num_channels = 1;
+    octets_per_channel = 1u;
+  } else if (ros_msg.encoding == "bayer_gbrg8") {
+    gz_msg.set_pixel_format_type(gz::msgs::PixelFormatType::BAYER_GBRG8);
+    num_channels = 1;
+    octets_per_channel = 1u;
+  } else if (ros_msg.encoding == "bayer_grbg8") {
+    gz_msg.set_pixel_format_type(gz::msgs::PixelFormatType::BAYER_GRBG8);
+    num_channels = 1;
+    octets_per_channel = 1u;
   } else {
     gz_msg.set_pixel_format_type(gz::msgs::PixelFormatType::UNKNOWN_PIXEL_FORMAT);
     std::cerr << "Unsupported pixel format [" << ros_msg.encoding << "]" << std::endl;
@@ -159,6 +175,22 @@ convert_gz_to_ros(
     ros_msg.encoding = "32FC1";
     num_channels = 1;
     octets_per_channel = 4u;
+  } else if (gz_msg.pixel_format_type() == gz::msgs::PixelFormatType::BAYER_RGGB8) {
+    ros_msg.encoding = "bayer_rggb8";
+    num_channels = 1;
+    octets_per_channel = 1u;
+  } else if (gz_msg.pixel_format_type() == gz::msgs::PixelFormatType::BAYER_BGGR8) {
+    ros_msg.encoding = "bayer_bggr8";
+    num_channels = 1;
+    octets_per_channel = 1u;
+  } else if (gz_msg.pixel_format_type() == gz::msgs::PixelFormatType::BAYER_GBRG8) {
+    ros_msg.encoding = "bayer_gbrg8";
+    num_channels = 1;
+    octets_per_channel = 1u;
+  } else if (gz_msg.pixel_format_type() == gz::msgs::PixelFormatType::BAYER_GRBG8) {
+    ros_msg.encoding = "bayer_grbg8";
+    num_channels = 1;
+    octets_per_channel = 1u;
   } else {
     std::cerr << "Unsupported pixel format [" << gz_msg.pixel_format_type() << "]" << std::endl;
     return;


### PR DESCRIPTION
# 🎉 New feature

Closes #791 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.