### PR TITLE
Pass frame_id per-bridge as ROS parameter. (#854)

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -329,10 +329,16 @@ Use tag `<ros_gz_bridge>` and add `<topic>` and `<service>` subelements, one for
 ```XML
 <launch>
   <arg name="world_name" default="empty" />
+  <arg name="robot_name" default="robot" />
   <ros_gz_bridge bridge_name="clock_bridge">
     <topic ros_topic_name="/clock" gz_topic_name="/clock"
            ros_type_name="rosgraph_msgs/msg/Clock" gz_type_name="gz.msgs.Clock"
            lazy="False" direction="GZ_TO_ROS" />
+  </ros_gz_bridge>
+  <ros_gz_bridge bridge_name="test_bridge">
+    <topic ros_topic_name="/camera/image" gz_topic_name="/world/$(var world_name)/model/$(var robot_name)/camera/sensor/image"
+           ros_type_name="sensor_msgs/msg/Image" gz_type_name="gz.msgs.Image"
+           lazy="True" direction="GZ_TO_ROS" frame_id="camera_optical_frame" />
     <service service_name="/world/$(var world_name)/control"
              ros_type_name="ros_gz_interfaces/srv/ControlWorld"
              gz_req_type_name="gz.msgs.WorldControl" gz_rep_type_name="gz.msgs.Boolean" />

--- a/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
+++ b/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
@@ -197,6 +197,7 @@ class RosGzBridge(Action):
                 ('lazy', str),
                 ('publisher_queue', int),
                 ('subscriber_queue', int),
+                ('frame_id', str),
             )
             for param, param_type in optional_params:
                 p = child.get_attr(param, data_type=param_type, optional=True)

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -86,6 +86,7 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
       this->declare_parameter(prefix + "publisher_queue", 10);
       this->declare_parameter(prefix + "subscriber_queue", 10);
       this->declare_parameter(prefix + "lazy", false);
+      this->declare_parameter(prefix + "frame_id", "");
     } else {
       const auto gz_req_type = this->declare_parameter(prefix + "gz_req_type_name",
         PARAMETER_STRING);
@@ -177,7 +178,8 @@ void RosGzBridge::spin()
           this->get_parameter(prefix + "lazy").as_bool(),
           {},
           {},
-          {}
+          {},
+          this->get_parameter(prefix + "frame_id").as_string()
         };
         if (expand_names) {
           config.gz_topic_name = rclcpp::expand_topic_or_service_name(

--- a/ros_gz_bridge/test/bridge_config.cpp
+++ b/ros_gz_bridge/test/bridge_config.cpp
@@ -82,6 +82,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[1];
@@ -92,6 +93,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[2];
@@ -102,6 +104,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[3];
@@ -112,6 +115,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[4];
@@ -137,6 +141,7 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_EQ(5u, config.subscriber_queue_size);
     EXPECT_EQ(true, config.is_lazy);
     EXPECT_EQ(ros_gz_bridge::BridgeDirection::ROS_TO_GZ, config.direction);
+    EXPECT_EQ("", config.frame_id);
   }
 
   {
@@ -149,6 +154,7 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_EQ(10u, config.subscriber_queue_size);
     EXPECT_EQ(false, config.is_lazy);
     EXPECT_EQ(ros_gz_bridge::BridgeDirection::GZ_TO_ROS, config.direction);
+    EXPECT_EQ("", config.frame_id);
   }
 
   {
@@ -157,6 +163,24 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_EQ("ros_gz_interfaces/srv/ControlWorld", config.ros_type_name);
     EXPECT_EQ("gz.msgs.WorldControl", config.gz_req_type_name);
     EXPECT_EQ("gz.msgs.Boolean", config.gz_rep_type_name);
+  }
+}
+
+TEST_F(BridgeConfig, FrameIdGz)
+{
+  auto results = ros_gz_bridge::readFromYamlFile("test/config/frame_id.yaml");
+  EXPECT_EQ(1u, results.size());
+
+  {
+    auto config = results[0];
+    EXPECT_EQ("imu_sensor_msgs_imu", config.ros_topic_name);
+    EXPECT_EQ("imu_sensor_msgs_imu", config.gz_topic_name);
+    EXPECT_EQ("sensor_msgs/msg/Imu", config.ros_type_name);
+    EXPECT_EQ("gz.msgs.IMU", config.gz_type_name);
+    EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
+    EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
+    EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("override", config.frame_id);
   }
 }
 

--- a/ros_gz_bridge/test/config/frame_id.yaml
+++ b/ros_gz_bridge/test/config/frame_id.yaml
@@ -1,0 +1,6 @@
+- ros_topic_name: "imu_sensor_msgs_imu"
+  gz_topic_name: "imu_sensor_msgs_imu"
+  ros_type_name: "sensor_msgs/msg/Imu"
+  gz_type_name: "gz.msgs.IMU"
+  direction: GZ_TO_ROS
+  frame_id: "override"


### PR DESCRIPTION
# Manual Backport

Replaces #855 .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.