### PR TITLE
Change air pressure launch file to Python format

### DIFF
--- a/ros_gz_sim_demos/README.md
+++ b/ros_gz_sim_demos/README.md
@@ -14,7 +14,7 @@ There's a convenient launch file, try for example:
 
 Publishes fluid pressure readings.
 
-    ros2 launch ros_gz_sim_demos air_pressure.launch.xml
+    ros2 launch ros_gz_sim_demos air_pressure.launch.py
 
 This demo also shows the use of custom QoS parameters. The sensor data is
 published as as "best-effort", so trying to subscribe to "reliable" data won't


### PR DESCRIPTION
Updated launch file extension from XML to Python for air pressure demo.

# 🦟 Bug fix
