### PR TITLE
Suggestion for new dynamic detachable joint plugin

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -211,6 +211,7 @@ if(BUILD_TESTING)
   target_include_directories(test_ros_gz_interfaces
     PRIVATE
     ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
   )
 
   add_library(test_utils

--- a/ros_gz_bridge/src/convert/ros_gz_interfaces_TEST.cpp
+++ b/ros_gz_bridge/src/convert/ros_gz_interfaces_TEST.cpp
@@ -16,6 +16,18 @@
 
 #include <ros_gz_bridge/convert/ros_gz_interfaces.hpp>
 
+#include "service_factories/ros_gz_interfaces.hpp"
+
+TEST(AttachDetachServiceTest, FactoryRegistration)
+{
+  auto factory = ros_gz_bridge::get_service_factory__ros_gz_interfaces(
+    "ros_gz_interfaces/srv/AttachDetach",
+    "gz.msgs.AttachDetachRequest",
+    "gz.msgs.Result");
+
+  ASSERT_NE(nullptr, factory);
+}
+
 // A more specific set of tests for the ros_gz_interfaces/msg/ParamVec to
 // to verify behaviors that couldn't easily be captured by the generic test framework
 struct RosToGzTest : public ::testing::Test

--- a/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
@@ -30,7 +30,6 @@
 #include "ros_gz_interfaces/srv/set_entity_pose.hpp"
 #include "ros_gz_interfaces/srv/attach_detach.hpp"
 #include "ros_gz_bridge/convert/ros_gz_interfaces.hpp"
-#include "ros_gz_bridge/convert/std_msgs.hpp"
 
 #include "service_factory.hpp"
 
@@ -154,7 +153,6 @@ convert_ros_to_gz(
   const ros_gz_interfaces::srv::AttachDetach::Request & ros_req,
   gz::msgs::AttachDetachRequest & gz_req)
 {
-  convert_ros_to_gz(ros_req.header, *gz_req.mutable_header());
   gz_req.set_child_model_name(ros_req.child_model_name);
   gz_req.set_child_link_name(ros_req.child_link_name);
   switch (ros_req.command)

--- a/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
@@ -16,6 +16,7 @@
 #include <gz/msgs/world_control.pb.h>
 #include <gz/msgs/entity.pb.h>
 #include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/dynamic_detachable_joint.pb.h>
 #include <gz/msgs/pose.pb.h>
 
 #include <memory>
@@ -26,6 +27,7 @@
 #include "ros_gz_interfaces/srv/delete_entity.hpp"
 #include "ros_gz_interfaces/srv/spawn_entity.hpp"
 #include "ros_gz_interfaces/srv/set_entity_pose.hpp"
+#include "ros_gz_interfaces/srv/attach_detach.hpp"
 #include "ros_gz_bridge/convert/ros_gz_interfaces.hpp"
 
 #include "service_factory.hpp"
@@ -91,6 +93,19 @@ get_service_factory__ros_gz_interfaces(
     >(ros_type_name, "gz.msgs.Pose", "gz.msgs.Boolean");
   }
 
+  if (
+    ros_type_name == "ros_gz_interfaces/srv/AttachDetach" &&
+    (gz_req_type_name.empty() || gz_req_type_name == "gz.msgs.AttachDetachRequest") &&
+    (gz_rep_type_name.empty() || gz_rep_type_name == "gz.msgs.AttachDetachResponse"))
+  {
+    return std::make_shared<
+      ServiceFactory<
+        ros_gz_interfaces::srv::AttachDetach,
+        gz::msgs::AttachDetachRequest,
+        gz::msgs::AttachDetachResponse>
+    >(ros_type_name, "gz.msgs.AttachDetachRequest", "gz.msgs.AttachDetachResponse");
+  }
+
   return nullptr;
 }
 
@@ -133,6 +148,17 @@ convert_ros_to_gz(
 
 template<>
 void
+convert_ros_to_gz(
+  const ros_gz_interfaces::srv::AttachDetach::Request & ros_req,
+  gz::msgs::AttachDetachRequest & gz_req)
+{
+  gz_req.set_child_model_name(ros_req.child_model_name);
+  gz_req.set_child_link_name(ros_req.child_link_name);
+  gz_req.set_command(ros_req.command);
+}
+
+template<>
+void
 convert_gz_to_ros(
   const gz::msgs::Boolean & gz_rep,
   ros_gz_interfaces::srv::ControlWorld::Response & ros_res)
@@ -165,6 +191,16 @@ convert_gz_to_ros(
   ros_gz_interfaces::srv::SetEntityPose::Response & ros_res)
 {
   ros_res.success = gz_rep.data();
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::AttachDetachResponse & gz_rep,
+  ros_gz_interfaces::srv::AttachDetach::Response & ros_res)
+{
+  ros_res.success = gz_rep.success();
+  ros_res.message = gz_rep.message();
 }
 
 template<>
@@ -204,6 +240,15 @@ send_response_on_error(ros_gz_interfaces::srv::SetEntityPose::Response & ros_res
   // TODO(now): Is it worth it to have a different field to encode Gazebo request errors?
   //  Currently we're reusing the success field, which seems fine for this case.
   ros_res.success = false;
+  return true;
+}
+
+template<>
+bool
+send_response_on_error(ros_gz_interfaces::srv::AttachDetach::Response & ros_res)
+{
+  ros_res.success = false;
+  ros_res.message = "Gazebo bridge error";
   return true;
 }
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/service_factories/ros_gz_interfaces.cpp
@@ -18,6 +18,7 @@
 #include <gz/msgs/entity_factory.pb.h>
 #include <gz/msgs/dynamic_detachable_joint.pb.h>
 #include <gz/msgs/pose.pb.h>
+#include <gz/msgs/result.pb.h>
 
 #include <memory>
 #include <string>
@@ -29,6 +30,7 @@
 #include "ros_gz_interfaces/srv/set_entity_pose.hpp"
 #include "ros_gz_interfaces/srv/attach_detach.hpp"
 #include "ros_gz_bridge/convert/ros_gz_interfaces.hpp"
+#include "ros_gz_bridge/convert/std_msgs.hpp"
 
 #include "service_factory.hpp"
 
@@ -96,14 +98,14 @@ get_service_factory__ros_gz_interfaces(
   if (
     ros_type_name == "ros_gz_interfaces/srv/AttachDetach" &&
     (gz_req_type_name.empty() || gz_req_type_name == "gz.msgs.AttachDetachRequest") &&
-    (gz_rep_type_name.empty() || gz_rep_type_name == "gz.msgs.AttachDetachResponse"))
+    (gz_rep_type_name.empty() || gz_rep_type_name == "gz.msgs.Result"))
   {
     return std::make_shared<
       ServiceFactory<
         ros_gz_interfaces::srv::AttachDetach,
         gz::msgs::AttachDetachRequest,
-        gz::msgs::AttachDetachResponse>
-    >(ros_type_name, "gz.msgs.AttachDetachRequest", "gz.msgs.AttachDetachResponse");
+        gz::msgs::Result>
+    >(ros_type_name, "gz.msgs.AttachDetachRequest", "gz.msgs.Result");
   }
 
   return nullptr;
@@ -152,9 +154,22 @@ convert_ros_to_gz(
   const ros_gz_interfaces::srv::AttachDetach::Request & ros_req,
   gz::msgs::AttachDetachRequest & gz_req)
 {
+  convert_ros_to_gz(ros_req.header, *gz_req.mutable_header());
   gz_req.set_child_model_name(ros_req.child_model_name);
   gz_req.set_child_link_name(ros_req.child_link_name);
-  gz_req.set_command(ros_req.command);
+  switch (ros_req.command)
+  {
+    case ros_gz_interfaces::srv::AttachDetach::Request::ATTACH:
+      gz_req.set_command(gz::msgs::AttachDetachRequest::ATTACH);
+      break;
+    case ros_gz_interfaces::srv::AttachDetach::Request::DETACH:
+      gz_req.set_command(gz::msgs::AttachDetachRequest::DETACH);
+      break;
+    case ros_gz_interfaces::srv::AttachDetach::Request::COMMAND_UNSPECIFIED:
+    default:
+      gz_req.set_command(gz::msgs::AttachDetachRequest::COMMAND_UNSPECIFIED);
+      break;
+  }
 }
 
 template<>
@@ -196,10 +211,10 @@ convert_gz_to_ros(
 template<>
 void
 convert_gz_to_ros(
-  const gz::msgs::AttachDetachResponse & gz_rep,
+  const gz::msgs::Result & gz_rep,
   ros_gz_interfaces::srv::AttachDetach::Response & ros_res)
 {
-  ros_res.success = gz_rep.success();
+  ros_res.error_code = gz_rep.error_code();
   ros_res.message = gz_rep.message();
 }
 
@@ -247,7 +262,7 @@ template<>
 bool
 send_response_on_error(ros_gz_interfaces::srv::AttachDetach::Response & ros_res)
 {
-  ros_res.success = false;
+  ros_res.error_code = 1;
   ros_res.message = "Gazebo bridge error";
   return true;
 }

--- a/ros_gz_interfaces/CMakeLists.txt
+++ b/ros_gz_interfaces/CMakeLists.txt
@@ -47,6 +47,7 @@ set(srv_files
   "srv/DeleteEntity.srv"
   "srv/SetEntityPose.srv"
   "srv/SpawnEntity.srv"
+  "srv/AttachDetach.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/ros_gz_interfaces/srv/AttachDetach.srv
+++ b/ros_gz_interfaces/srv/AttachDetach.srv
@@ -1,4 +1,3 @@
-std_msgs/Header header
 string child_model_name
 string child_link_name
 uint8 COMMAND_UNSPECIFIED=0

--- a/ros_gz_interfaces/srv/AttachDetach.srv
+++ b/ros_gz_interfaces/srv/AttachDetach.srv
@@ -1,0 +1,6 @@
+string child_model_name  # Message to create a new entity
+string child_link_name 
+string command 
+---
+bool success                                     # Return true if spawned successfully.
+string message

--- a/ros_gz_interfaces/srv/AttachDetach.srv
+++ b/ros_gz_interfaces/srv/AttachDetach.srv
@@ -1,6 +1,10 @@
-string child_model_name  # Message to create a new entity
-string child_link_name 
-string command 
+std_msgs/Header header
+string child_model_name
+string child_link_name
+uint8 COMMAND_UNSPECIFIED=0
+uint8 ATTACH=1
+uint8 DETACH=2
+uint8 command
 ---
-bool success                                     # Return true if spawned successfully.
+int32 error_code
 string message


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🎉 New feature

Closes -

## Summary
Added ros - gz bridge support for the the `dynamic_detachable_joint` system discussed in Issue https://github.com/gazebosim/gz-sim/issues/2362


## Test it

Adding the plugin to robot model URDF/SDF
```
    <gazebo>
      <plugin filename="gz-sim-dynamic-detachable-joint-system"
            name="gz::sim::systems::DynamicDetachableJoint">
        <parent_link>robotiq_85_left_finger_tip_link</parent_link>
        <service_name>/payload/attach_detach</service_name>
        <output_topic>/child_state</output_topic>
        <attach_distance>0.25</attach_distance>
      </plugin>
    </gazebo>

```

GZ Service call command
```
# Attach
gz service -s /payload/attach_detach \
    --reqtype gz.msgs.AttachDetachRequest \
    --reptype gz.msgs.AttachDetachResponse \
    --timeout 3000 \
    --req 'child_model_name: "cube", 
           child_link_name: "link", 
           command: "attach"'

# Detach
gz service -s /payload/attach_detach \
    --reqtype gz.msgs.AttachDetachRequest \
    --reptype gz.msgs.AttachDetachResponse \
    --timeout 2000 \
    --req 'child_model_name: "cube", 
           child_link_name: "link", 
           command: "detach"'
```
ROS2 Service call command
```
# Attach
ros2 service call /payload/attach_detach \
    ros_gz_interfaces/srv/AttachDetach \
    "{child_model_name: 'cube', 
      child_link_name: 'link', 
      command: 'attach'}"

# Detach  
ros2 service call /payload/attach_detach \
    ros_gz_interfaces/srv/AttachDetach \
    "{child_model_name: 'cube', 
      child_link_name: 'link', 
      command: 'detach'}"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.) 

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

