### PR TITLE
Handle frame id in tfmessage conversions

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -213,6 +213,13 @@ e.g. by using a static transform publisher. Users can then use the
 ros2 run ros_gz_bridge parameter_bridge /rgbd_camera/image@sensor_msgs/msg/Image@gz.msgs.Image --ros-args -p override_frame_id:=my_custom_optical_frame
 ```
 
+This also works for messages with multiple frames, such as `tf2_msgs/msg/TFMessage`, which contains a vector of `TransformStamped` messages. The `override_frame_id` will be applied to each transform's `header.frame_id`:
+
+```bash
+. ~/bridge_ws/install/setup.bash
+ros2 run ros_gz_bridge parameter_bridge /tf@tf2_msgs/msg/TFMessage@gz.msgs.Pose_V --ros-args -p override_frame_id:=world
+```
+
 ## Example 3: Static bridge
 
 In this example, we're going to run an executable that starts a bidirectional

--- a/ros_gz_bridge/src/convert/geometry_msgs.cpp
+++ b/ros_gz_bridge/src/convert/geometry_msgs.cpp
@@ -236,6 +236,7 @@ convert_ros_to_gz(
 {
   convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
   convert_ros_to_gz(ros_msg.transform, gz_msg);
+  gz_msg.set_name(ros_msg.child_frame_id);
 
   auto newPair = gz_msg.mutable_header()->add_data();
   newPair->set_key("child_frame_id");
@@ -256,6 +257,9 @@ convert_gz_to_ros(
       ros_msg.child_frame_id = frame_id_gz_to_ros(aPair.value(0));
       break;
     }
+  }
+  if (ros_msg.child_frame_id.empty() && !gz_msg.name().empty()) {
+    ros_msg.child_frame_id = frame_id_gz_to_ros(gz_msg.name());
   }
 }
 

--- a/ros_gz_bridge/src/convert/tf2_msgs.cpp
+++ b/ros_gz_bridge/src/convert/tf2_msgs.cpp
@@ -28,7 +28,6 @@ convert_ros_to_gz(
   for (auto const & t : ros_msg.transforms) {
     auto p = gz_msg.add_pose();
     convert_ros_to_gz(t, *p);
-    p->set_name(t.child_frame_id);
   }
 
   if (!ros_msg.transforms.empty()) {
@@ -48,9 +47,6 @@ convert_gz_to_ros(
   for (auto const & p : gz_msg.pose()) {
     geometry_msgs::msg::TransformStamped tf;
     convert_gz_to_ros(p, tf);
-    if (!p.name().empty()) {
-      tf.child_frame_id = frame_id_gz_to_ros(p.name());
-    }
     ros_msg.transforms.push_back(tf);
   }
 }

--- a/ros_gz_bridge/src/convert/tf2_msgs.cpp
+++ b/ros_gz_bridge/src/convert/tf2_msgs.cpp
@@ -28,6 +28,7 @@ convert_ros_to_gz(
   for (auto const & t : ros_msg.transforms) {
     auto p = gz_msg.add_pose();
     convert_ros_to_gz(t, *p);
+    p->set_name(t.child_frame_id);
   }
 
   if (!ros_msg.transforms.empty()) {
@@ -47,6 +48,9 @@ convert_gz_to_ros(
   for (auto const & p : gz_msg.pose()) {
     geometry_msgs::msg::TransformStamped tf;
     convert_gz_to_ros(p, tf);
+    if (!p.name().empty()) {
+      tf.child_frame_id = frame_id_gz_to_ros(p.name());
+    }
     ros_msg.transforms.push_back(tf);
   }
 }

--- a/ros_gz_bridge/src/factory.hpp
+++ b/ros_gz_bridge/src/factory.hpp
@@ -43,6 +43,16 @@ struct has_header<T, std::void_t<decltype(T::header)>>: std::true_type
 {
 };
 
+template<class T, class = void>
+struct has_transforms : std::false_type
+{
+};
+
+template<class T>
+struct has_transforms<T, std::void_t<decltype(T::transforms)>>: std::true_type
+{
+};
+
 namespace ros_gz_bridge
 {
 
@@ -198,6 +208,12 @@ protected:
       }
       if (!gz_to_ros_parameters.override_frame_id.empty()) {
         ros_msg.header.frame_id = gz_to_ros_parameters.override_frame_id;
+      }
+    } else if constexpr (has_transforms<ROS_T>::value) {
+      if (!gz_to_ros_parameters.override_frame_id.empty()) {
+        for (auto & tf : ros_msg.transforms) {
+          tf.header.frame_id = gz_to_ros_parameters.override_frame_id;
+        }
       }
     }
     ros_pub->publish(ros_msg);

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -395,6 +395,7 @@ void createTestMsg(gz::msgs::Pose_V & _msg)
 {
   createTestMsg(*(_msg.mutable_header()));
   createTestMsg(*(_msg.add_pose()));
+  _msg.mutable_pose(0)->set_name("child_frame_id_value");
 }
 
 void compareTestMsg(const std::shared_ptr<gz::msgs::Pose_V> & _msg)
@@ -404,6 +405,7 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::Pose_V> & _msg)
 
   compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
   compareTestMsg(std::make_shared<gz::msgs::Pose>(_msg->pose(0)));
+  EXPECT_EQ(_msg->pose(0).name(), "child_frame_id_value");
 }
 
 void createTestMsg(gz::msgs::Twist & _msg)


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🎉 New feature

Closes #848 

## Summary

In ros_gz_bridge, when converting to or from ROS2 stamped transform types, we now pass frame_ids for both the parent and child frames.

### ROS2 -> Gazebo
The TransformStamped.child_frame_id field is copied to the gz.msgs.Pose.name field.

### Gazebo -> ROS2
The gz.msgs.Pose.name field is copied to the TransformStamped.child_frame_id field.
To populate the TransformStamped.header.frame_id field, we leverage the already-existing override_frame_id parameter of the bridge node.

The logic applies to TFMessage and Pose_V types also.

## Test it
Existing unit test has been updated to check the gz.msgs.Pose.name field for the ROS -> Gazebo case.

For Gazebo -> ROS, launch Gazebo along with a bridge node configured for Pose to TransformStamped, with a value set for override_frame_id. Echo the ROS output topic to verify.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests - **Updated an existing test**
- [X] Updated documentation (as needed) - **Added a note to `ros_gz_bridge/README.md`**
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them) - **n/a**
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [X] Updated Bazel files (if adding new files). Created an issue otherwise. **n/a**
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [X] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.) **PR is not AI-gen**

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.