### PR TITLE
Pass frame_id per-bridge as ROS parameter.

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -330,10 +330,16 @@ Use tag `<ros_gz_bridge>` and add `<topic>` and `<service>` subelements, one for
 ```XML
 <launch>
   <arg name="world_name" default="empty" />
+  <arg name="robot_name" default="robot" />
   <ros_gz_bridge bridge_name="clock_bridge">
     <topic ros_topic_name="/clock" gz_topic_name="/clock"
            ros_type_name="rosgraph_msgs/msg/Clock" gz_type_name="gz.msgs.Clock"
            lazy="False" direction="GZ_TO_ROS" qos_profile="CLOCK" />
+  </ros_gz_bridge>
+  <ros_gz_bridge bridge_name="test_bridge">
+    <topic ros_topic_name="/camera/image" gz_topic_name="/world/$(var world_name)/model/$(var robot_name)/camera/sensor/image"
+           ros_type_name="sensor_msgs/msg/Image" gz_type_name="gz.msgs.Image"
+           lazy="True" direction="GZ_TO_ROS" frame_id="camera_optical_frame" />
     <service service_name="/world/$(var world_name)/control"
              ros_type_name="ros_gz_interfaces/srv/ControlWorld"
              gz_req_type_name="gz.msgs.WorldControl" gz_rep_type_name="gz.msgs.Boolean" />

--- a/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
+++ b/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
@@ -198,6 +198,7 @@ class RosGzBridge(Action):
                 ('publisher_queue', int),
                 ('subscriber_queue', int),
                 ('qos_profile', str),
+                ('frame_id', str),
             )
             for param, param_type in optional_params:
                 p = child.get_attr(param, data_type=param_type, optional=True)

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -90,6 +90,7 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
       this->declare_parameter(prefix + "subscriber_queue", -1);
       this->declare_parameter(prefix + "lazy", this->get_parameter("lazy").as_bool());
       this->declare_parameter(prefix + "qos_profile", "");
+      this->declare_parameter(prefix + "frame_id", "");
     } else {
       const auto gz_req_type = this->declare_parameter(prefix + "gz_req_type_name",
         PARAMETER_STRING);
@@ -216,7 +217,8 @@ void RosGzBridge::spin()
           qos_profile,
           {},
           {},
-          {}
+          {},
+          this->get_parameter(prefix + "frame_id").as_string()
         };
         if (expand_names) {
           config.gz_topic_name = rclcpp::expand_topic_or_service_name(

--- a/ros_gz_bridge/test/bridge_config.cpp
+++ b/ros_gz_bridge/test/bridge_config.cpp
@@ -85,6 +85,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_FALSE(config.qos_profile.has_value());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[1];
@@ -98,6 +99,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_FALSE(config.qos_profile.has_value());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[2];
@@ -111,6 +113,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_FALSE(config.qos_profile.has_value());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[3];
@@ -124,6 +127,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_FALSE(config.qos_profile.has_value());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[4];
@@ -152,6 +156,7 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_FALSE(config.qos_profile.has_value());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(6u)), config.PublisherQoS());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(5u)), config.SubscriberQoS());
+    EXPECT_EQ("", config.frame_id);
   }
 
   {
@@ -167,6 +172,7 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_FALSE(config.qos_profile.has_value());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(20u)), config.PublisherQoS());
     EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
+    EXPECT_EQ("", config.frame_id);
   }
 
   {
@@ -197,6 +203,7 @@ TEST_F(BridgeConfig, QoSFullGz)
     EXPECT_EQ(rclcpp::SensorDataQoS(), *config.qos_profile);
     EXPECT_EQ(rclcpp::SensorDataQoS(), config.PublisherQoS());
     EXPECT_EQ(rclcpp::SensorDataQoS(), config.SubscriberQoS());
+    EXPECT_EQ("", config.frame_id);
   }
 
   {
@@ -213,6 +220,29 @@ TEST_F(BridgeConfig, QoSFullGz)
     EXPECT_EQ(rclcpp::ClockQoS(), *config.qos_profile);
     EXPECT_EQ(rclcpp::ClockQoS().keep_last(20u), config.PublisherQoS());
     EXPECT_EQ(rclcpp::ClockQoS(), config.SubscriberQoS());
+    EXPECT_EQ("", config.frame_id);
+  }
+}
+
+TEST_F(BridgeConfig, FrameIdGz)
+{
+  auto results = ros_gz_bridge::readFromYamlFile("test/config/frame_id.yaml");
+  EXPECT_EQ(1u, results.size());
+
+  {
+    auto config = results[0];
+    EXPECT_EQ("imu_sensor_msgs_imu", config.ros_topic_name);
+    EXPECT_EQ("imu_sensor_msgs_imu", config.gz_topic_name);
+    EXPECT_EQ("sensor_msgs/msg/Imu", config.ros_type_name);
+    EXPECT_EQ("gz.msgs.IMU", config.gz_type_name);
+    EXPECT_FALSE(config.publisher_queue_size.has_value());
+    EXPECT_FALSE(config.subscriber_queue_size.has_value());
+    EXPECT_EQ(ros_gz_bridge::BridgeDirection::GZ_TO_ROS, config.direction);
+    EXPECT_EQ(std::nullopt, config.is_lazy);
+    EXPECT_FALSE(config.qos_profile.has_value());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.PublisherQoS());
+    EXPECT_EQ(rclcpp::QoS(rclcpp::KeepLast(10u)), config.SubscriberQoS());
+    EXPECT_EQ("override", config.frame_id);
   }
 }
 

--- a/ros_gz_bridge/test/config/frame_id.yaml
+++ b/ros_gz_bridge/test/config/frame_id.yaml
@@ -1,0 +1,6 @@
+- ros_topic_name: "imu_sensor_msgs_imu"
+  gz_topic_name: "imu_sensor_msgs_imu"
+  ros_type_name: "sensor_msgs/msg/Imu"
+  gz_type_name: "gz.msgs.IMU"
+  direction: GZ_TO_ROS
+  frame_id: "override"


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR expands the feature added in https://github.com/gazebosim/ros_gz/pull/825 so that `frame_id` can also be specified via ROS parameters and using the launch action.

## Test it

```XML
<launch>
  <arg name="world_name" default="empty" />
  <arg name="robot_name" default="robot" />
  <ros_gz_bridge bridge_name="clock_bridge">
    <topic ros_topic_name="/clock" gz_topic_name="/clock"
           ros_type_name="rosgraph_msgs/msg/Clock" gz_type_name="gz.msgs.Clock"
           lazy="False" direction="GZ_TO_ROS" qos_profile="CLOCK" />
  </ros_gz_bridge>
  <ros_gz_bridge bridge_name="test_bridge">
    <topic ros_topic_name="/camera/image" gz_topic_name="/world/$(var world_name)/model/$(var robot_name)/camera/sensor/image"
           ros_type_name="sensor_msgs/msg/Image" gz_type_name="gz.msgs.Image"
           lazy="True" direction="GZ_TO_ROS" frame_id="camera_optical_frame" />
    <service service_name="/world/$(var world_name)/control"
             ros_type_name="ros_gz_interfaces/srv/ControlWorld"
             gz_req_type_name="gz.msgs.WorldControl" gz_rep_type_name="gz.msgs.Boolean" />
  </ros_gz_bridge>
</launch>
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.