### PR TITLE
get rid of deprecated rclcpp::spin_some()

### DIFF
--- a/ros_gz_bridge/test/resource/ros_publisher.cpp.em
+++ b/ros_gz_bridge/test/resource/ros_publisher.cpp.em
@@ -22,6 +22,8 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("ros_string_publisher");
   rclcpp::Rate loop_rate(100);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
 @[for m in mappings]@
   // @(m.ros2_string()).
@@ -38,7 +40,7 @@ int main(int argc, char ** argv)
     @(m.unique())_pub->publish(@(m.unique())_msg);
 @[end for]@
 
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
   }
 

--- a/ros_gz_bridge/test/utils/test_utils.hpp
+++ b/ros_gz_bridge/test/utils/test_utils.hpp
@@ -64,11 +64,13 @@ void waitUntilBoolVarAndSpin(
   const std::chrono::duration<Rep, Period> & _sleepEach,
   const int _retries)
 {
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
   int i = 0;
   while (!_boolVar && i < _retries && rclcpp::ok()) {
     ++i;
     std::this_thread::sleep_for(_sleepEach);
-    rclcpp::spin_some(node->get_node_base_interface());
+    executor.spin_some();
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This depends on https://github.com/ros2/rclcpp/pull/2848

Related with 
 - https://build.ros2.org/job/Rpr__ros_gz__ubuntu_noble_amd64/399/clang-tidy/
 - 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
