### PR TITLE
Dynamic ros gz bridges

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -321,6 +321,15 @@ if(BUILD_TESTING)
   target_include_directories(test_launch_action_subscriber
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test/subscribers)
 
+  add_executable(test_dynamic_bridge test/test_dynamic_bridge.cpp)
+  target_link_libraries(test_dynamic_bridge
+    ${GTEST_LIBRARIES}
+    gz-msgs::core
+    gz-transport::core
+    rclcpp::rclcpp
+    ${std_msgs_TARGETS}
+  )
+
   install(TARGETS
     test_launch_action_subscriber
     test_ros_publisher
@@ -329,6 +338,7 @@ if(BUILD_TESTING)
     test_gz_subscriber
     test_gz_server
     test_ros_client
+    test_dynamic_bridge
     DESTINATION lib/${PROJECT_NAME}
   )
 
@@ -352,6 +362,22 @@ if(BUILD_TESTING)
 
   add_launch_test(test/launch/test_launch_action_classic.launch.py
     TIMEOUT 200
+  )
+
+  add_launch_test(test/launch/test_dynamic_bridge.launch.py
+    TARGET test_dynamic_bridge_gz_to_ros
+    TIMEOUT 200
+    ARGS
+      "direction:=GZ_TO_ROS"
+      "gtest_filter:=-DynamicBridgeTest.BridgesBidirectionally"
+  )
+
+  add_launch_test(test/launch/test_dynamic_bridge.launch.py
+    TARGET test_dynamic_bridge_bidirectional
+    TIMEOUT 200
+    ARGS
+      "direction:=BIDIRECTIONAL"
+      "gtest_filter:=DynamicBridgeTest.BridgesBidirectionally"
   )
 
   ament_add_gtest(${PROJECT_NAME}_bridge_config test/bridge_config.cpp

--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -410,6 +410,19 @@ ros2 topic pub /demo/chatter std_msgs/msg/String "data: 'Hi from inside of a nam
 
 By changing `chatter` to `/chatter` or `~/chatter` you can obtain different results.
 
+## Example 9: Dynamically bridge Gazebo topics
+
+The bridge can discover advertised Gazebo Transport topics and create bridges for
+topics whose Gazebo message types have known ROS mappings:
+
+```bash
+ros2 run ros_gz_bridge parameter_bridge --ros-args -p create_dynamic_bridges:=true
+```
+
+By default, dynamically discovered bridges are created from Gazebo to ROS. Set
+`dynamic_bridge_direction` to `BIDIRECTIONAL` or `ROS_TO_GZ` to change the
+direction.
+
 ## API
 
 ROS 2 Parameters:
@@ -423,6 +436,16 @@ ROS 2 Parameters:
     * type: string
     * default: ""
     * description: YAML file to be loaded as the bridge configuration
+* `create_dynamic_bridges`
+    * type: bool
+    * default: false
+    * description: Discover Gazebo topics and automatically create bridges for
+      topics with known Gazebo to ROS message mappings.
+* `dynamic_bridge_direction`
+    * type: string
+    * default: "GZ_TO_ROS"
+    * description: Direction used for dynamically discovered bridges. Supported
+      values are "GZ_TO_ROS", "ROS_TO_GZ", and "BIDIRECTIONAL".
 * `expand_gz_topic_names`
     * type: bool
     * default: false

--- a/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
@@ -16,6 +16,7 @@
 #define ROS_GZ_BRIDGE__ROS_GZ_BRIDGE_HPP_
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -56,6 +57,9 @@ protected:
   /// \brief Periodic callback to check connectivity and liveliness
   void spin();
 
+  /// \brief Add bridges for discovered Gazebo topics with known ROS mappings.
+  void add_dynamic_bridges();
+
 protected:
   /// \brief Pointer to Gazebo node used to create publishers/subscribers
   std::shared_ptr<gz::transport::Node> gz_node_;
@@ -68,6 +72,12 @@ protected:
 
   /// \brief Timer to control periodic callback
   rclcpp::TimerBase::SharedPtr heartbeat_timer_;
+
+  /// \brief True after bridge configuration parameters have been processed.
+  bool configured_bridges_created_{false};
+
+  /// \brief Topic/type pairs that have already had bridge creation attempted.
+  std::set<std::string> bridge_topics_;
 };
 }  // namespace ros_gz_bridge
 

--- a/ros_gz_bridge/src/parameter_bridge.cpp
+++ b/ros_gz_bridge/src/parameter_bridge.cpp
@@ -77,7 +77,9 @@ int main(int argc, char * argv[])
 
   bool create_dynamic_bridges = false;
   bridge_node->get_parameter("create_dynamic_bridges", create_dynamic_bridges);
-  if (filteredArgs.empty() && !create_dynamic_bridges) {
+  std::string config_file;
+  bridge_node->get_parameter("config_file", config_file);
+  if (filteredArgs.empty() && !create_dynamic_bridges && config_file.empty()) {
     usage();
     return -1;
   }

--- a/ros_gz_bridge/src/parameter_bridge.cpp
+++ b/ros_gz_bridge/src/parameter_bridge.cpp
@@ -68,16 +68,19 @@ using BridgeConfig = ros_gz_bridge::BridgeConfig;
 //////////////////////////////////////////////////
 int main(int argc, char * argv[])
 {
-  if (argc < 2) {
-    usage();
-    return -1;
-  }
   // skip the process name in argument processing
   ++argv;
   --argc;
   auto filteredArgs = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
   auto bridge_node = std::make_shared<RosGzBridge>(rclcpp::NodeOptions());
+
+  bool create_dynamic_bridges = false;
+  bridge_node->get_parameter("create_dynamic_bridges", create_dynamic_bridges);
+  if (filteredArgs.empty() && !create_dynamic_bridges) {
+    usage();
+    return -1;
+  }
 
   // Set lazy subscriber on a global basis
   bool lazy_subscription = false;

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -16,16 +16,47 @@
 
 #include <cstddef>
 #include <memory>
+#include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 
 #include "bridge_handle_ros_to_gz.hpp"
 #include "bridge_handle_gz_to_ros.hpp"
+#include "get_mappings.hpp"
 
 #include <rclcpp/expand_topic_or_service_name.hpp>
 
 namespace ros_gz_bridge
 {
+
+namespace
+{
+std::string bridge_key(const BridgeConfig & config)
+{
+  std::stringstream stream;
+  stream << config.ros_topic_name << '|';
+  stream << config.ros_type_name << '|';
+  stream << config.gz_topic_name << '|';
+  stream << config.gz_type_name << '|';
+  stream << static_cast<int>(config.direction);
+  return stream.str();
+}
+
+BridgeDirection parse_bridge_direction(const std::string & direction)
+{
+  if (direction == "BIDIRECTIONAL") {
+    return BridgeDirection::BIDIRECTIONAL;
+  }
+  if (direction == "GZ_TO_ROS") {
+    return BridgeDirection::GZ_TO_ROS;
+  }
+  if (direction == "ROS_TO_GZ") {
+    return BridgeDirection::ROS_TO_GZ;
+  }
+  return BridgeDirection::NONE;
+}
+}  // namespace
 
 RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
 : rclcpp::Node("ros_gz_bridge", options)
@@ -38,6 +69,8 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
   this->declare_parameter<bool>("expand_gz_topic_names", false);
   this->declare_parameter<bool>("override_timestamps_with_wall_time", false);
   this->declare_parameter<std::string>("override_frame_id", "");
+  this->declare_parameter<bool>("create_dynamic_bridges", false);
+  this->declare_parameter<std::string>("dynamic_bridge_direction", "GZ_TO_ROS");
   this->declare_parameter("bridge_names", std::vector<std::string>());
   const auto names = this->get_parameter("bridge_names").as_string_array();
 
@@ -120,7 +153,7 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
 
 void RosGzBridge::spin()
 {
-  if (handles_.empty()) {
+  if (!configured_bridges_created_) {
     std::string config_file;
     this->get_parameter("config_file", config_file);
     bool expand_names;
@@ -158,16 +191,8 @@ void RosGzBridge::spin()
       const auto prefix = "bridges." + name + ".";
       if (!this->get_parameter(prefix + "ros_topic_name").as_string().empty()) {
         const auto directionStr = this->get_parameter(prefix + "direction").as_string();
-        BridgeDirection direction {BridgeDirection::NONE};
-        if (directionStr == "NONE") {
-          direction = BridgeDirection::NONE;
-        } else if (directionStr == "BIDIRECTIONAL") {
-          direction = BridgeDirection::BIDIRECTIONAL;
-        } else if (directionStr == "GZ_TO_ROS") {
-          direction = BridgeDirection::GZ_TO_ROS;
-        } else if (directionStr == "ROS_TO_GZ") {
-          direction = BridgeDirection::ROS_TO_GZ;
-        } else {
+        const auto direction = parse_bridge_direction(directionStr);
+        if (direction == BridgeDirection::NONE && directionStr != "NONE") {
           RCLCPP_ERROR(
             this->get_logger(),
             "Bridge %s defines unknown direction %s.",
@@ -234,9 +259,76 @@ void RosGzBridge::spin()
           this->get_parameter(prefix + "service_name").as_string());
       }
     }
+    configured_bridges_created_ = true;
   }
+
+  bool create_dynamic_bridges = false;
+  this->get_parameter("create_dynamic_bridges", create_dynamic_bridges);
+  if (create_dynamic_bridges) {
+    this->add_dynamic_bridges();
+  }
+
   for (auto & bridge : handles_) {
     bridge->Spin();
+  }
+}
+
+void RosGzBridge::add_dynamic_bridges()
+{
+  std::vector<std::string> gz_topics;
+  gz_node_->TopicList(gz_topics);
+
+  bool lazy;
+  this->get_parameter("lazy", lazy);
+
+  const auto direction_str = this->get_parameter("dynamic_bridge_direction").as_string();
+  const auto direction = parse_bridge_direction(direction_str);
+  if (direction == BridgeDirection::NONE) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "Ignoring dynamic bridge discovery with invalid direction [%s].",
+      direction_str.c_str());
+    return;
+  }
+
+  for (const auto & gz_topic : gz_topics) {
+    std::vector<gz::transport::MessagePublisher> publishers;
+    std::vector<gz::transport::MessagePublisher> subscribers;
+    if (!gz_node_->TopicInfo(gz_topic, publishers, subscribers)) {
+      continue;
+    }
+
+    std::set<std::string> gz_type_names;
+    for (const auto & publisher : publishers) {
+      const auto gz_type_name = publisher.MsgTypeName();
+      if (!gz_type_name.empty()) {
+        gz_type_names.insert(gz_type_name);
+      }
+    }
+
+    if (gz_type_names.size() > 1) {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Skipping dynamic bridge for topic [%s] with multiple Gazebo types.",
+        gz_topic.c_str());
+      continue;
+    }
+
+    for (const auto & gz_type_name : gz_type_names) {
+      std::string ros_type_name;
+      if (!get_gz_to_ros_mapping(gz_type_name, ros_type_name)) {
+        continue;
+      }
+
+      BridgeConfig config;
+      config.ros_type_name = ros_type_name;
+      config.ros_topic_name = gz_topic;
+      config.gz_type_name = gz_type_name;
+      config.gz_topic_name = gz_topic;
+      config.direction = direction;
+      config.is_lazy = lazy;
+      this->add_bridge(config);
+    }
   }
 }
 
@@ -264,6 +356,14 @@ void RosGzBridge::add_bridge(const BridgeConfig & input_config)
   if (config.direction == BridgeDirection::BIDIRECTIONAL) {
     ros_to_gz = true;
     gz_to_ros = true;
+  }
+
+  if (!gz_to_ros && !ros_to_gz) {
+    return;
+  }
+
+  if (!bridge_topics_.insert(bridge_key(config)).second) {
+    return;
   }
 
   try {

--- a/ros_gz_bridge/test/launch/test_dynamic_bridge.launch.py
+++ b/ros_gz_bridge/test/launch/test_dynamic_bridge.launch.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+import launch_testing
+
+
+def generate_test_description():
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        parameters=[{
+            'create_dynamic_bridges': True,
+            'dynamic_bridge_direction': LaunchConfiguration('direction'),
+            'subscription_heartbeat': 50,
+        }],
+        output='screen',
+    )
+    process_under_test = Node(
+        package='ros_gz_bridge',
+        executable='test_dynamic_bridge',
+        arguments=[['--gtest_filter=', LaunchConfiguration('gtest_filter')]],
+        output='screen',
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable('GZ_PARTITION', 'ros_gz_dynamic_bridge_test'),
+        SetEnvironmentVariable('ROS_DOMAIN_ID', '42'),
+        DeclareLaunchArgument('direction'),
+        DeclareLaunchArgument('gtest_filter'),
+        bridge,
+        process_under_test,
+        launch_testing.util.KeepAliveProc(),
+        launch_testing.actions.ReadyToTest(),
+    ]), locals()
+
+
+class DynamicBridgeTest(unittest.TestCase):
+
+    def test_termination(self, process_under_test, proc_info):
+        proc_info.assertWaitForShutdown(process=process_under_test, timeout=200)
+
+
+@launch_testing.post_shutdown_test()
+class DynamicBridgeTestAfterShutdown(unittest.TestCase):
+
+    def test_exit_code(self, process_under_test, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info,
+            [launch_testing.asserts.EXIT_OK],
+            process_under_test,
+        )

--- a/ros_gz_bridge/test/test_dynamic_bridge.cpp
+++ b/ros_gz_bridge/test/test_dynamic_bridge.cpp
@@ -1,0 +1,297 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <gz/msgs/int64.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gz/transport/Node.hh>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+constexpr auto kDiscoveryTimeout = 5s;
+
+class DynamicBridgeTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+protected:
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+
+protected:
+  void SetUp() override
+  {
+    static std::atomic<int> nodeId{0};
+    this->rosNode = std::make_shared<rclcpp::Node>(
+      "dynamic_bridge_test_" + std::to_string(nodeId++));
+    this->executor.add_node(this->rosNode);
+  }
+
+protected:
+  void TearDown() override
+  {
+    this->executor.remove_node(this->rosNode);
+    this->rosNode.reset();
+  }
+
+protected:
+  bool SpinUntil(
+    const std::function<bool()> & _condition,
+    const std::chrono::steady_clock::duration & _timeout = kDiscoveryTimeout)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + _timeout;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      this->executor.spin_some();
+      if (_condition()) {
+        return true;
+      }
+      std::this_thread::sleep_for(10ms);
+    }
+    this->executor.spin_some();
+    return _condition();
+  }
+
+protected:
+  rclcpp::Node::SharedPtr rosNode;
+
+protected:
+  rclcpp::executors::SingleThreadedExecutor executor;
+};
+
+TEST_F(DynamicBridgeTest, DiscoversTopicAfterStartup)
+{
+  const std::string topic = "/dynamic_bridge_late_topic";
+  std::atomic<bool> received{false};
+  std::string receivedData;
+  auto subscription = this->rosNode->create_subscription<std_msgs::msg::String>(
+    topic, 10,
+    [&received, &receivedData](const std_msgs::msg::String & _msg)
+    {
+      receivedData = _msg.data;
+      received = true;
+    });
+
+  gz::transport::Node gzNode;
+  auto publisher = gzNode.Advertise<gz::msgs::StringMsg>(topic);
+  ASSERT_TRUE(publisher.Valid());
+  ASSERT_TRUE(this->SpinUntil([&publisher]() {return publisher.HasConnections();}));
+  ASSERT_TRUE(this->SpinUntil(
+      [this, &topic]() {return this->rosNode->count_publishers(topic) >= 1u;}));
+
+  gz::msgs::StringMsg message;
+  message.set_data("late topic");
+  ASSERT_TRUE(publisher.Publish(message));
+  ASSERT_TRUE(this->SpinUntil([&received]() {return received.load();}));
+  EXPECT_EQ("late topic", receivedData);
+}
+
+TEST_F(DynamicBridgeTest, BridgesBidirectionally)
+{
+  const std::string topic = "/dynamic_bridge_bidirectional";
+  std::mutex mutex;
+  std::vector<std::string> rosMessages;
+  std::vector<std::string> gzMessages;
+
+  auto rosSubscription = this->rosNode->create_subscription<std_msgs::msg::String>(
+    topic, 10,
+    [&mutex, &rosMessages](const std_msgs::msg::String & _msg)
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      rosMessages.push_back(_msg.data);
+    });
+  auto rosPublisher = this->rosNode->create_publisher<std_msgs::msg::String>(topic, 10);
+
+  gz::transport::Node gzNode;
+  auto gzPublisher = gzNode.Advertise<gz::msgs::StringMsg>(topic);
+  ASSERT_TRUE(gzPublisher.Valid());
+  ASSERT_TRUE(this->SpinUntil([&gzPublisher]() {return gzPublisher.HasConnections();}));
+  ASSERT_TRUE(this->SpinUntil(
+      [this, &topic]() {return this->rosNode->count_publishers(topic) >= 2u;}));
+
+  gz::msgs::StringMsg gzMessage;
+  gzMessage.set_data("from Gazebo");
+  ASSERT_TRUE(gzPublisher.Publish(gzMessage));
+  ASSERT_TRUE(this->SpinUntil(
+      [&mutex, &rosMessages]()
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        return std::find(rosMessages.begin(), rosMessages.end(), "from Gazebo") !=
+               rosMessages.end();
+    }));
+
+  ASSERT_TRUE(gzNode.Subscribe<gz::msgs::StringMsg>(
+    topic,
+      [&mutex, &gzMessages](const gz::msgs::StringMsg & _msg)
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        gzMessages.push_back(_msg.data());
+    }));
+  ASSERT_TRUE(this->SpinUntil(
+      [this]() {
+        return this->rosNode->count_subscribers(
+      "/dynamic_bridge_bidirectional") > 0;
+                                           }));
+
+  std_msgs::msg::String rosMessage;
+  rosMessage.data = "from ROS";
+  ASSERT_TRUE(this->SpinUntil(
+      [&mutex, &gzMessages, &rosMessage, &rosPublisher]()
+      {
+        rosPublisher->publish(rosMessage);
+        std::lock_guard<std::mutex> lock(mutex);
+        return std::find(gzMessages.begin(), gzMessages.end(), "from ROS") != gzMessages.end();
+    }));
+}
+
+TEST_F(DynamicBridgeTest, DoesNotCreateDuplicateBridges)
+{
+  const std::string topic = "/dynamic_bridge_no_duplicates";
+  std::atomic<int> received{0};
+  auto subscription = this->rosNode->create_subscription<std_msgs::msg::String>(
+    topic, 10,
+    [&received](const std_msgs::msg::String &) {++received;});
+
+  gz::transport::Node gzNode;
+  auto publisher = gzNode.Advertise<gz::msgs::StringMsg>(topic);
+  ASSERT_TRUE(publisher.Valid());
+  ASSERT_TRUE(this->SpinUntil([&publisher]() {return publisher.HasConnections();}));
+  ASSERT_TRUE(this->SpinUntil(
+      [this, &topic]()
+      {
+        return !this->rosNode->get_publishers_info_by_topic(topic).empty();
+    }));
+
+  const auto deadline = std::chrono::steady_clock::now() + 300ms;
+  while (std::chrono::steady_clock::now() < deadline) {
+    this->executor.spin_some();
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(1u, this->rosNode->get_publishers_info_by_topic(topic).size());
+
+  gz::msgs::StringMsg message;
+  message.set_data("once");
+  ASSERT_TRUE(publisher.Publish(message));
+  ASSERT_TRUE(this->SpinUntil([&received]() {return received.load() > 0;}));
+  std::this_thread::sleep_for(100ms);
+  this->executor.spin_some();
+  EXPECT_EQ(1, received.load());
+}
+
+TEST_F(DynamicBridgeTest, IgnoresUnsupportedTypesAndKeepsRunning)
+{
+  gz::transport::Node gzNode;
+  const std::string unsupportedTopic = "/dynamic_bridge_unsupported";
+  auto unsupportedPublisher = gzNode.Advertise<gz::msgs::Int64>(unsupportedTopic);
+  ASSERT_TRUE(unsupportedPublisher.Valid());
+
+  const auto deadline = std::chrono::steady_clock::now() + 300ms;
+  while (std::chrono::steady_clock::now() < deadline) {
+    this->executor.spin_some();
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_TRUE(this->rosNode->get_publishers_info_by_topic(unsupportedTopic).empty());
+
+  const std::string supportedTopic = "/dynamic_bridge_after_unsupported";
+  std::atomic<bool> received{false};
+  auto subscription = this->rosNode->create_subscription<std_msgs::msg::String>(
+    supportedTopic, 10,
+    [&received](const std_msgs::msg::String &) {received = true;});
+  auto supportedPublisher = gzNode.Advertise<gz::msgs::StringMsg>(supportedTopic);
+  ASSERT_TRUE(supportedPublisher.Valid());
+  ASSERT_TRUE(this->SpinUntil(
+      [&supportedPublisher]() {return supportedPublisher.HasConnections();}));
+  ASSERT_TRUE(this->SpinUntil(
+      [this, &supportedTopic]()
+      {
+        return this->rosNode->count_publishers(supportedTopic) == 1u;
+    }));
+
+  gz::msgs::StringMsg message;
+  message.set_data("still running");
+  ASSERT_TRUE(supportedPublisher.Publish(message));
+  EXPECT_TRUE(this->SpinUntil([&received]() {return received.load();}));
+}
+
+TEST_F(DynamicBridgeTest, DeliversBurstWithoutDuplicates)
+{
+  constexpr int messageCount = 50;
+  const std::string topic = "/dynamic_bridge_burst";
+  std::mutex mutex;
+  std::vector<int> received;
+  auto subscription = this->rosNode->create_subscription<std_msgs::msg::String>(
+    topic, rclcpp::QoS(messageCount),
+    [&mutex, &received](const std_msgs::msg::String & _msg)
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      received.push_back(std::stoi(_msg.data));
+    });
+
+  gz::transport::Node gzNode;
+  auto publisher = gzNode.Advertise<gz::msgs::StringMsg>(topic);
+  ASSERT_TRUE(publisher.Valid());
+  ASSERT_TRUE(this->SpinUntil([&publisher]() {return publisher.HasConnections();}));
+  ASSERT_TRUE(this->SpinUntil(
+      [this, &topic]() {return this->rosNode->count_publishers(topic) >= 1u;}));
+
+  for (int i = 0; i < messageCount; ++i) {
+    gz::msgs::StringMsg message;
+    message.set_data(std::to_string(i));
+    ASSERT_TRUE(publisher.Publish(message));
+    this->executor.spin_some();
+    std::this_thread::sleep_for(20ms);
+  }
+
+  ASSERT_TRUE(this->SpinUntil(
+      [&mutex, &received]()
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        return received.size() == messageCount;
+    }));
+
+  std::lock_guard<std::mutex> lock(mutex);
+  EXPECT_EQ(messageCount, received.size());
+  EXPECT_EQ(messageCount, std::set<int>(received.begin(), received.end()).size());
+  for (int i = 0; i < messageCount; ++i) {
+    EXPECT_EQ(i, received[i]);
+  }
+}
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/ros_gz_bridge/test/test_dynamic_bridge.cpp
+++ b/ros_gz_bridge/test/test_dynamic_bridge.cpp
@@ -152,13 +152,14 @@ TEST_F(DynamicBridgeTest, BridgesBidirectionally)
                rosMessages.end();
     }));
 
-  ASSERT_TRUE(gzNode.Subscribe<gz::msgs::StringMsg>(
-    topic,
-      [&mutex, &gzMessages](const gz::msgs::StringMsg & _msg)
-      {
-        std::lock_guard<std::mutex> lock(mutex);
-        gzMessages.push_back(_msg.data());
-    }));
+  std::function<void(const gz::msgs::StringMsg &)> gzCallback =
+    [&mutex, &gzMessages](const gz::msgs::StringMsg & _msg)
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      gzMessages.push_back(_msg.data());
+    };
+  ASSERT_TRUE(gzNode.Subscribe(topic, gzCallback));
+
   ASSERT_TRUE(this->SpinUntil(
       [this]() {
         return this->rosNode->count_subscribers(


### PR DESCRIPTION
# 🎉 New feature

Closes #849

## Summary

Adds opt-in dynamic discovery of Gazebo Transport topics to `ros_gz_bridge`.

When `create_dynamic_bridges` is enabled, the bridge periodically:

- Discovers Gazebo topics using `TopicList` and `TopicInfo`.
- Maps supported Gazebo message types using the existing generated mappings.
- Creates bridges for topics that appear after startup.
- Prevents duplicate bridge creation.
- Ignores unsupported or ambiguous message types.

Dynamic bridges default to `GZ_TO_ROS`. The direction can be changed using
`dynamic_bridge_direction`, including `BIDIRECTIONAL`.

`parameter_bridge` can now run without positional topic arguments when dynamic
bridging is enabled.

## Usage

```bash
ros2 run ros_gz_bridge parameter_bridge \
  --ros-args \
  -p create_dynamic_bridges:=true
```

Publish from Gazebo:

```bash
gz topic -t /hello_dynamic_bridge \
  -m gz.msgs.StringMsg \
  -p 'data: "hello from Gazebo"'
```

Observe from ROS:

```bash
ros2 topic echo /hello_dynamic_bridge std_msgs/msg/String
```

## Tests

Added launch integration tests covering:

- Discovery of topics created after bridge startup.
- Gazebo-to-ROS message delivery.
- Bidirectional ROS and Gazebo delivery.
- Duplicate bridge prevention.
- Unsupported message types.
- A burst of 50 ordered messages without duplicates.
- Isolation from other ROS and Gazebo processes.

The tests use separate `GZ_PARTITION` and `ROS_DOMAIN_ID` values.

```bash
source /opt/ros/rolling/setup.bash

colcon build --packages-select ros_gz_bridge \
  --cmake-args -DBUILD_TESTING=ON

source install/setup.bash
colcon test --packages-select ros_gz_bridge
colcon test-result --all --verbose
```

Local result:

```text
100% tests passed, 0 tests failed out of 20
```

## Backport Policy

- [x] This **should not** be backported

This is a Jetty roadmap feature introducing new parameters and behavior.

## Checklist

- [ ] Signed all commits for DCO
- [x] Screen capture not applicable; this feature has no UI
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation
- [x] Migration guide not needed; the feature is opt-in
- [x] Python binding changes are not applicable
- [x] `codecheck` passed
- [x] All tests passed
- [x] Bazel changes are not applicable to this package
- [ ] Reviewed another open Gazebo pull request
- [x] GenAI was used and `Generated-by` trailers are included

**Note to maintainers**: Please use **Squash-Merge** and retain the
`Signed-off-by` and `Generated-by` trailers.