### PR TITLE
Fix service-only YAML reload loop in ros_gz_bridge

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -341,6 +341,13 @@ if(BUILD_TESTING)
   target_include_directories(${PROJECT_NAME}_bridge_config PRIVATE src)
   target_link_libraries(${PROJECT_NAME}_bridge_config rclcpp::rclcpp ${bridge_lib})
 
+  ament_add_gtest(${PROJECT_NAME}_ros_gz_bridge test/ros_gz_bridge.cpp
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  target_include_directories(${PROJECT_NAME}_ros_gz_bridge PRIVATE src)
+
+  ament_target_dependencies(${PROJECT_NAME}_ros_gz_bridge rclcpp)
+  target_link_libraries(${PROJECT_NAME}_ros_gz_bridge ${bridge_lib})
+
   ament_add_gtest(${PROJECT_NAME}_gid_filtering test/test_gid_filtering.cpp)
   target_link_libraries(${PROJECT_NAME}_gid_filtering
     rclcpp::rclcpp

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -120,7 +120,7 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
 
 void RosGzBridge::spin()
 {
-  if (handles_.empty()) {
+  if (handles_.empty() && services_.empty()) {
     std::string config_file;
     this->get_parameter("config_file", config_file);
     bool expand_names;

--- a/ros_gz_bridge/test/config/service_only.yaml
+++ b/ros_gz_bridge/test/config/service_only.yaml
@@ -1,0 +1,4 @@
+- service_name: "/gz_ros/test/serviceclient/world_control"
+  ros_type_name: "ros_gz_interfaces/srv/ControlWorld"
+  gz_req_type_name: "gz.msgs.WorldControl"
+  gz_rep_type_name: "gz.msgs.Boolean"

--- a/ros_gz_bridge/test/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/test/ros_gz_bridge.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include <rcutils/logging.h>
+#include <rclcpp/rclcpp.hpp>
+#include <ros_gz_bridge/ros_gz_bridge.hpp>
+
+size_t g_service_bridge_create_logs = 0;
+
+class TestableRosGzBridge : public ros_gz_bridge::RosGzBridge
+{
+public:
+  explicit TestableRosGzBridge(const rclcpp::NodeOptions & options)
+  : ros_gz_bridge::RosGzBridge(options)
+  {
+  }
+
+  using ros_gz_bridge::RosGzBridge::spin;
+
+  size_t HandleCount() const
+  {
+    return handles_.size();
+  }
+
+  size_t ServiceCount() const
+  {
+    return services_.size();
+  }
+};
+
+class RosGzBridgeTest : public ::testing::Test
+{
+protected:
+  rcutils_logging_output_handler_t previous_output_handler;
+
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override
+  {
+    g_service_bridge_create_logs = 0;
+    rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_INFO);
+
+    auto logging_handler = [](
+      const rcutils_log_location_t *,
+      int, const char *, rcutils_time_point_value_t,
+      const char * format, va_list * args) -> void
+      {
+        char buffer[1024];
+        vsnprintf(buffer, sizeof(buffer), format, *args);
+
+        const std::string message = buffer;
+        if (message.find("Creating ROS->GZ service bridge") != std::string::npos) {
+          ++g_service_bridge_create_logs;
+        }
+      };
+
+    this->previous_output_handler = rcutils_logging_get_output_handler();
+    rcutils_logging_set_output_handler(logging_handler);
+  }
+
+  void TearDown() override
+  {
+    rcutils_logging_set_output_handler(this->previous_output_handler);
+  }
+};
+
+TEST_F(RosGzBridgeTest, ServiceOnlyConfigIsLoadedOnce)
+{
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("config_file", "test/config/service_only.yaml");
+
+  auto bridge = std::make_shared<TestableRosGzBridge>(options);
+
+  bridge->spin();
+  EXPECT_EQ(0u, bridge->HandleCount());
+  EXPECT_EQ(1u, bridge->ServiceCount());
+  EXPECT_EQ(1u, g_service_bridge_create_logs);
+
+  bridge->spin();
+  EXPECT_EQ(0u, bridge->HandleCount());
+  EXPECT_EQ(1u, bridge->ServiceCount());
+  EXPECT_EQ(1u, g_service_bridge_create_logs);
+}


### PR DESCRIPTION
## Summary

This fixes a service-only YAML config path in `ros_gz_bridge`.

When a config file only defines service bridges, `RosGzBridge::spin()` keeps treating the bridge as uninitialized because `handles_` stays empty. That means the same service bridge setup can be attempted again on every heartbeat. Topic bridges do not hit this because they populate `handles_`.

The patch treats existing service bridges as loaded bridge configuration too, and adds a small regression test for a service-only YAML file.

Fixes #877.

## Context

Found while checking ROS/Gazebo setup failure modes for robotics diagnostics work. The user report in #877 had a nice minimal Jazzy repro, so this seemed like a good small fix instead of just another troubleshooting note.

## Validation

- `git diff --check`
- Targeted gtest passed in a clean Docker env (`ros:rolling-ros-base`): `ros_gz_bridge_ros_gz_bridge` / `RosGzBridgeTest.ServiceOnlyConfigIsLoadedOnce` (details: https://github.com/gazebosim/ros_gz/pull/878#issuecomment-4389349097)

## PR Checklist

- GenAI used to generate or assist with generating code: **Yes** (AI-assisted drafting via Codex/ChatGPT; changes reviewed and adjusted by a human)
