### PR TITLE
 test(ros_gz_bridge): Added tests for per-bridge frame_id setting from launch action.

### DIFF
--- a/ros_gz_bridge/test/config/test-config.yaml
+++ b/ros_gz_bridge/test/config/test-config.yaml
@@ -4,6 +4,13 @@
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
 
+# Rewrite frame ID
+- ros_topic_name: "image_sensor_msgs_image"
+  gz_topic_name: "image_sensor_msgs_image"
+  ros_type_name: "sensor_msgs/msg/Image"
+  gz_type_name: "gz.msgs.Image"
+  frame_id: "override"
+
 # Set just ROS topic name, applies to both
 - ros_topic_name: "boolean_std_msgs_bool"
   gz_topic_name: "boolean_std_msgs_bool"

--- a/ros_gz_bridge/test/launch/test_launch_action.launch
+++ b/ros_gz_bridge/test/launch/test_launch_action.launch
@@ -23,6 +23,10 @@ limitations under the License.
         <topic ros_topic_name="/imu_sensor_msgs_imu" gz_topic_name="/imu_sensor_msgs_imu"
                ros_type_name="sensor_msgs/msg/Imu" gz_type_name="gz.msgs.IMU"
                lazy="False" direction="GZ_TO_ROS" publisher_queue_size="1" subscriber_queue_size="1" />
+        <topic ros_topic_name="/image_sensor_msgs_image" gz_topic_name="/image_sensor_msgs_image"
+               ros_type_name="sensor_msgs/msg/Image" gz_type_name="gz.msgs.Image"
+               lazy="False" direction="GZ_TO_ROS" publisher_queue_size="1" subscriber_queue_size="1"
+               frame_id="override" />
         <service service_name="/gz_ros/test/serviceclient/world_control"
                  ros_type_name="ros_gz_interfaces/srv/ControlWorld"
                  gz_req_type_name="gz.msgs.WorldControl" gz_rep_type_name="gz.msgs.Boolean" />

--- a/ros_gz_bridge/test/subscribers/launch_action_subscriber.cpp
+++ b/ros_gz_bridge/test/subscribers/launch_action_subscriber.cpp
@@ -21,6 +21,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include "ros_subscriber.hpp"
 #include "utils/test_utils.hpp"
@@ -63,6 +64,21 @@ TEST(LaunchActionSubscriberTest, imu_sensors_msgs_imu)
     ros_subscriber::TestNode(), client.callbackExecuted, 10ms, 200);
 
   EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(LaunchActionSubscriberTest, image_sensor_msgs_image)
+{
+  ros_subscriber::TestSubOnly<sensor_msgs::msg::Image> client(
+    "image_sensor_msgs_image");
+
+  using namespace std::chrono_literals;
+  ros_gz_bridge::testing::waitUntilBoolVarAndSpin(
+    ros_subscriber::TestNode(), client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+  ASSERT_NE(nullptr, client.msg);
+  EXPECT_EQ("override", client.msg->header.frame_id);
 }
 
 /////////////////////////////////////////////////

--- a/ros_gz_bridge/test/subscribers/ros_subscriber.hpp
+++ b/ros_gz_bridge/test/subscribers/ros_subscriber.hpp
@@ -63,6 +63,37 @@ private:
   typename rclcpp::Subscription<ROS_T>::SharedPtr sub;
 };
 
+/////////////////////////////////////////////////
+/// \brief A class for testing ROS topic subscription with custom examination
+///        of the test message.
+template<typename ROS_T>
+class TestSubOnly
+{
+public:
+  /// \brief Class constructor.
+  explicit TestSubOnly(const std::string & _topic)
+  {
+    using std::placeholders::_1;
+    this->sub = TestNode()->create_subscription<ROS_T>(
+      _topic, 1,
+      [this](const ROS_T & _msg)
+      {
+        this->callbackExecuted = true;
+        this->msg = std::make_shared<ROS_T>(_msg);
+      });
+  }
+
+  /// \brief Member variables that flag when the actions are executed.
+
+public:
+  bool callbackExecuted = false;
+  typename ROS_T::SharedPtr msg;
+
+private:
+  /// \brief ROS subscriber;
+  typename rclcpp::Subscription<ROS_T>::SharedPtr sub;
+};
+
 
 }  // namespace ros_subscriber
 


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/ros_gz/pull/854#pullrequestreview-3969606649 .

Forward-ports #860 to Rolling.

## Summary

This PR adds the tests for rewriting frame ID in bridge launch action, as requested in https://github.com/gazebosim/ros_gz/pull/854#pullrequestreview-3969606649 .

This PR requires #858 .

## Test it

Just run tests.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.