### PR TITLE
Added implementation to get entity bound

### DIFF
--- a/ros_gz_sim/CMakeLists.txt
+++ b/ros_gz_sim/CMakeLists.txt
@@ -89,6 +89,7 @@ set(gz_simulation_interfaces_sources
   src/gz_simulation_interfaces/services/delete_entity.cpp
   src/gz_simulation_interfaces/services/get_entities.cpp
   src/gz_simulation_interfaces/services/get_entities_states.cpp
+  src/gz_simulation_interfaces/services/get_entity_bounds.cpp
   src/gz_simulation_interfaces/services/get_entity_info.cpp
   src/gz_simulation_interfaces/services/get_entity_state.cpp
   src/gz_simulation_interfaces/services/get_simulation_state.cpp

--- a/ros_gz_sim/src/gz_simulation_interfaces/gz_simulation_interfaces.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/gz_simulation_interfaces.cpp
@@ -41,6 +41,7 @@
 #include "services/delete_entity.hpp"
 #include "services/get_entities.hpp"
 #include "services/get_entities_states.hpp"
+#include "services/get_entity_bounds.hpp"
 #include "services/get_entity_info.hpp"
 #include "services/get_entity_state.hpp"
 #include "services/get_simulation_state.hpp"
@@ -105,6 +106,7 @@ void GzSimulationInterfaces::Implementation::CreateInterfaces()
 
   this->AddInterface<services::DeleteEntity>();
   this->AddInterface<services::GetEntities>();
+  this->AddInterface<services::GetEntityBounds>();
   this->AddInterface<services::GetEntityInfo>();
   this->AddInterface<services::GetEntityState>();
   this->AddInterface<services::GetEntitiesStates>();

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Open Source Robotics Foundation, Inc.
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.cpp
@@ -1,0 +1,101 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "get_entity_bounds.hpp"
+
+#include <memory>
+#include <optional>
+
+#include <gz/math/AxisAlignedBox.hh>
+#include <gz/sim/Entity.hh>
+#include <gz/sim/Link.hh>
+#include <gz/sim/Model.hh>
+
+#include "../gazebo_proxy.hpp"
+#include "../utils.hpp"
+#include "simulation_interfaces/msg/bounds.hpp"
+#include "simulation_interfaces/srv/get_entity_bounds.hpp"
+
+namespace ros_gz_sim
+{
+namespace gz_simulation_interfaces
+{
+namespace services
+{
+using GetEntityBoundsSrv = simulation_interfaces::srv::GetEntityBounds;
+using RequestPtr = GetEntityBoundsSrv::Request::ConstSharedPtr;
+using ResponsePtr = GetEntityBoundsSrv::Response::SharedPtr;
+
+using simulation_interfaces::msg::Bounds;
+using simulation_interfaces::msg::Result;
+
+GetEntityBounds::GetEntityBounds(
+  std::shared_ptr<rclcpp::Node> ros_node, std::shared_ptr<GazeboProxy> gz_proxy)
+: HandlerBase(ros_node, gz_proxy)
+{
+  auto service_cb = [this](RequestPtr request, ResponsePtr response) {
+      if (!this->gz_proxy_->AssertUpdatedState(response->result)) {
+        return;
+      }
+      // Mutable ECM: EnableBoundingBoxChecks creates the AxisAlignedBox
+      // component that Physics fills.
+      this->gz_proxy_->WithEcm([&](gz::sim::EntityComponentManager & ecm) {
+          auto entity = ecm.EntityByName(request->entity);
+          if (!entity) {
+            response->result.result = Result::RESULT_NOT_FOUND;
+            response->result.error_message = "Requested entity not found";
+            return;
+          }
+          gz::sim::Model model(*entity);
+          auto linkEntity = model.CanonicalLink(ecm);
+          if (linkEntity == gz::sim::kNullEntity) {
+            response->result.result = Result::RESULT_OPERATION_FAILED;
+            response->result.error_message = "Entity has no canonical link";
+            return;
+          }
+          gz::sim::Link link(linkEntity);
+          // Gazebo does not report a link's bounding box unless asked. Enabling
+          // is idempotent; Physics initialises and then keeps the
+          // components::AxisAlignedBox up to date from the collision shapes.
+          link.EnableBoundingBoxChecks(ecm, true);
+          // AABB in the LINK frame — matches the Bounds contract (bounds are
+          // relative to the entity's canonical link transform, REP-103).
+          std::optional<gz::math::AxisAlignedBox> aabb = link.AxisAlignedBox(ecm);
+          if (!aabb.has_value()) {
+            // Just enabled; Physics has not filled the component yet. Callers
+            // poll (e.g. the GT perception shim), so report a transient failure
+            // and let them retry on the next tick.
+            response->result.result = Result::RESULT_OPERATION_FAILED;
+            response->result.error_message =
+              "Bounding box not available yet — enabled, retry";
+            return;
+          }
+          Bounds bounds;
+          bounds.type = Bounds::TYPE_BOX;
+          bounds.points.resize(2);
+          ConvertVector3(aabb->Min(), bounds.points[0]);
+          ConvertVector3(aabb->Max(), bounds.points[1]);
+          response->bounds = bounds;
+          response->result.result = Result::RESULT_OK;
+    });
+    };
+  this->services_handle_ =
+    ros_node->create_service<GetEntityBoundsSrv>("get_entity_bounds", service_cb);
+
+  RCLCPP_INFO_STREAM(
+    ros_node->get_logger(), "Created service " << this->services_handle_->get_service_name());
+}
+}  // namespace services
+}  // namespace gz_simulation_interfaces
+}  // namespace ros_gz_sim

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.cpp
@@ -78,7 +78,7 @@ GetEntityBounds::GetEntityBounds(
             // and let them retry on the next tick.
             response->result.result = Result::RESULT_OPERATION_FAILED;
             response->result.error_message =
-              "Bounding box not available yet — enabled, retry";
+            "Bounding box not available yet — enabled, retry";
             return;
           }
           Bounds bounds;

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.hpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Open Source Robotics Foundation, Inc.
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.hpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/get_entity_bounds.hpp
@@ -1,0 +1,51 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GZ_SIMULATION_INTERFACES__SERVICES__GET_ENTITY_BOUNDS_HPP_
+#define GZ_SIMULATION_INTERFACES__SERVICES__GET_ENTITY_BOUNDS_HPP_
+
+#include <memory>
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/service.hpp>
+
+#include "../handler_base.hpp"
+
+namespace ros_gz_sim
+{
+namespace gz_simulation_interfaces
+{
+
+class GazeboProxy;
+
+namespace services
+{
+/// \class GetEntityBounds
+/// \brief Implements the `simulation_interfaces/GetEntityBounds` interface.
+///
+/// Returns the axis-aligned bounding box of an entity's canonical link, in the
+/// link frame (REP-103), as a Bounds/TYPE_BOX (min corner, max corner). The box
+/// is computed by Gazebo's Physics system once bounding-box checks are enabled
+/// on the link; the first request for a given entity enables them and reports a
+/// transient failure until Physics has filled the component on a later update
+/// (callers such as the ground-truth perception shim poll, so they retry).
+class GetEntityBounds : public HandlerBase
+{
+public:
+  GetEntityBounds(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<GazeboProxy> gz_proxy);
+};
+}  // namespace services
+}  // namespace gz_simulation_interfaces
+}  // namespace ros_gz_sim
+#endif  // GZ_SIMULATION_INTERFACES__SERVICES__GET_ENTITY_BOUNDS_HPP_

--- a/ros_gz_sim/test/test_gz_simulation_interfaces.launch.py
+++ b/ros_gz_sim/test/test_gz_simulation_interfaces.launch.py
@@ -29,7 +29,13 @@ from launch_testing.asserts import assertExitCodes
 import rclpy
 import rclpy.action
 from simulation_interfaces.action import SimulateSteps
-from simulation_interfaces.msg import EntityCategory, Result, SimulationState, SimulatorFeatures
+from simulation_interfaces.msg import (
+    Bounds,
+    EntityCategory,
+    Result,
+    SimulationState,
+    SimulatorFeatures,
+)
 import simulation_interfaces.srv as si
 
 # Match name used in launch files
@@ -161,6 +167,23 @@ class TestGzSimulationInterfaces(unittest.TestCase):
             si.ResetSimulation, 'reset_simulation')
         request.scope = si.ResetSimulation.Request.SCOPE_DEFAULT
         return self.call_and_spin(reset_simulation, request)
+
+    def get_entity_bounds(self, entity_name, timeout_sec=15) -> si.GetEntityBounds.Response:
+        get_entity_bounds, request = self.setup_client(
+            si.GetEntityBounds, 'get_entity_bounds')
+        request.entity = entity_name
+        # The first request for an entity enables bounding-box checks; Gazebo's
+        # Physics system fills the AxisAlignedBox component on a later update, so
+        # the service reports a transient RESULT_OPERATION_FAILED until then.
+        # Poll until the bounds become available or we time out.
+        deadline = time.time() + timeout_sec
+        response = None
+        while time.time() < deadline:
+            response = self.call_and_spin(get_entity_bounds, request)
+            if response is not None and response.result.result == Result.RESULT_OK:
+                return response
+            time.sleep(0.5)
+        return response
 
     # tests
 
@@ -373,6 +396,32 @@ class TestGzSimulationInterfaces(unittest.TestCase):
         # Do it again to make sure subsequent actions are handled properly
         send_goal_and_check_results()
         self.assertGreater(self.feedback_cb_count, 1)
+
+    def test_get_entity_bounds(self) -> None:
+        # The "sphere" model has a radius-1 collision, so its axis-aligned
+        # bounding box in the canonical link frame spans [-1, 1] on each axis.
+        # ("box" is deleted by test_delete_entity, which runs earlier, so it is
+        # not a reliable target here.)
+        response = self.get_entity_bounds('sphere')
+        self.assert_result_ok(response)
+        self.assertEqual(response.bounds.type, Bounds.TYPE_BOX)
+        self.assertEqual(len(response.bounds.points), 2)
+
+        min_point, max_point = response.bounds.points
+        self.assertAlmostEqual(min_point.x, -1.0, delta=1e-2)
+        self.assertAlmostEqual(min_point.y, -1.0, delta=1e-2)
+        self.assertAlmostEqual(min_point.z, -1.0, delta=1e-2)
+        self.assertAlmostEqual(max_point.x, 1.0, delta=1e-2)
+        self.assertAlmostEqual(max_point.y, 1.0, delta=1e-2)
+        self.assertAlmostEqual(max_point.z, 1.0, delta=1e-2)
+
+    def test_get_entity_bounds_not_found(self) -> None:
+        get_entity_bounds, request = self.setup_client(
+            si.GetEntityBounds, 'get_entity_bounds')
+        request.entity = 'this_entity_does_not_exist'
+        response = self.call_and_spin(get_entity_bounds, request)
+        self.assertIsNotNone(response)
+        self.assertEqual(response.result.result, Result.RESULT_NOT_FOUND)
 
     def test_get_entity_info(self) -> None:
         get_entity_info, request = self.setup_client(


### PR DESCRIPTION
# 🎉 New feature

It does not close issue, since I did not open any.

## Summary
It implements existing TODO for service `/gzsrv/get_entity_bounds`

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [x] Other `it depends on simulation interfaces. `
## Test it

Start Gazebo:
```
ros2 run ros_gz_sim gzserver --ros-args -p world_sdf_file:=/opt/ros/jazzy/opt/gz_sim_vendor/share/gz/gz-sim8/worlds/shapes.sdf
```
Ask simulation interfaces:
```
ros2 service call /gzserver/get_entity_bounds simulation_interfaces/srv/GetEntityBounds "{entity: 'box'}"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [X] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.8

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.