### PR TITLE
Add override_frame_id parameter

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -191,6 +191,26 @@ The screenshot shows all the shell windows and their expected content
 
 ![Gazebo Transport images and ROS rqt](images/bridge_image_exchange.png)
 
+
+### GZ to ROS frame_id override
+
+The bridge has a parameter named `override_frame_id` that allows users to
+override the `frame_id` of messages when bridging topics.
+
+As an example, for sensors like cameras, it is commonly expected that ROS image
+data are in a z-forward optical frame, see
+[REP-0103](https://www.ros.org/reps/rep-0103.html).
+When bridging GZ to ROS `Image` and `CameraInfo` topics, users
+typically create a new optical frame with an x to z-forward transformation,
+e.g. by using a static transform publisher. Users can then use the
+`override_frame_id` parameter to override the `Image` or `CameraInfo` messages'
+`frame_id` field to point to the optical frame.
+
+```bash
+. ~/bridge_ws/install/setup.bash
+ros2 run ros_gz_bridge parameter_bridge /rgbd_camera/image@sensor_msgs/msg/Image@gz.msgs.Image --ros-args -p override_frame_id:=my_custom_optical_frame
+```
+
 ## Example 3: Static bridge
 
 In this example, we're going to run an executable that starts a bidirectional
@@ -383,6 +403,27 @@ By changing `chatter` to `/chatter` or `~/chatter` you can obtain different resu
 
 ROS 2 Parameters:
 
- * `subscription_heartbeat` - Period at which the node checks for new subscribers for lazy bridges.
- * `config_file` - YAML file to be loaded as the bridge configuration
- * `expand_gz_topic_names` - Enable or disable ROS namespace applied on GZ topics.
+* `subscription_heartbeat`
+    * type: double
+    * default: 1000
+    * description: Period (ms) at which the node checks for new subscribers for
+      lazy bridges.
+* `config_file`
+    * type: string
+    * default: ""
+    * description: YAML file to be loaded as the bridge configuration
+* `expand_gz_topic_names`
+    * type: bool
+    * default: false
+    * description: Enable or disable ROS namespace applied on GZ topics.
+* `override_timestamps_with_wall_time`
+    * type: bool
+    * default: false
+    * direction: GZ to ROS
+    * description: Override the header.stamp field of outgoing messages with
+      wall time.
+ * `override_frame_id`
+    * type: string
+    * default: ""
+    * direction: GZ to ROS
+    * description: Override the `header.frame_id` field with a new string value.

--- a/ros_gz_bridge/src/bridge_handle.cpp
+++ b/ros_gz_bridge/src/bridge_handle.cpp
@@ -30,8 +30,6 @@ BridgeHandle::BridgeHandle(
   config_(config),
   factory_(get_factory(config.ros_type_name, config.gz_type_name))
 {
-  ros_node_->get_parameter("override_timestamps_with_wall_time",
-    override_timestamps_with_wall_time_);
 }
 
 BridgeHandle::~BridgeHandle() = default;

--- a/ros_gz_bridge/src/bridge_handle.hpp
+++ b/ros_gz_bridge/src/bridge_handle.hpp
@@ -101,9 +101,6 @@ protected:
 
   /// \brief Typed factory used to create publishers/subscribers
   std::shared_ptr<FactoryInterface> factory_;
-
-  /// \brief Override the header.stamp field of the outgoing messages with the wall time
-  bool override_timestamps_with_wall_time_ = false;
 };
 
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
@@ -19,6 +19,19 @@
 namespace ros_gz_bridge
 {
 
+BridgeHandleGzToRos::BridgeHandleGzToRos(
+  rclcpp::Node::SharedPtr ros_node,
+  std::shared_ptr<gz::transport::Node> gz_node,
+  const BridgeConfig & config)
+: BridgeHandle(ros_node, gz_node, config)
+{
+  ros_node_->get_parameter("override_timestamps_with_wall_time",
+      gz_to_ros_parameters_.override_timestamps_with_wall_time);
+
+  ros_node_->get_parameter("override_frame_id",
+      gz_to_ros_parameters_.override_frame_id);
+}
+
 BridgeHandleGzToRos::~BridgeHandleGzToRos() = default;
 
 size_t BridgeHandleGzToRos::NumSubscriptions() const
@@ -71,7 +84,7 @@ void BridgeHandleGzToRos::StartSubscriber()
     this->config_.gz_topic_name,
     this->config_.subscriber_queue_size.value_or(kDefaultSubscriberQueue),
     this->ros_publisher_,
-    override_timestamps_with_wall_time_);
+    gz_to_ros_parameters_);
 
   this->gz_subscriber_ = this->gz_node_;
 }

--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros.hpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros.hpp
@@ -21,6 +21,7 @@
 #include <rclcpp/subscription_base.hpp>
 
 #include "bridge_handle.hpp"
+#include "bridge_handle_gz_to_ros_parameters.hpp"
 
 namespace ros_gz_bridge
 {
@@ -32,7 +33,10 @@ class BridgeHandleGzToRos : public BridgeHandle
 {
 public:
   /// \brief Constructor
-  using BridgeHandle::BridgeHandle;
+  BridgeHandleGzToRos(
+    rclcpp::Node::SharedPtr ros_node,
+    std::shared_ptr<gz::transport::Node> gz_node,
+    const BridgeConfig & config);
 
   /// \brief Destructor
   ~BridgeHandleGzToRos() override;
@@ -62,6 +66,9 @@ protected:
 
   /// \brief ROS publisher, populated when publisher active
   rclcpp::PublisherBase::SharedPtr ros_publisher_ = {nullptr};
+
+  /// \brief GZ to ROS parameters
+  BridgeHandleGzToRosParameters gz_to_ros_parameters_;
 };
 
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros_parameters.hpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros_parameters.hpp
@@ -1,0 +1,37 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BRIDGE_HANDLE_GZ_TO_ROS_PARAMETERS_HPP_
+#define BRIDGE_HANDLE_GZ_TO_ROS_PARAMETERS_HPP_
+
+#include <optional>
+#include <string>
+
+namespace ros_gz_bridge
+{
+
+struct BridgeHandleGzToRosParameters
+{
+  /// \brief Override the header.stamp field of the outgoing messages with
+  /// the wall time
+  bool override_timestamps_with_wall_time = false;
+
+  /// \brief Override the header.frame_id field of the outgoing messages with
+  /// this new frame_id string
+  std::string override_frame_id;
+};
+
+}  // namespace ros_gz_bridge
+
+#endif  // BRIDGE_HANDLE_GZ_TO_ROS_PARAMETERS_HPP_

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -117,16 +117,16 @@ public:
     const std::string & topic_name,
     size_t /*queue_size*/,
     rclcpp::PublisherBase::SharedPtr ros_pub,
-    bool override_timestamps_with_wall_time)
+    const BridgeHandleGzToRosParameters & gz_to_ros_parameters)
   {
     auto pub = std::dynamic_pointer_cast<rclcpp::Publisher<ROS_T>>(ros_pub);
     if (pub == nullptr) {
       return;
     }
     std::function<void(const GZ_T &)> subCb =
-      [this, pub, override_timestamps_with_wall_time](const GZ_T & _msg)
+      [this, pub, gz_to_ros_parameters](const GZ_T & _msg)
       {
-        this->gz_callback(_msg, pub, override_timestamps_with_wall_time);
+        this->gz_callback(_msg, pub, gz_to_ros_parameters);
       };
 
     // Ignore messages that are published from this bridge.
@@ -157,17 +157,20 @@ protected:
   void gz_callback(
     const GZ_T & gz_msg,
     std::shared_ptr<rclcpp::Publisher<ROS_T>> ros_pub,
-    bool override_timestamps_with_wall_time)
+    const BridgeHandleGzToRosParameters & gz_to_ros_parameters)
   {
     ROS_T ros_msg;
     convert_gz_to_ros(gz_msg, ros_msg);
     if constexpr (has_header<ROS_T>::value) {
-      if (override_timestamps_with_wall_time) {
+      if (gz_to_ros_parameters.override_timestamps_with_wall_time) {
         auto now = std::chrono::system_clock::now().time_since_epoch();
         auto ns =
           std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
         ros_msg.header.stamp.sec = ns / 1e9;
         ros_msg.header.stamp.nanosec = ns - ros_msg.header.stamp.sec * 1e9;
+      }
+      if (!gz_to_ros_parameters.override_frame_id.empty()) {
+        ros_msg.header.frame_id = gz_to_ros_parameters.override_frame_id;
       }
     }
     ros_pub->publish(ros_msg);

--- a/ros_gz_bridge/src/factory_interface.hpp
+++ b/ros_gz_bridge/src/factory_interface.hpp
@@ -24,6 +24,8 @@
 // include ROS 2
 #include <rclcpp/rclcpp.hpp>
 
+#include "bridge_handle_gz_to_ros_parameters.hpp"
+
 namespace ros_gz_bridge
 {
 
@@ -61,7 +63,7 @@ public:
     const std::string & topic_name,
     size_t queue_size,
     rclcpp::PublisherBase::SharedPtr ros_pub,
-    bool override_timestamps_with_wall_time) = 0;
+    const BridgeHandleGzToRosParameters & gz_to_ros_parameters) = 0;
 };
 
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -36,6 +36,7 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
   this->declare_parameter<std::string>("config_file", "");
   this->declare_parameter<bool>("expand_gz_topic_names", false);
   this->declare_parameter<bool>("override_timestamps_with_wall_time", false);
+  this->declare_parameter<std::string>("override_frame_id", "");
   this->declare_parameter("bridge_names", std::vector<std::string>());
   const auto names = this->get_parameter("bridge_names").as_string_array();
 


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/gazebosim/gz-sensors/issues/488

## Summary

Add a new `override_frame_id` parameter that allows users to override the message header's `frame_id` field with their own custom string.

This is a subset of the changes from https://github.com/gazebosim/ros_gz/pull/703. This PR only adds the `override_frame_id` parameter without the feature for automatic optical frame conversion / TF broadcasting.

## Test it

1. Terminal 1: Run sensors demo world with gazebo in headless mode:
    ```
    gz sim -v 4 ./src/gz-sim/examples/worlds/sensors_demo.sdf -r -s
    ```

2. Terminal 2: Run the bridge with the `override_frame_id` parameter set to `my_custom_frame_id`
    ```
    ros2 run ros_gz_bridge parameter_bridge /rgbd_camera/image@sensor_msgs/msg/Image@gz.msgs.Image --ros-args -p override_frame_id:=my_custom_frame_id
    ```
3. Terminal 3: Echo the `/rgbd_camera/image` topic and verify that the `frame_id` is overridden

    ```
    ros2 topic echo /rgbd_camera/image | grep frame_id
    ```

    It should print out

    ```
      frame_id: my_custom_frame_id
    ```


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

