### PR TITLE
Fix missing timestamp in Pose_V -> PoseArray bridge

### DIFF
--- a/ros_gz_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_gz_bridge/src/convert/geometry_msgs.cpp
@@ -127,13 +127,11 @@ convert_gz_to_ros(
   geometry_msgs::msg::PoseArray & ros_msg)
 {
   convert_gz_to_ros(gz_msg.header(), ros_msg.header);
-  if (ros_msg.header.stamp.sec == 0 && ros_msg.header.stamp.nanosec == 0)
-    {
-      if (gz_msg.pose_size() > 0 && gz_msg.pose(0).has_header())
-      {
-         convert_gz_to_ros(gz_msg.pose(0).header(), ros_msg.header);
-      }
+  if (ros_msg.header.stamp.sec == 0 && ros_msg.header.stamp.nanosec == 0) {
+    if (gz_msg.pose_size() > 0 && gz_msg.pose(0).has_header()) {
+      convert_gz_to_ros(gz_msg.pose(0).header(), ros_msg.header);
     }
+  }
   ros_msg.poses.clear();
   for (auto const & p : gz_msg.pose()) {
     geometry_msgs::msg::Pose pose;

--- a/ros_gz_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_gz_bridge/src/convert/geometry_msgs.cpp
@@ -127,6 +127,13 @@ convert_gz_to_ros(
   geometry_msgs::msg::PoseArray & ros_msg)
 {
   convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+  if (ros_msg.header.stamp.sec == 0 && ros_msg.header.stamp.nanosec == 0)
+    {
+      if (gz_msg.pose_size() > 0 && gz_msg.pose(0).has_header())
+      {
+         convert_gz_to_ros(gz_msg.pose(0).header(), ros_msg.header);
+      }
+    }
   ros_msg.poses.clear();
   for (auto const & p : gz_msg.pose()) {
     geometry_msgs::msg::Pose pose;


### PR DESCRIPTION
# Bug fix

Fixes #782

## Summary
This PR fixes an issue where bridging `gz.msgs.Pose_V` to `geometry_msgs/PoseArray` resulted in empty header timestamps (`sec: 0`), causing issues for downstream ROS 2 nodes requiring synchronized data.

### The Issue
Currently, `gz-sim` (specifically the `PosePublisher` system) does not populate the top-level `Pose_V` header. However, valid timestamps exist within the individual `pose` elements inside the vector. The bridge previously only checked the top-level header, resulting in messages arriving in ROS 2 with zero timestamps.

### The Fix
Modified `geometry_msgs.cpp` to include a robust fallback logic:
1. It attempts to copy the main header first (standard behavior).
2. If the main header is empty (timestamp is 0), it checks the first element of the pose vector.
3. If a valid timestamp exists in the inner pose, it populates the `PoseArray` header with that timestamp.

### Verification
Reproduced using the test case from #782 on a Rolling source build.

**Before Fix:**
```bash
$ ros2 topic echo /model/test_box/pose_static --once
header:
  stamp:
    sec: 0
    nanosec: 0
   ```
**After Fix:**
```bash
$ ros2 topic echo /model/test_box/pose_static --once
header:
  stamp:
    sec: 389
    nanosec: 227000000
```
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] codecheck passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://www.google.com/search?q=https://github.com/pulls%3Fq%3Dis%253Aopen%2Bis%253Apr%2Buser%253Agazebosim%2Barchived%253Afalse%2B) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits.

Generated-by: Gemini