### PR TITLE
Fix bridge_params TypeError

### DIFF
--- a/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
+++ b/ros_gz_bridge/ros_gz_bridge/actions/ros_gz_bridge.py
@@ -93,6 +93,7 @@ class RosGzBridge(Action):
         self.__log_level = log_level
         self.__bridge_params = [{'config_file':  self.__config_file}]
         if bridge_params is not None:
+            bridge_params = normalize_typed_substitution(bridge_params, dict)
             # This handling of bridge_params was copied from launch_ros/actions/node.py
             ensure_argument_type(bridge_params, (list), 'bridge_params', 'RosGzBridge')
             # All elements in the list are paths to files with parameters (or substitutions that


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #803 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Fixes a TypeError in the ros_gz_bridge launch action when a bridge_params argument is passed by ensuring substitution is performed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.