### PR TITLE
Fix CLI namespace expansion for expand_gz_topic_names

### DIFF
--- a/ros_gz_bridge/src/parameter_bridge.cpp
+++ b/ros_gz_bridge/src/parameter_bridge.cpp
@@ -84,6 +84,10 @@ int main(int argc, char * argv[])
   bridge_node->declare_parameter<bool>("lazy", false);
   bridge_node->get_parameter("lazy", lazy_subscription);
 
+  bool expand_gz_topic_names = false;
+  bridge_node->get_parameter("expand_gz_topic_names", expand_gz_topic_names);
+  std::string ns = bridge_node->get_namespace();
+
   const std::string delim = "@";
   const std::string delimGzToROS = "[";
   const std::string delimROSToGz = "]";
@@ -101,6 +105,21 @@ int main(int argc, char * argv[])
     config.ros_topic_name = arg.substr(0, delimPos);
     config.gz_topic_name = arg.substr(0, delimPos);
     arg.erase(0, delimPos + delim.size());
+
+    if (expand_gz_topic_names) {
+      std::string gz_topic = config.gz_topic_name;
+      // Strip leading slash from the topic to prevent double slashes (e.g., /demo//chatter)
+      if (!gz_topic.empty() && gz_topic.front() == '/') {
+        gz_topic.erase(0, 1);
+      }
+      
+      // Safely append the namespace
+      if (ns == "/") {
+        config.gz_topic_name = "/" + gz_topic;
+      } else {
+        config.gz_topic_name = ns + "/" + gz_topic;
+      }
+    }
 
     // Get the direction delimiter, which should be one of:
     //   @ == bidirectional, or


### PR DESCRIPTION
**Description:**
Fixes #702. 
 
**The Issue:**
When creating a bridge via CLI string parsing (e.g., `topic@ros_type@gz_type`), the `expand_gz_topic_names` parameter was being completely ignored, whereas it worked correctly when passed via a YAML config file.
 
**The Fix:**
Updated the argument parsing loop in `parameter_bridge.cpp` to:
1. Fetch the `expand_gz_topic_names` parameter and the node's current namespace via `get_namespace()`.
2. Safely prepend the ROS namespace to `config.gz_topic_name` when the parameter is set to true, preventing double slashes.
 
**Testing:**
Reproduced the original issue using the `osrf/ros:humble-simulation` Docker container. Built this branch from source and verified that running:
`ros2 run ros_gz_bridge parameter_bridge chatter@std_msgs/msg/String@ignition.msgs.StringMsg --ros-args -p expand_gz_topic_names:=true -r __ns:=/demo`

Now correctly results in `ign topic -l` outputting: `/demo/chatter`