### PR TITLE
feat: Added lazy subscribe support for GZ image bridge

### DIFF
--- a/ros_gz_image/README.md
+++ b/ros_gz_image/README.md
@@ -15,8 +15,28 @@ To run the bridge from the command line:
 ros2 run ros_gz_image image_bridge /topic1 /topic2
 ```
 
-You can also modify the [Quality of Service (QoS) policy](https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html#qos-policies) used to publish images using an additional `qos` ROS parameter. For example:
+## Parameters
+
+### `qos` (string, default: `"default"`)
+
+Modify the [Quality of Service (QoS) policy](https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html#qos-policies) used to publish images. Accepted values: `default`, `sensor_data`, `system_default`.
 
 ```shell
-ros2 run ros_gz_image image_bridge /topic1 /topic2 --ros-args qos:=sensor_data
+ros2 run ros_gz_image image_bridge /topic1 /topic2 --ros-args -p qos:=sensor_data
+```
+
+### `lazy` (bool, default: `false`)
+
+When set to `true`, the bridge will only subscribe to the Gazebo topic when there is at least one ROS subscriber. This avoids unnecessary message processing when no one is listening.
+
+```shell
+ros2 run ros_gz_image image_bridge /topic1 /topic2 --ros-args -p lazy:=true
+```
+
+### `subscription_heartbeat` (int, default: `1000`)
+
+Interval in milliseconds at which the bridge checks the ROS subscriber count to start or stop the Gazebo subscription. Only relevant when `lazy:=true`.
+
+```shell
+ros2 run ros_gz_image image_bridge /topic1 /topic2 --ros-args -p lazy:=true -p subscription_heartbeat:=500
 ```

--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -41,7 +41,6 @@ public:
     std::shared_ptr<gz::transport::Node> _gz_node,
     bool _lazy = false)
   : topic_(_topic),
-    node_(_node),
     gz_node_(_gz_node),
     is_lazy_(_lazy)
   {
@@ -72,7 +71,7 @@ public:
 
   /// \brief Manage Gazebo subscription lifecycle based on ROS subscriber count.
   /// Only active when lazy mode is enabled.
-  void Spin()
+  void CheckSubscribers()
   {
     if (!is_lazy_) {
       return;
@@ -112,9 +111,6 @@ private:
   /// \brief Image topic name
   std::string topic_;
 
-  /// \brief ROS node
-  std::shared_ptr<rclcpp::Node> node_;
-
   /// \brief Gazebo transport node
   std::shared_ptr<gz::transport::Node> gz_node_;
 
@@ -137,7 +133,12 @@ void usage()
   std::cerr << "Bridge a collection of Gazebo Transport image topics to ROS " <<
     "using image_transport.\n\n" <<
     "  image_bridge <topic> <topic> ..\n\n" <<
-    "E.g.: image_bridge /camera/front/image_raw" << std::endl;
+    "Optional ROS parameters:\n" <<
+    "  qos:=<profile>              QoS profile: default, sensor_data, system_default\n" <<
+    "  lazy:=<true|false>          Only subscribe to Gazebo when ROS subscribers are present\n" <<
+    "  subscription_heartbeat:=<ms> Interval (ms) to check ROS subscriber count (default: 1000)\n\n" <<
+    "E.g.: image_bridge /camera/front/image_raw\n" <<
+    "E.g.: image_bridge /camera/front/image_raw --ros-args -p lazy:=true" << std::endl;
 }
 
 //////////////////////////////////////////////////
@@ -181,7 +182,7 @@ int main(int argc, char * argv[])
       std::chrono::milliseconds(heartbeat_ms),
       [&handlers]() {
         for (auto & handler : handlers) {
-          handler->Spin();
+          handler->CheckSubscribers();
         }
       });
   }

--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -14,6 +14,7 @@
 
 #include <rmw/qos_profiles.h>
 
+#include <chrono>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -33,19 +34,25 @@ public:
   /// \param[in] _topic Image base topic
   /// \param[in] _node Pointer to ROS node
   /// \param[in] _gz_node Pointer to Gazebo node
+  /// \param[in] _lazy Whether to lazily subscribe to Gazebo only when ROS subscribers are present
   Handler(
     const std::string & _topic,
     std::shared_ptr<rclcpp::Node> _node,
-    std::shared_ptr<gz::transport::Node> _gz_node)
+    std::shared_ptr<gz::transport::Node> _gz_node,
+    bool _lazy = false)
+  : topic_(_topic),
+    node_(_node),
+    gz_node_(_gz_node),
+    is_lazy_(_lazy)
   {
     // Get QoS profile from parameter
-    rclcpp::QoS qos_profile = rclcpp::QoS(10);
+    qos_profile_ = rclcpp::QoS(10);
     const auto qos_str =
       _node->get_parameter("qos").get_parameter_value().get<std::string>();
     if (qos_str == "system_default") {
-      qos_profile = rclcpp::SystemDefaultsQoS();
+      qos_profile_ = rclcpp::SystemDefaultsQoS();
     } else if (qos_str == "sensor_data") {
-      qos_profile = rclcpp::SensorDataQoS();
+      qos_profile_ = rclcpp::SensorDataQoS();
     } else if (qos_str != "default") {
       RCLCPP_ERROR(
         _node->get_logger(),
@@ -53,25 +60,75 @@ public:
         qos_str.c_str());
     }
 
-    // Create publishers and subscribers
-    this->ros_pub = image_transport::create_publisher(
-      *_node, _topic, qos_profile);
+    // Always create the ROS publisher
+    this->ros_pub_ = image_transport::create_publisher(
+      *_node, _topic, qos_profile_);
 
-    _gz_node->Subscribe(_topic, &Handler::OnImage, this);
+    // Subscribe to Gazebo immediately unless lazy
+    if (!is_lazy_) {
+      StartSubscriber();
+    }
+  }
+
+  /// \brief Manage Gazebo subscription lifecycle based on ROS subscriber count.
+  /// Only active when lazy mode is enabled.
+  void Spin()
+  {
+    if (!is_lazy_) {
+      return;
+    }
+
+    const size_t num_subs = ros_pub_.getNumSubscribers();
+
+    if (has_subscriber_ && num_subs == 0) {
+      StopSubscriber();
+    } else if (!has_subscriber_ && num_subs > 0) {
+      StartSubscriber();
+    }
   }
 
 private:
+  void StartSubscriber()
+  {
+    gz_node_->Subscribe(topic_, &Handler::OnImage, this);
+    has_subscriber_ = true;
+  }
+
+  void StopSubscriber()
+  {
+    gz_node_->Unsubscribe(topic_);
+    has_subscriber_ = false;
+  }
+
   /// \brief Callback when Gazebo image is received
   /// \param[in] _gz_msg Gazebo message
   void OnImage(const gz::msgs::Image & _gz_msg)
   {
     sensor_msgs::msg::Image ros_msg;
     ros_gz_bridge::convert_gz_to_ros(_gz_msg, ros_msg);
-    this->ros_pub.publish(ros_msg);
+    this->ros_pub_.publish(ros_msg);
   }
 
+  /// \brief Image topic name
+  std::string topic_;
+
+  /// \brief ROS node
+  std::shared_ptr<rclcpp::Node> node_;
+
+  /// \brief Gazebo transport node
+  std::shared_ptr<gz::transport::Node> gz_node_;
+
+  /// \brief Whether to use lazy subscription
+  bool is_lazy_{false};
+
+  /// \brief Whether currently subscribed to Gazebo topic
+  bool has_subscriber_{false};
+
+  /// \brief QoS profile for ROS publisher
+  rclcpp::QoS qos_profile_{10};
+
   /// \brief ROS image publisher
-  image_transport::Publisher ros_pub;
+  image_transport::Publisher ros_pub_;
 };
 
 //////////////////////////////////////////////////
@@ -96,6 +153,11 @@ int main(int argc, char * argv[])
   // ROS node
   auto node_ = rclcpp::Node::make_shared("ros_gz_image");
   node_->declare_parameter("qos", "default");
+  node_->declare_parameter("lazy", false);
+  node_->declare_parameter("subscription_heartbeat", 1000);
+
+  const bool lazy = node_->get_parameter("lazy").as_bool();
+  const int heartbeat_ms = node_->get_parameter("subscription_heartbeat").as_int();
 
   // Gazebo node
   auto gz_node = std::make_shared<gz::transport::Node>();
@@ -107,9 +169,21 @@ int main(int argc, char * argv[])
   --argc;
   auto args = rclcpp::remove_ros_arguments(argc, argv);
 
-  // Create publishers and subscribers
+  // Create publishers (and subscribers if not lazy)
   for (auto topic : args) {
-    handlers.push_back(std::make_shared<Handler>(topic, node_, gz_node));
+    handlers.push_back(std::make_shared<Handler>(topic, node_, gz_node, lazy));
+  }
+
+  // When lazy, periodically check ROS subscriber count to start/stop Gz subscriptions
+  rclcpp::TimerBase::SharedPtr heartbeat_timer;
+  if (lazy) {
+    heartbeat_timer = node_->create_wall_timer(
+      std::chrono::milliseconds(heartbeat_ms),
+      [&handlers]() {
+        for (auto & handler : handlers) {
+          handler->Spin();
+        }
+      });
   }
 
   // Spin ROS and Gz until shutdown

--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -136,7 +136,8 @@ void usage()
     "Optional ROS parameters:\n" <<
     "  qos:=<profile>              QoS profile: default, sensor_data, system_default\n" <<
     "  lazy:=<true|false>          Only subscribe to Gazebo when ROS subscribers are present\n" <<
-    "  subscription_heartbeat:=<ms> Interval (ms) to check ROS subscriber count (default: 1000)\n\n" <<
+    "  subscription_heartbeat:=<ms> Interval (ms) to check ROS subscriber count (default: 1000)\n\n"
+            <<
     "E.g.: image_bridge /camera/front/image_raw\n" <<
     "E.g.: image_bridge /camera/front/image_raw --ros-args -p lazy:=true" << std::endl;
 }

--- a/ros_gz_image/src/image_bridge.cpp
+++ b/ros_gz_image/src/image_bridge.cpp
@@ -14,6 +14,7 @@
 
 #include <rmw/qos_profiles.h>
 
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <memory>
@@ -45,13 +46,13 @@ public:
     is_lazy_(_lazy)
   {
     // Get QoS profile from parameter
-    qos_profile_ = rclcpp::QoS(10);
+    rclcpp::QoS qos_profile = rclcpp::QoS(10);
     const auto qos_str =
       _node->get_parameter("qos").get_parameter_value().get<std::string>();
     if (qos_str == "system_default") {
-      qos_profile_ = rclcpp::SystemDefaultsQoS();
+      qos_profile = rclcpp::SystemDefaultsQoS();
     } else if (qos_str == "sensor_data") {
-      qos_profile_ = rclcpp::SensorDataQoS();
+      qos_profile = rclcpp::SensorDataQoS();
     } else if (qos_str != "default") {
       RCLCPP_ERROR(
         _node->get_logger(),
@@ -61,7 +62,7 @@ public:
 
     // Always create the ROS publisher
     this->ros_pub_ = image_transport::create_publisher(
-      *_node, _topic, qos_profile_);
+      *_node, _topic, qos_profile);
 
     // Subscribe to Gazebo immediately unless lazy
     if (!is_lazy_) {
@@ -118,10 +119,7 @@ private:
   bool is_lazy_{false};
 
   /// \brief Whether currently subscribed to Gazebo topic
-  bool has_subscriber_{false};
-
-  /// \brief QoS profile for ROS publisher
-  rclcpp::QoS qos_profile_{10};
+  std::atomic<bool> has_subscriber_{false};
 
   /// \brief ROS image publisher
   image_transport::Publisher ros_pub_;
@@ -161,6 +159,15 @@ int main(int argc, char * argv[])
   const bool lazy = node_->get_parameter("lazy").as_bool();
   const int heartbeat_ms = node_->get_parameter("subscription_heartbeat").as_int();
 
+  if (lazy && heartbeat_ms <= 0) {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "subscription_heartbeat must be a positive integer (got %d). Using default of 1000 ms.",
+      heartbeat_ms);
+    rclcpp::shutdown();
+    return -1;
+  }
+
   // Gazebo node
   auto gz_node = std::make_shared<gz::transport::Node>();
 
@@ -172,7 +179,7 @@ int main(int argc, char * argv[])
   auto args = rclcpp::remove_ros_arguments(argc, argv);
 
   // Create publishers (and subscribers if not lazy)
-  for (auto topic : args) {
+  for (const auto & topic : args) {
     handlers.push_back(std::make_shared<Handler>(topic, node_, gz_node, lazy));
   }
 


### PR DESCRIPTION
# 🎉 New feature

Closes #752

## Summary

Adds a `lazy` option to the `ros_gz_image` bridge similar to what already exists for the `ros_gz_bridge`. This can be quite important as cameras usually take a lot of resources that shouldn't be used up if there is no active subscriber.

Example command:
```
ros2 run ros_gz_image image_bridge /camera --ros-args -p lazy:=true
```

Example output:
No ROS subscribers => bridge doesn't subscribe to camera
```
Publishers [Address, Message Type]:
  tcp://172.17.0.1:40959, gz.msgs.Image
No subscribers on topic [/world/default/model/x500_lidar_and_camera_0/link/navigation_camera_link/sensor/navigation_camera/image]
```

ROS subscriber => bridge subcribes to camera:
```
Publishers [Address, Message Type]:
  tcp://172.17.0.1:40959, gz.msgs.Image
Subscribers [Address, Message Type]:
  tcp://172.17.0.1:37671, gz.msgs.Image
```

## Test it

Create a world with a camera inside it. Then run:
```
ros2 run ros_gz_image image_bridge /camera --ros-args -p lazy:=true
```

If no subscriber exists `gz topic -i -t /camera` should return no subscriber. After subscribing with for example `ros2 topic hz -w 10 /camera` when reruning `gz topic -i -t /camera` there should be a subscriber visible.

Note: I tested on ROS2 Humble and therefore would already have a backport for this version.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.