### PR TITLE
Expose header for `GzServer` (backport #681)

### DIFF
--- a/ros_gz_sim/include/ros_gz_sim/gzserver.hpp
+++ b/ros_gz_sim/include/ros_gz_sim/gzserver.hpp
@@ -1,0 +1,44 @@
+// Copyright 2025 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS_GZ_SIM__GZSERVER_HPP_
+#define ROS_GZ_SIM__GZSERVER_HPP_
+
+#include <thread>
+#include <rclcpp/node.hpp>
+
+// ROS node that executes a gz-sim Server given a world SDF file or string.
+namespace ros_gz_sim
+{
+class GzServer : public rclcpp::Node
+{
+public:
+  // Class constructor.
+  explicit GzServer(const rclcpp::NodeOptions & options);
+
+public:
+  // Class destructor.
+  ~GzServer();
+
+public:
+  /// \brief Run the gz sim server.
+  void OnStart();
+
+private:
+  /// \brief We don't want to block the ROS thread.
+  std::thread thread_;
+};
+}  // namespace ros_gz_sim
+
+#endif  // ROS_GZ_SIM__GZSERVER_HPP_

--- a/ros_gz_sim/src/gzserver.cpp
+++ b/ros_gz_sim/src/gzserver.cpp
@@ -21,62 +21,52 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
-// ROS node that executes a gz-sim Server given a world SDF file or string.
+#include <ros_gz_sim/gzserver.hpp>
+
 namespace ros_gz_sim
 {
-class GzServer : public rclcpp::Node
+
+GzServer::GzServer(const rclcpp::NodeOptions & options)
+: Node("gzserver", options)
 {
-public:
-  // Class constructor.
-  explicit GzServer(const rclcpp::NodeOptions & options)
-  : Node("gzserver", options)
-  {
-    thread_ = std::thread(std::bind(&GzServer::OnStart, this));
+  thread_ = std::thread(std::bind(&GzServer::OnStart, this));
+}
+
+GzServer::~GzServer()
+{
+  // Make sure to join the thread on shutdown.
+  if (thread_.joinable()) {
+    thread_.join();
   }
+}
 
-public:
-  // Class destructor.
-  ~GzServer()
-  {
-    // Make sure to join the thread on shutdown.
-    if (thread_.joinable()) {
-      thread_.join();
-    }
-  }
+void GzServer::OnStart()
+{
+  auto world_sdf_file = this->declare_parameter("world_sdf_file", "");
+  auto world_sdf_string = this->declare_parameter("world_sdf_string", "");
+  auto initial_sim_time = this->declare_parameter("initial_sim_time", 0.0);
 
-public:
-  /// \brief Run the gz sim server.
-  void OnStart()
-  {
-    auto world_sdf_file = this->declare_parameter("world_sdf_file", "");
-    auto world_sdf_string = this->declare_parameter("world_sdf_string", "");
-    auto initial_sim_time = this->declare_parameter("initial_sim_time", 0.0);
+  gz::common::Console::SetVerbosity(4);
+  gz::sim::ServerConfig server_config;
 
-    gz::common::Console::SetVerbosity(4);
-    gz::sim::ServerConfig server_config;
-
-    if (!world_sdf_file.empty()) {
-      server_config.SetSdfFile(world_sdf_file);
-    } else if (!world_sdf_string.empty()) {
-      server_config.SetSdfString(world_sdf_string);
-    } else {
-      RCLCPP_ERROR(
-        this->get_logger(),
-        "Must specify either 'world_sdf_file' or 'world_sdf_string'");
-      rclcpp::shutdown();
-      return;
-    }
-
-    server_config.SetInitialSimTime(initial_sim_time);
-    gz::sim::Server server(server_config);
-    server.Run(true /*blocking*/, 0, false /*paused*/);
+  if (!world_sdf_file.empty()) {
+    server_config.SetSdfFile(world_sdf_file);
+  } else if (!world_sdf_string.empty()) {
+    server_config.SetSdfString(world_sdf_string);
+  } else {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Must specify either 'world_sdf_file' or 'world_sdf_string'");
     rclcpp::shutdown();
+    return;
   }
 
-private:
-  /// \brief We don't want to block the ROS thread.
-  std::thread thread_;
-};
+  server_config.SetInitialSimTime(initial_sim_time);
+  gz::sim::Server server(server_config);
+  server.Run(true /*blocking*/, 0, false /*paused*/);
+  rclcpp::shutdown();
+}
+
 }  // namespace ros_gz_sim
 
 RCLCPP_COMPONENTS_REGISTER_NODE(ros_gz_sim::GzServer)


### PR DESCRIPTION
Backport of #681 

Needed by #802 

## Summary
Currently, no header file is defined for https://github.com/gazebosim/ros_gz/blob/ros2/ros_gz_sim/src/gzserver.cpp

This means that currently there is no possibility to import the node in a custom main.cpp to be statically composed with other nodes in the same process space, but the user is forced to go with dynamic composition.

This PR exposes the class via its own header file.


**Note to maintainers**: Remember to use **Rebase-and-Merge**.