### PR TITLE
Add dependency to ros2pkg

### DIFF
--- a/ros_gz_sim/package.xml
+++ b/ros_gz_sim/package.xml
@@ -38,6 +38,7 @@
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
   <depend>rcpputils</depend>
+  <depend>ros2pkg</depend>
   <depend>ros_gz_interfaces</depend>
   <depend>simulation_interfaces</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION


## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Technically, ros2pkg is a runtime dependency of ros_gz_sim, since it's used inside the package's launch files [here](https://github.com/gazebosim/ros_gz/blob/7658f4a8848af0cad42433e1c99bd1482ab02d4d/ros_gz_sim/launch/gz_sim.launch.py.in#L23) and [here](https://github.com/gazebosim/ros_gz/blob/7658f4a8848af0cad42433e1c99bd1482ab02d4d/ros_gz_sim/ros_gz_sim/actions/gzserver.py#L31). I am aware that ros2pkg is such a core dependency (in fact it's a transitive dependency of ros-core) such that the practical relevance is very little, but it seems clean to me to add it.

I've stumbled upon this as we use [industrial_ci](https://github.com/ros-industrial/industrial_ci) for our GitHub actions which doesn't use a ROS docker image but starts from a plain ubuntu image and adds only what is specified as dependency. See [this run](https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/runs/21159567925/job/60851349615) for example.

If you think this is too basic to declare as a dependency, feel free to reject this. I'm currently looking into mitigating this for us by installing ros-core inside the CI container.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
