### PR TITLE
Remove image_transport deprecation

### DIFF
--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -39,13 +39,13 @@ public:
     std::shared_ptr<gz::transport::Node> _gz_node)
   {
     // Get QoS profile from parameter
-    rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+    rclcpp::QoS qos_profile = rclcpp::QoS(10);
     const auto qos_str =
       _node->get_parameter("qos").get_parameter_value().get<std::string>();
     if (qos_str == "system_default") {
-      qos_profile = rmw_qos_profile_system_default;
+      qos_profile = rclcpp::SystemDefaultsQoS();
     } else if (qos_str == "sensor_data") {
-      qos_profile = rmw_qos_profile_sensor_data;
+      qos_profile = rclcpp::SensorDataQoS();
     } else if (qos_str != "default") {
       RCLCPP_ERROR(
         _node->get_logger(),
@@ -55,7 +55,7 @@ public:
 
     // Create publishers and subscribers
     this->ros_pub = image_transport::create_publisher(
-      _node.get(), _topic, qos_profile);
+      *_node, _topic, qos_profile);
 
     _gz_node->Subscribe(_topic, &Handler::OnImage, this);
   }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Related with https://build.ros2.org/job/Rpr__ros_gz__ubuntu_noble_amd64/399/clang-tidy/folder.-661980038/

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.