### PR TITLE
sensor_msgs bounds fixes

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -213,6 +213,20 @@ if(BUILD_TESTING)
     ${PROJECT_SOURCE_DIR}/include
   )
 
+  ament_add_gtest(test_sensor_msgs
+    ${PROJECT_SOURCE_DIR}/src/convert/sensor_msgs_TEST.cpp
+  )
+  target_link_libraries(test_sensor_msgs
+    ${bridge_lib}
+    ${sensor_msgs_TARGETS}
+    gtest
+    gtest_main
+  )
+  target_include_directories(test_sensor_msgs
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+  )
+
   add_library(test_utils
     test/utils/gz_test_msg.cpp
     test/utils/ros_test_msg.cpp

--- a/ros_gz_bridge/src/convert/sensor_msgs.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs.cpp
@@ -278,7 +278,10 @@ convert_gz_to_ros(
   if (gz_msg.has_intrinsics()) {
     const auto & intrinsics = gz_msg.intrinsics();
 
-    for (auto i = 0; i < intrinsics.k_size(); ++i) {
+    // ros_msg.k is std::array<double, 9>; never write past its bounds.
+    const auto k_count =
+      std::min<size_t>(intrinsics.k_size(), ros_msg.k.size());
+    for (size_t i = 0; i < k_count; ++i) {
       ros_msg.k[i] = intrinsics.k(i);
     }
   }
@@ -286,12 +289,18 @@ convert_gz_to_ros(
   if (gz_msg.has_projection()) {
     const auto & projection = gz_msg.projection();
 
-    for (auto i = 0; i < projection.p_size(); ++i) {
+    // ros_msg.p is std::array<double, 12>; never write past its bounds.
+    const auto p_count =
+      std::min<size_t>(projection.p_size(), ros_msg.p.size());
+    for (size_t i = 0; i < p_count; ++i) {
       ros_msg.p[i] = projection.p(i);
     }
   }
 
-  for (auto i = 0; i < gz_msg.rectification_matrix_size(); ++i) {
+  // ros_msg.r is std::array<double, 9>; never write past its bounds.
+  const auto r_count =
+    std::min<size_t>(gz_msg.rectification_matrix_size(), ros_msg.r.size());
+  for (size_t i = 0; i < r_count; ++i) {
     ros_msg.r[i] = gz_msg.rectification_matrix(i);
   }
 }
@@ -362,12 +371,21 @@ convert_ros_to_gz(
 {
   convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
 
+  // The JointState spec allows `name`, `velocity`, and `effort` to be empty
+  // or shorter than `position`, so each array is indexed only within its
+  // own bounds.
   for (auto i = 0u; i < ros_msg.position.size(); ++i) {
     auto newJoint = gz_msg.add_joint();
-    newJoint->set_name(ros_msg.name[i]);
+    if (i < ros_msg.name.size()) {
+      newJoint->set_name(ros_msg.name[i]);
+    }
     newJoint->mutable_axis1()->set_position(ros_msg.position[i]);
-    newJoint->mutable_axis1()->set_velocity(ros_msg.velocity[i]);
-    newJoint->mutable_axis1()->set_force(ros_msg.effort[i]);
+    if (i < ros_msg.velocity.size()) {
+      newJoint->mutable_axis1()->set_velocity(ros_msg.velocity[i]);
+    }
+    if (i < ros_msg.effort.size()) {
+      newJoint->mutable_axis1()->set_force(ros_msg.effort[i]);
+    }
   }
 }
 
@@ -429,8 +447,15 @@ convert_ros_to_gz(
   const sensor_msgs::msg::LaserScan & ros_msg,
   gz::msgs::LaserScan & gz_msg)
 {
-  const unsigned int num_readings =
+  // Computing count from angle range/increment can disagree with the actual
+  // ranges array (FP rounding); intensities is also optional and frequently
+  // empty. Clamp to the publisher's actual array sizes to stay in bounds.
+  const unsigned int computed_count =
     (ros_msg.angle_max - ros_msg.angle_min) / ros_msg.angle_increment;
+  const unsigned int ranges_count =
+    std::min<size_t>(computed_count, ros_msg.ranges.size());
+  const unsigned int intensities_count =
+    std::min<size_t>(computed_count, ros_msg.intensities.size());
 
   convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
   gz_msg.set_frame(ros_msg.header.frame_id);
@@ -439,7 +464,7 @@ convert_ros_to_gz(
   gz_msg.set_angle_step(ros_msg.angle_increment);
   gz_msg.set_range_min(ros_msg.range_min);
   gz_msg.set_range_max(ros_msg.range_max);
-  gz_msg.set_count(num_readings);
+  gz_msg.set_count(ranges_count);
 
   // Not supported in sensor_msgs::msg::LaserScan.
   gz_msg.set_vertical_angle_min(0.0);
@@ -447,8 +472,10 @@ convert_ros_to_gz(
   gz_msg.set_vertical_angle_step(0.0);
   gz_msg.set_vertical_count(0u);
 
-  for (auto i = 0u; i < gz_msg.count(); ++i) {
+  for (auto i = 0u; i < ranges_count; ++i) {
     gz_msg.add_ranges(ros_msg.ranges[i]);
+  }
+  for (auto i = 0u; i < intensities_count; ++i) {
     gz_msg.add_intensities(ros_msg.intensities[i]);
   }
 }
@@ -479,18 +506,31 @@ convert_gz_to_ros(
   // If there are multiple vertical beams, use the one in the middle.
   size_t start = (vertical_count / 2) * count;
 
+  // Defensively clamp ranges/intensities to whatever the sender actually
+  // populated — `count` is just a declared field and may exceed the array.
+  const size_t ranges_avail =
+    (start < static_cast<size_t>(gz_msg.ranges_size())) ?
+    (gz_msg.ranges_size() - start) :
+    0u;
+  const size_t intensities_avail =
+    (start < static_cast<size_t>(gz_msg.intensities_size())) ?
+    (gz_msg.intensities_size() - start) :
+    0u;
+  const size_t ranges_count = std::min<size_t>(count, ranges_avail);
+  const size_t intensities_count = std::min<size_t>(count, intensities_avail);
+
   // Copy ranges into ROS message.
-  ros_msg.ranges.resize(count);
+  ros_msg.ranges.resize(ranges_count);
   std::copy(
     gz_msg.ranges().begin() + start,
-    gz_msg.ranges().begin() + start + count,
+    gz_msg.ranges().begin() + start + ranges_count,
     ros_msg.ranges.begin());
 
   // Copy intensities into ROS message.
-  ros_msg.intensities.resize(count);
+  ros_msg.intensities.resize(intensities_count);
   std::copy(
     gz_msg.intensities().begin() + start,
-    gz_msg.intensities().begin() + start + count,
+    gz_msg.intensities().begin() + start + intensities_count,
     ros_msg.intensities.begin());
 }
 

--- a/ros_gz_bridge/src/convert/sensor_msgs_TEST.cpp
+++ b/ros_gz_bridge/src/convert/sensor_msgs_TEST.cpp
@@ -1,0 +1,178 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Bounds-safety tests for sensor_msgs <-> gz::msgs converters.
+//
+// Every test in this file targets a specific out-of-bounds read or write
+// reachable from a *spec-conformant* input message. Without the
+// corresponding fixes these tests either crash (under AddressSanitizer)
+// or produce garbage values.
+
+#include <gtest/gtest.h>
+
+#include <ros_gz_bridge/convert/sensor_msgs.hpp>
+
+// ---------------------------------------------------------------------------
+// JointState ROS->GZ : gh issue #118
+//
+// sensor_msgs/JointState allows `name`, `velocity`, and `effort` to be
+// shorter than `position` (the spec explicitly says they may be empty).
+// joint_state_publisher publishes `position`-only messages, which made
+// the bridge crash with signal 245 (issue #118, open since 2020).
+// ---------------------------------------------------------------------------
+TEST(JointStateRosToGz, PositionOnlyDoesNotReadPastVelocityOrEffort)
+{
+  sensor_msgs::msg::JointState ros_msg;
+  ros_msg.name = {"joint1", "joint2"};
+  ros_msg.position = {0.1, 0.2};
+  // velocity and effort intentionally empty.
+
+  gz::msgs::Model gz_msg;
+  ASSERT_NO_FATAL_FAILURE(ros_gz_bridge::convert_ros_to_gz(ros_msg, gz_msg));
+
+  ASSERT_EQ(2, gz_msg.joint_size());
+  EXPECT_EQ("joint1", gz_msg.joint(0).name());
+  EXPECT_DOUBLE_EQ(0.1, gz_msg.joint(0).axis1().position());
+  EXPECT_DOUBLE_EQ(0.0, gz_msg.joint(0).axis1().velocity());
+  EXPECT_DOUBLE_EQ(0.0, gz_msg.joint(0).axis1().force());
+  EXPECT_EQ("joint2", gz_msg.joint(1).name());
+  EXPECT_DOUBLE_EQ(0.2, gz_msg.joint(1).axis1().position());
+}
+
+TEST(JointStateRosToGz, NameShorterThanPositionDoesNotOverread)
+{
+  sensor_msgs::msg::JointState ros_msg;
+  // Two positions but only one name — the bridge must not read name[1].
+  ros_msg.name = {"only_joint"};
+  ros_msg.position = {0.1, 0.2};
+
+  gz::msgs::Model gz_msg;
+  ASSERT_NO_FATAL_FAILURE(ros_gz_bridge::convert_ros_to_gz(ros_msg, gz_msg));
+
+  ASSERT_EQ(2, gz_msg.joint_size());
+  EXPECT_EQ("only_joint", gz_msg.joint(0).name());
+  EXPECT_EQ("", gz_msg.joint(1).name());
+}
+
+// ---------------------------------------------------------------------------
+// LaserScan ROS->GZ : count is computed from angle range / increment,
+// which can disagree with the actual array sizes due to FP rounding.
+// Many lidars also publish no intensities at all. The bridge must clamp
+// to the actual array sizes instead of trusting the computed count.
+// ---------------------------------------------------------------------------
+TEST(LaserScanRosToGz, ComputedCountLargerThanRangesArrayIsClamped)
+{
+  sensor_msgs::msg::LaserScan ros_msg;
+  ros_msg.angle_min = 0.0f;
+  ros_msg.angle_max = 1.0f;
+  ros_msg.angle_increment = 0.1f;  // (1.0 - 0.0) / 0.1 == 10 by computation
+  ros_msg.range_min = 0.0f;
+  ros_msg.range_max = 10.0f;
+  // ...but the publisher only filled 5 samples.
+  ros_msg.ranges = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+  ros_msg.intensities = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f};
+
+  gz::msgs::LaserScan gz_msg;
+  ASSERT_NO_FATAL_FAILURE(ros_gz_bridge::convert_ros_to_gz(ros_msg, gz_msg));
+
+  EXPECT_LE(static_cast<size_t>(gz_msg.ranges_size()), ros_msg.ranges.size());
+  EXPECT_LE(
+    static_cast<size_t>(gz_msg.intensities_size()),
+    ros_msg.intensities.size());
+}
+
+TEST(LaserScanRosToGz, EmptyIntensitiesDoesNotOverread)
+{
+  sensor_msgs::msg::LaserScan ros_msg;
+  ros_msg.angle_min = 0.0f;
+  ros_msg.angle_max = 1.0f;
+  ros_msg.angle_increment = 0.25f;
+  ros_msg.ranges = {1.0f, 2.0f, 3.0f, 4.0f};
+  // intensities deliberately empty — common for many real lidars.
+
+  gz::msgs::LaserScan gz_msg;
+  ASSERT_NO_FATAL_FAILURE(ros_gz_bridge::convert_ros_to_gz(ros_msg, gz_msg));
+
+  EXPECT_EQ(0, gz_msg.intensities_size());
+}
+
+// ---------------------------------------------------------------------------
+// LaserScan GZ->ROS : trusts gz_msg.count() against the actual ranges
+// array length. A malformed message with count > ranges_size() would
+// cause an OOB read.
+// ---------------------------------------------------------------------------
+TEST(LaserScanGzToRos, CountLargerThanRangesArrayIsClamped)
+{
+  gz::msgs::LaserScan gz_msg;
+  gz_msg.set_angle_min(0.0);
+  gz_msg.set_angle_max(1.0);
+  gz_msg.set_angle_step(0.1);
+  gz_msg.set_range_min(0.0);
+  gz_msg.set_range_max(10.0);
+  // count says 10 but only 3 ranges are actually filled.
+  gz_msg.set_count(10);
+  gz_msg.set_vertical_count(1);
+  for (int i = 0; i < 3; ++i) {
+    gz_msg.add_ranges(static_cast<double>(i));
+    gz_msg.add_intensities(static_cast<double>(i));
+  }
+
+  sensor_msgs::msg::LaserScan ros_msg;
+  ASSERT_NO_FATAL_FAILURE(ros_gz_bridge::convert_gz_to_ros(gz_msg, ros_msg));
+
+  EXPECT_LE(ros_msg.ranges.size(), static_cast<size_t>(gz_msg.ranges_size()));
+  EXPECT_LE(
+    ros_msg.intensities.size(),
+    static_cast<size_t>(gz_msg.intensities_size()));
+}
+
+// ---------------------------------------------------------------------------
+// CameraInfo GZ->ROS : ROS arrays are fixed-size (k:9, p:12, r:9). A
+// Gazebo publisher with more elements would write past the std::array.
+// ---------------------------------------------------------------------------
+TEST(CameraInfoGzToRos, IntrinsicsLongerThanRosArrayDoesNotOverflow)
+{
+  gz::msgs::CameraInfo gz_msg;
+  gz_msg.set_width(640);
+  gz_msg.set_height(480);
+  auto * intrinsics = gz_msg.mutable_intrinsics();
+  // Stuff 12 entries — ros_msg.k is std::array<double, 9>.
+  for (int i = 0; i < 12; ++i) {
+    intrinsics->add_k(static_cast<double>(i));
+  }
+  auto * projection = gz_msg.mutable_projection();
+  // Stuff 16 entries — ros_msg.p is std::array<double, 12>.
+  for (int i = 0; i < 16; ++i) {
+    projection->add_p(static_cast<double>(i));
+  }
+  // Stuff 12 entries — ros_msg.r is std::array<double, 9>.
+  for (int i = 0; i < 12; ++i) {
+    gz_msg.add_rectification_matrix(static_cast<double>(i));
+  }
+
+  sensor_msgs::msg::CameraInfo ros_msg;
+  ASSERT_NO_FATAL_FAILURE(ros_gz_bridge::convert_gz_to_ros(gz_msg, ros_msg));
+
+  // We only assert that the bridge truncated to the fixed-size arrays.
+  // Anything else (or a crash) means the bug is still present.
+  for (size_t i = 0; i < ros_msg.k.size(); ++i) {
+    EXPECT_DOUBLE_EQ(static_cast<double>(i), ros_msg.k[i]);
+  }
+  for (size_t i = 0; i < ros_msg.p.size(); ++i) {
+    EXPECT_DOUBLE_EQ(static_cast<double>(i), ros_msg.p[i]);
+  }
+  for (size_t i = 0; i < ros_msg.r.size(); ++i) {
+    EXPECT_DOUBLE_EQ(static_cast<double>(i), ros_msg.r[i]);
+  }
+}


### PR DESCRIPTION
  # 🦟 Bug fix

  Fixes #118.

  ## Summary

Several `sensor_msgs` converters indexed into ROS arrays without first checking the array length, producing out-of-bounds reads/writes on spec-conformant inputs. The headline case (#118) is `JointState` ROS→GZ: `joint_state_publisher`
  publishes messages with `velocity=[]` and `effort=[]` by default, and the bridge crashed with `SIGSEGV` (reported as "signal 245") on the very first message.

What   ## Checklist

  - [x] Signed all commits for DCO
  - [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
  - [x] Added tests
  - [ ] Updated documentation (as needed)
  - [ ] Updated migration guide (as needed)
  - [ ] Consider updating Python bindings (if the library has them)
  - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
  - [x] All package tests passed (`colcon test --packages-select ros_gz_bridge`)
  - [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
  - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
  - [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits.

  Generated-by: Claude Code (Opus 4.7).

  **Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
