### PR TITLE
ci: install ros-base in ubuntu container

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -21,6 +21,10 @@ apt-get install -y python3-colcon-common-extensions \
                    python3-rosdep \
                    libcli11-dev
 
+# Ensure the base ROS distro is installed so /opt/ros/$ROS_DISTRO exists
+# before sourcing it below.
+apt-get install -y ros-$ROS_DISTRO-ros-base
+
 rosdep init
 rosdep update
 rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO $ROSDEP_ARGS


### PR DESCRIPTION
The current `ROS2 CI` workflow runs inside an `ubuntu:24.04` container and calls `.github/workflows/build-and-test.sh`.

Right now that script does not install any base ROS packages before running:

`source /opt/ros/$ROS_DISTRO/setup.bash`

…so the job can fail immediately with:

`.github/workflows/build-and-test.sh: line 29: /opt/ros/rolling/setup.bash: No such file or directory`

This PR installs `ros-$ROS_DISTRO-ros-base` before sourcing. That creates `/opt/ros/$ROS_DISTRO` and lets the job proceed to the actual build/test steps.

Repro (current `ros2`):
- `docker run --rm --platform linux/amd64 -t -v "$PWD":/repo -w /repo ubuntu:24.04 bash -lc 'export ROS_DISTRO=rolling; export ROSDEP_ARGS=""; .github/workflows/build-and-test.sh'`

Validation (this change):
- `apt-get install -y ros-rolling-ros-base` succeeds in `ubuntu:24.04` with the repo's configured ROS apt source and provides `/opt/ros/rolling/setup.bash`.
