### PR TITLE
 test(ros_gz_bridge): Added tests for per-bridge frame_id setting from launch action.

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -329,10 +329,16 @@ Use tag `<ros_gz_bridge>` and add `<topic>` and `<service>` subelements, one for
 ```XML
 <launch>
   <arg name="world_name" default="empty" />
+  <arg name="robot_name" default="robot" />
   <ros_gz_bridge bridge_name="clock_bridge">
     <topic ros_topic_name="/clock" gz_topic_name="/clock"
            ros_type_name="rosgraph_msgs/msg/Clock" gz_type_name="gz.msgs.Clock"
            lazy="False" direction="GZ_TO_ROS" />
+  </ros_gz_bridge>
+  <ros_gz_bridge bridge_name="test_bridge">
+    <topic ros_topic_name="/camera/image" gz_topic_name="/world/$(var world_name)/model/$(var robot_name)/camera/sensor/image"
+           ros_type_name="sensor_msgs/msg/Image" gz_type_name="gz.msgs.Image"
+           lazy="True" direction="GZ_TO_ROS" frame_id="camera_optical_frame" />
     <service service_name="/world/$(var world_name)/control"
              ros_type_name="ros_gz_interfaces/srv/ControlWorld"
              gz_req_type_name="gz.msgs.WorldControl" gz_rep_type_name="gz.msgs.Boolean" />

--- a/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
+++ b/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
@@ -197,6 +197,7 @@ class RosGzBridge(Action):
                 ('lazy', str),
                 ('publisher_queue', int),
                 ('subscriber_queue', int),
+                ('frame_id', str),
             )
             for param, param_type in optional_params:
                 p = child.get_attr(param, data_type=param_type, optional=True)

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -86,6 +86,7 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
       this->declare_parameter(prefix + "publisher_queue", 10);
       this->declare_parameter(prefix + "subscriber_queue", 10);
       this->declare_parameter(prefix + "lazy", false);
+      this->declare_parameter(prefix + "frame_id", "");
     } else {
       const auto gz_req_type = this->declare_parameter(prefix + "gz_req_type_name",
         PARAMETER_STRING);
@@ -177,7 +178,8 @@ void RosGzBridge::spin()
           this->get_parameter(prefix + "lazy").as_bool(),
           {},
           {},
-          {}
+          {},
+          this->get_parameter(prefix + "frame_id").as_string()
         };
         if (expand_names) {
           config.gz_topic_name = rclcpp::expand_topic_or_service_name(

--- a/ros_gz_bridge/test/bridge_config.cpp
+++ b/ros_gz_bridge/test/bridge_config.cpp
@@ -82,6 +82,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[1];
@@ -92,6 +93,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[2];
@@ -102,6 +104,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[3];
@@ -112,6 +115,7 @@ TEST_F(BridgeConfig, Minimum)
     EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
     EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("", config.frame_id);
   }
   {
     auto config = results[4];
@@ -137,6 +141,7 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_EQ(5u, config.subscriber_queue_size);
     EXPECT_EQ(true, config.is_lazy);
     EXPECT_EQ(ros_gz_bridge::BridgeDirection::ROS_TO_GZ, config.direction);
+    EXPECT_EQ("", config.frame_id);
   }
 
   {
@@ -149,6 +154,7 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_EQ(10u, config.subscriber_queue_size);
     EXPECT_EQ(false, config.is_lazy);
     EXPECT_EQ(ros_gz_bridge::BridgeDirection::GZ_TO_ROS, config.direction);
+    EXPECT_EQ("", config.frame_id);
   }
 
   {
@@ -157,6 +163,24 @@ TEST_F(BridgeConfig, FullGz)
     EXPECT_EQ("ros_gz_interfaces/srv/ControlWorld", config.ros_type_name);
     EXPECT_EQ("gz.msgs.WorldControl", config.gz_req_type_name);
     EXPECT_EQ("gz.msgs.Boolean", config.gz_rep_type_name);
+  }
+}
+
+TEST_F(BridgeConfig, FrameIdGz)
+{
+  auto results = ros_gz_bridge::readFromYamlFile("test/config/frame_id.yaml");
+  EXPECT_EQ(1u, results.size());
+
+  {
+    auto config = results[0];
+    EXPECT_EQ("imu_sensor_msgs_imu", config.ros_topic_name);
+    EXPECT_EQ("imu_sensor_msgs_imu", config.gz_topic_name);
+    EXPECT_EQ("sensor_msgs/msg/Imu", config.ros_type_name);
+    EXPECT_EQ("gz.msgs.IMU", config.gz_type_name);
+    EXPECT_EQ(ros_gz_bridge::kDefaultPublisherQueue, config.publisher_queue_size);
+    EXPECT_EQ(ros_gz_bridge::kDefaultSubscriberQueue, config.subscriber_queue_size);
+    EXPECT_EQ(ros_gz_bridge::kDefaultLazy, config.is_lazy);
+    EXPECT_EQ("override", config.frame_id);
   }
 }
 

--- a/ros_gz_bridge/test/config/frame_id.yaml
+++ b/ros_gz_bridge/test/config/frame_id.yaml
@@ -1,0 +1,6 @@
+- ros_topic_name: "imu_sensor_msgs_imu"
+  gz_topic_name: "imu_sensor_msgs_imu"
+  ros_type_name: "sensor_msgs/msg/Imu"
+  gz_type_name: "gz.msgs.IMU"
+  direction: GZ_TO_ROS
+  frame_id: "override"

--- a/ros_gz_bridge/test/config/test-config.yaml
+++ b/ros_gz_bridge/test/config/test-config.yaml
@@ -4,6 +4,13 @@
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
 
+# Rewrite frame ID
+- ros_topic_name: "image_sensor_msgs_image"
+  gz_topic_name: "image_sensor_msgs_image"
+  ros_type_name: "sensor_msgs/msg/Image"
+  gz_type_name: "gz.msgs.Image"
+  frame_id: "override"
+
 # Set just ROS topic name, applies to both
 - ros_topic_name: "boolean_std_msgs_bool"
   gz_topic_name: "boolean_std_msgs_bool"

--- a/ros_gz_bridge/test/launch/test_launch_action.launch
+++ b/ros_gz_bridge/test/launch/test_launch_action.launch
@@ -23,6 +23,10 @@ limitations under the License.
         <topic ros_topic_name="/imu_sensor_msgs_imu" gz_topic_name="/imu_sensor_msgs_imu"
                ros_type_name="sensor_msgs/msg/Imu" gz_type_name="gz.msgs.IMU"
                lazy="False" direction="GZ_TO_ROS" publisher_queue_size="1" subscriber_queue_size="1" />
+        <topic ros_topic_name="/image_sensor_msgs_image" gz_topic_name="/image_sensor_msgs_image"
+               ros_type_name="sensor_msgs/msg/Image" gz_type_name="gz.msgs.Image"
+               lazy="False" direction="GZ_TO_ROS" publisher_queue_size="1" subscriber_queue_size="1"
+               frame_id="override" />
         <service service_name="/gz_ros/test/serviceclient/world_control"
                  ros_type_name="ros_gz_interfaces/srv/ControlWorld"
                  gz_req_type_name="gz.msgs.WorldControl" gz_rep_type_name="gz.msgs.Boolean" />

--- a/ros_gz_bridge/test/subscribers/launch_action_subscriber.cpp
+++ b/ros_gz_bridge/test/subscribers/launch_action_subscriber.cpp
@@ -21,6 +21,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include "ros_subscriber.hpp"
 #include "utils/test_utils.hpp"
@@ -63,6 +64,21 @@ TEST(LaunchActionSubscriberTest, imu_sensors_msgs_imu)
     ros_subscriber::TestNode(), client.callbackExecuted, 10ms, 200);
 
   EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(LaunchActionSubscriberTest, image_sensor_msgs_image)
+{
+  ros_subscriber::TestSubOnly<sensor_msgs::msg::Image> client(
+    "image_sensor_msgs_image");
+
+  using namespace std::chrono_literals;
+  ros_gz_bridge::testing::waitUntilBoolVarAndSpin(
+    ros_subscriber::TestNode(), client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+  ASSERT_NE(nullptr, client.msg);
+  EXPECT_EQ("override", client.msg->header.frame_id);
 }
 
 /////////////////////////////////////////////////

--- a/ros_gz_bridge/test/subscribers/ros_subscriber.hpp
+++ b/ros_gz_bridge/test/subscribers/ros_subscriber.hpp
@@ -63,6 +63,37 @@ private:
   typename rclcpp::Subscription<ROS_T>::SharedPtr sub;
 };
 
+/////////////////////////////////////////////////
+/// \brief A class for testing ROS topic subscription with custom examination
+///        of the test message.
+template<typename ROS_T>
+class TestSubOnly
+{
+public:
+  /// \brief Class constructor.
+  explicit TestSubOnly(const std::string & _topic)
+  {
+    using std::placeholders::_1;
+    this->sub = TestNode()->create_subscription<ROS_T>(
+      _topic, 1,
+      [this](const ROS_T & _msg)
+      {
+        this->callbackExecuted = true;
+        this->msg = std::make_shared<ROS_T>(_msg);
+      });
+  }
+
+  /// \brief Member variables that flag when the actions are executed.
+
+public:
+  bool callbackExecuted = false;
+  typename ROS_T::SharedPtr msg;
+
+private:
+  /// \brief ROS subscriber;
+  typename rclcpp::Subscription<ROS_T>::SharedPtr sub;
+};
+
 
 }  // namespace ros_subscriber
 


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/ros_gz/pull/854#pullrequestreview-3969606649 .

## Summary

This PR adds the tests for rewriting frame ID in bridge launch action, as requested in https://github.com/gazebosim/ros_gz/pull/854#pullrequestreview-3969606649 .

This PR requires #858 .

## Test it

Just run tests.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.