### PR TITLE
Restore rolling CI on Ubuntu 26.04 resolute

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -26,10 +26,20 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ros-arc
   > /etc/apt/sources.list.d/ros2-testing.list
 
 apt-get update -qq
+# Install the build dependencies explicitly rather than relying on rosdep to
+# resolve them against the rolling distribution.yaml — that resolution path
+# was producing "No definition for noble" for gz_*_vendor and the
+# ament/launch test deps on this image.
 apt-get install -y python3-colcon-common-extensions \
                    python3-rosdep \
                    libcli11-dev \
-                   ros-$ROS_DISTRO-ros-base
+                   ros-$ROS_DISTRO-ros-base \
+                   ros-$ROS_DISTRO-ament-lint-common \
+                   ros-$ROS_DISTRO-launch-testing-ament-cmake \
+                   ros-$ROS_DISTRO-gz-math-vendor \
+                   ros-$ROS_DISTRO-gz-msgs-vendor \
+                   ros-$ROS_DISTRO-gz-sim-vendor \
+                   ros-$ROS_DISTRO-gz-transport-vendor
 
 rosdep init
 rosdep update

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -8,18 +8,28 @@ export DEBIAN_FRONTEND=noninteractive
 export ROS_PYTHON_VERSION=3
 
 apt update -qq
-apt install -qq -y lsb-release wget curl build-essential
+apt install -qq -y lsb-release wget curl gnupg build-essential ca-certificates
 
-echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+# Use signed-by keyring files. `apt-key add` is removed on Ubuntu 24.04
+# (noble), so the previous form silently produced untrusted apt sources
+# and `ros-rolling-*` was never installable.
+install -d -m 0755 /etc/apt/keyrings
 
-# Dependencies.
-echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-testing.list
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+curl -fsSL https://packages.osrfoundation.org/gazebo.gpg \
+  -o /etc/apt/keyrings/pkgs-osrf-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" \
+  > /etc/apt/sources.list.d/gazebo-stable.list
+
+curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+  -o /etc/apt/keyrings/ros-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(lsb_release -cs) main" \
+  > /etc/apt/sources.list.d/ros2-testing.list
+
 apt-get update -qq
 apt-get install -y python3-colcon-common-extensions \
                    python3-rosdep \
-                   libcli11-dev
+                   libcli11-dev \
+                   ros-$ROS_DISTRO-ros-base
 
 rosdep init
 rosdep update

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -26,37 +26,17 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ros-arc
   > /etc/apt/sources.list.d/ros2-testing.list
 
 apt-get update -qq
-# Install build dependencies explicitly. On this image `rosdep update` only
-# fetches the base/python/ruby YAMLs and does not pull the rolling
-# distribution.yaml, so ROS-released packages like gz_*_vendor, actuator_msgs,
-# gps_msgs, vision_msgs, etc. silently fail to install.
-#
-# ros-$ROS_DISTRO-desktop covers ros-base, common_interfaces (geometry_msgs,
-# nav_msgs, sensor_msgs, …), image_transport, rviz2, rqt-*,
-# robot_state_publisher, launch_testing_ament_cmake, ament_lint_common.
+# Bootstrap: tools rosdep itself needs, plus `ros-base` so /opt/ros/$ROS_DISTRO
+# exists to source. Every workspace dependency is then resolved by rosdep
+# against the rolling distribution.yaml.
 apt-get install -y python3-colcon-common-extensions \
                    python3-rosdep \
                    libcli11-dev \
-                   ros-$ROS_DISTRO-desktop \
-                   ros-$ROS_DISTRO-gz-math-vendor \
-                   ros-$ROS_DISTRO-gz-msgs-vendor \
-                   ros-$ROS_DISTRO-gz-sim-vendor \
-                   ros-$ROS_DISTRO-gz-transport-vendor \
-                   ros-$ROS_DISTRO-yaml-cpp-vendor \
-                   ros-$ROS_DISTRO-actuator-msgs \
-                   ros-$ROS_DISTRO-gps-msgs \
-                   ros-$ROS_DISTRO-marine-acoustic-msgs \
-                   ros-$ROS_DISTRO-vision-msgs \
-                   ros-$ROS_DISTRO-trajectory-msgs \
-                   ros-$ROS_DISTRO-simulation-interfaces \
-                   ros-$ROS_DISTRO-image-transport-plugins \
-                   ros-$ROS_DISTRO-rviz-imu-plugin \
-                   ros-$ROS_DISTRO-sdformat-urdf \
-                   ros-$ROS_DISTRO-xacro
+                   ros-$ROS_DISTRO-ros-base
 
 rosdep init
-rosdep update
-rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO $ROSDEP_ARGS
+rosdep update --rosdistro $ROS_DISTRO
+rosdep install --from-paths ./ -i -y --rosdistro $ROS_DISTRO $ROSDEP_ARGS
 
 # Build.
 source /opt/ros/$ROS_DISTRO/setup.bash

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -26,20 +26,33 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ros-arc
   > /etc/apt/sources.list.d/ros2-testing.list
 
 apt-get update -qq
-# Install the build dependencies explicitly rather than relying on rosdep to
-# resolve them against the rolling distribution.yaml — that resolution path
-# was producing "No definition for noble" for gz_*_vendor and the
-# ament/launch test deps on this image.
+# Install build dependencies explicitly. On this image `rosdep update` only
+# fetches the base/python/ruby YAMLs and does not pull the rolling
+# distribution.yaml, so ROS-released packages like gz_*_vendor, actuator_msgs,
+# gps_msgs, vision_msgs, etc. silently fail to install.
+#
+# ros-$ROS_DISTRO-desktop covers ros-base, common_interfaces (geometry_msgs,
+# nav_msgs, sensor_msgs, …), image_transport, rviz2, rqt-*,
+# robot_state_publisher, launch_testing_ament_cmake, ament_lint_common.
 apt-get install -y python3-colcon-common-extensions \
                    python3-rosdep \
                    libcli11-dev \
-                   ros-$ROS_DISTRO-ros-base \
-                   ros-$ROS_DISTRO-ament-lint-common \
-                   ros-$ROS_DISTRO-launch-testing-ament-cmake \
+                   ros-$ROS_DISTRO-desktop \
                    ros-$ROS_DISTRO-gz-math-vendor \
                    ros-$ROS_DISTRO-gz-msgs-vendor \
                    ros-$ROS_DISTRO-gz-sim-vendor \
-                   ros-$ROS_DISTRO-gz-transport-vendor
+                   ros-$ROS_DISTRO-gz-transport-vendor \
+                   ros-$ROS_DISTRO-yaml-cpp-vendor \
+                   ros-$ROS_DISTRO-actuator-msgs \
+                   ros-$ROS_DISTRO-gps-msgs \
+                   ros-$ROS_DISTRO-marine-acoustic-msgs \
+                   ros-$ROS_DISTRO-vision-msgs \
+                   ros-$ROS_DISTRO-trajectory-msgs \
+                   ros-$ROS_DISTRO-simulation-interfaces \
+                   ros-$ROS_DISTRO-image-transport-plugins \
+                   ros-$ROS_DISTRO-rviz-imu-plugin \
+                   ros-$ROS_DISTRO-sdformat-urdf \
+                   ros-$ROS_DISTRO-xacro
 
 rosdep init
 rosdep update

--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -23,7 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - docker-image: "ubuntu:24.04"
+          # rolling no longer releases for noble (24.04). Per rosdistro's
+          # rolling/distribution.yaml, release_platforms.ubuntu = [resolute].
+          - docker-image: "ubuntu:resolute"
             ros-distro: "rolling"
     container:
       image: ${{ matrix.docker-image }}

--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -24,7 +24,8 @@ jobs:
       matrix:
         include:
           # rolling no longer releases for noble (24.04). Per rosdistro's
-          # rolling/distribution.yaml, release_platforms.ubuntu = [resolute].
+          # rolling/distribution.yaml, release_platforms.ubuntu = [resolute]
+          # (Ubuntu 26.04 LTS).
           - docker-image: "ubuntu:resolute"
             ros-distro: "rolling"
     container:

--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -213,7 +213,11 @@ if(BUILD_TESTING)
     ${PROJECT_SOURCE_DIR}/include
   )
 
-  add_library(test_utils
+  # Static so the installed test binaries don't need libtest_utils.so on
+  # their runtime loader path — the .so wasn't being installed, which made
+  # `ros2 run ros_gz_bridge test_*` fail with linker error 127 under
+  # colcon test.
+  add_library(test_utils STATIC
     test/utils/gz_test_msg.cpp
     test/utils/ros_test_msg.cpp
   )

--- a/ros_gz_sim/test/test_gz_simulation_interfaces.launch.py
+++ b/ros_gz_sim/test/test_gz_simulation_interfaces.launch.py
@@ -218,6 +218,11 @@ class TestGzSimulationInterfaces(unittest.TestCase):
         request.initial_pose.pose.position.x = 4.0
         request.initial_pose.pose.position.y = -20.0
         request.initial_pose.pose.position.z = 4.0
+        # geometry_msgs/Quaternion defaults to (0,0,0,0) which has zero norm
+        # and gets rejected by Gazebo's create service, causing the model to
+        # spawn at the world origin instead of the requested pose. Send a
+        # valid identity quaternion explicitly.
+        request.initial_pose.pose.orientation.w = 1.0
 
         self.assertTrue(self.call_and_spin(spawn_entity, request))
         time.sleep(2)


### PR DESCRIPTION
# 🦟 Bug fix

  ## Summary

  `.github/workflows/build-and-test.sh` fails on every PR (and on `ros2` itself) because `apt-key add` was removed on Ubuntu 24.04. Both apt sources it adds (`packages.osrfoundation.org/gazebo` and `packages.ros.org/ros2-testing`) end up untrusted, so `apt` silently drops them and `ros-rolling-*` is never installable. The script then `source`s a ROS setup file that was never created, and the job exits with:

  ```
  .github/workflows/build-and-test.sh: line 29: /opt/ros/rolling/setup.bash: No such file or directory
  ```

  ## Checklist

  - [x] Signed all commits for DCO
  - [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
  - [ ] Added tests
  - [ ] Updated documentation (as needed)
  - [ ] Updated migration guide (as needed)
  - [ ] Consider updating Python bindings (if the library has them)
  - [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
  - [ ] All tests passed (verified by this PR's own CI run)
  - [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
  - [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
  - [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits.

  Generated-by: Claude Code (Opus 4.7).

  **Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
