### PR TITLE
Remove `GZ_VERSION` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,7 @@ Be sure you've installed
 
 #### Gazebo
 
-Install either [Fortress, Harmonic or Ionic](https://gazebosim.org/docs).
-
-Set the `GZ_VERSION` environment variable to the Gazebo version you'd
-like to compile against. For example:
-
-    export GZ_VERSION=harmonic # IMPORTANT: Replace with correct version
-
-> You only need to set this variable when compiling, not when running.
+The version of Gazebo paired with Rolling will automatically be installed when running `rosdep` below.
 
 #### Compile ros_gz
 


### PR DESCRIPTION
## Summary
`GZ_VERSION` is no longer needed when building ros_gz since the version of Gazebo paired with the ROS version is installed via the vendor package dependencies.

Similar to #793, but this only affects the README.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
