### PR TITLE
Add support for configurable frame_id in Gazebo subscriber

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -311,6 +311,7 @@ bridge may be specified:
                             # "GZ_TO_ROS" - Bridge Gz topic to ROS
                             # "ROS_TO_GZ" - Bridge ROS topic to Gz
   qos_profile: SENSOR_DATA  # Default is a default-constructed QoS with appropriate queue size
+  frame_id: "map"           # Optional: Override the frame_id in the ROS message header
 ```
 
 To run the bridge node with the above configuration:

--- a/ros_gz_bridge/include/ros_gz_bridge/bridge_config.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/bridge_config.hpp
@@ -96,6 +96,9 @@ struct BridgeConfig
 
   /// \brief The ROS service type response.
   std::string gz_rep_type_name;
+
+  /// \brief The Frame ID to inject into the ROS header.
+  std::string frame_id = "";
 };
 
 /// \brief Generate a group of BridgeConfigs from a YAML String

--- a/ros_gz_bridge/src/bridge_config.cpp
+++ b/ros_gz_bridge/src/bridge_config.cpp
@@ -39,6 +39,7 @@ constexpr const char kQosProfile[] = "qos_profile";
 constexpr const char kLazy[] = "lazy";
 constexpr const char kGzReqTypeName[] = "gz_req_type_name";
 constexpr const char kGzRepTypeName[] = "gz_rep_type_name";
+constexpr const char kFrameId[] = "frame_id";
 
 // Comparison strings for bridge directions
 constexpr const char kBidirectional[] = "BIDIRECTIONAL";
@@ -170,6 +171,10 @@ std::optional<BridgeConfig> parseEntry(const YAML::Node & yaml_node)
 
     ret.gz_type_name = gz_type_name;
     ret.ros_type_name = ros_type_name;
+
+    if (yaml_node[kFrameId]) {
+      ret.frame_id = yaml_node[kFrameId].as<std::string>();
+    }
 
 
     if (yaml_node[kQosProfile]) {

--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
@@ -71,7 +71,8 @@ void BridgeHandleGzToRos::StartSubscriber()
     this->config_.gz_topic_name,
     this->config_.subscriber_queue_size.value_or(kDefaultSubscriberQueue),
     this->ros_publisher_,
-    override_timestamps_with_wall_time_);
+    override_timestamps_with_wall_time_,
+    this->config_.frame_id);
 
   this->gz_subscriber_ = this->gz_node_;
 }

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -117,16 +117,17 @@ public:
     const std::string & topic_name,
     size_t /*queue_size*/,
     rclcpp::PublisherBase::SharedPtr ros_pub,
-    bool override_timestamps_with_wall_time)
+    bool override_timestamps_with_wall_time,
+    const std::string & frame_id = "") override
   {
     auto pub = std::dynamic_pointer_cast<rclcpp::Publisher<ROS_T>>(ros_pub);
     if (pub == nullptr) {
       return;
     }
     std::function<void(const GZ_T &)> subCb =
-      [this, pub, override_timestamps_with_wall_time](const GZ_T & _msg)
+      [this, pub, override_timestamps_with_wall_time, frame_id](const GZ_T & _msg)
       {
-        this->gz_callback(_msg, pub, override_timestamps_with_wall_time);
+        this->gz_callback(_msg, pub, override_timestamps_with_wall_time, frame_id);
       };
 
     // Ignore messages that are published from this bridge.
@@ -157,10 +158,16 @@ protected:
   void gz_callback(
     const GZ_T & gz_msg,
     std::shared_ptr<rclcpp::Publisher<ROS_T>> ros_pub,
-    bool override_timestamps_with_wall_time)
+    bool override_timestamps_with_wall_time,
+    const std::string & frame_id)
   {
     ROS_T ros_msg;
     convert_gz_to_ros(gz_msg, ros_msg);
+    if (!frame_id.empty()) {
+      if constexpr (has_header<ROS_T>::value) {
+        ros_msg.header.frame_id = frame_id;
+      }
+    }
     if constexpr (has_header<ROS_T>::value) {
       if (override_timestamps_with_wall_time) {
         auto now = std::chrono::system_clock::now().time_since_epoch();

--- a/ros_gz_bridge/src/factory_interface.hpp
+++ b/ros_gz_bridge/src/factory_interface.hpp
@@ -61,7 +61,8 @@ public:
     const std::string & topic_name,
     size_t queue_size,
     rclcpp::PublisherBase::SharedPtr ros_pub,
-    bool override_timestamps_with_wall_time) = 0;
+    bool override_timestamps_with_wall_time,
+    const std::string & frame_id = "") = 0;
 };
 
 }  // namespace ros_gz_bridge


### PR DESCRIPTION
- Allow users to specify 'frame_id' in the bridge configuration YAML.
- Inject the frame ID into the ROS message header if the message type supports it.
- Resolves issue where Gazebo messages with empty headers (e.g. Pose_V) result in invalid ROS messages.

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #796

## Summary
This PR adds support for a new YAML configuration parameter `frame_id` for Gazebo subscribers. This allows users to manually inject a Frame ID into the ROS message header when bridging topics where the source Gazebo message does not contain header information (e.g., `ignition.msgs.Pose_V`).

**Problem:**
When bridging `Pose_V` from Gazebo to `PoseArray` in ROS 2, the resulting ROS message has an empty `header.frame_id`. This makes the data unusable for downstream ROS nodes (like Nav2 or TF listeners) that require a valid frame of reference.

**Solution:**
- Modified `BridgeConfig` to parse an optional `frame_id` field.
- Updated `FactoryInterface` and `Factory` to accept and pass the `frame_id`.
- In `gz_callback`, if `frame_id` is set and the ROS message type has a header, the ID is injected before publishing.

**Testing:**
- Built `ros_gz_bridge` successfully.
- Verified manual reproduction: mapped `/world/shapes/dynamic_pose/info` to `/pose_v_test` with `frame_id: "map"`.
- Confirmed output ROS message contains `frame_id: "map"`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR?

Generated-by: Gemini

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

