### PR TITLE
Add AirSpeed message and bridge mapping

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -30,6 +30,7 @@ The following message types can be bridged for topics:
 | nav_msgs/msg/Odometry                          | gz.msgs.Odometry                    |
 | nav_msgs/msg/Odometry                          | gz.msgs.OdometryWithCovariance      |
 | rcl_interfaces/msg/ParameterValue              | gz.msgs.Any                         |
+| ros_gz_interfaces/msg/AirSpeed                 | gz.msgs.AirSpeed                    |
 | ros_gz_interfaces/msg/Altimeter                | gz.msgs.Altimeter                   |
 | ros_gz_interfaces/msg/Contact                  | gz.msgs.Contact                     |
 | ros_gz_interfaces/msg/Contacts                 | gz.msgs.Contacts                    |

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
@@ -16,6 +16,7 @@
 #define ROS_GZ_BRIDGE__CONVERT__ROS_GZ_INTERFACES_HPP_
 
 // Gazebo Msgs
+#include <gz/msgs/air_speed.pb.h>
 #include <gz/msgs/altimeter.pb.h>
 #include <gz/msgs/contact.pb.h>
 #include <gz/msgs/contacts.pb.h>
@@ -40,6 +41,7 @@
 #include <gz/msgs/world_stats.pb.h>
 
 // ROS 2 messages
+#include <ros_gz_interfaces/msg/air_speed.hpp>
 #include <ros_gz_interfaces/msg/altimeter.hpp>
 #include <ros_gz_interfaces/msg/contact.hpp>
 #include <ros_gz_interfaces/msg/contacts.hpp>
@@ -80,6 +82,18 @@ void
 convert_gz_to_ros(
   const gz::msgs::JointWrench & gz_msg,
   ros_gz_interfaces::msg::JointWrench & ros_msg);
+
+template<>
+void
+convert_ros_to_gz(
+  const ros_gz_interfaces::msg::AirSpeed & ros_msg,
+  gz::msgs::AirSpeed & gz_msg);
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::AirSpeed & gz_msg,
+  ros_gz_interfaces::msg::AirSpeed & ros_msg);
 
 template<>
 void

--- a/ros_gz_bridge/ros_gz_bridge/mappings.py
+++ b/ros_gz_bridge/ros_gz_bridge/mappings.py
@@ -62,6 +62,7 @@ MAPPINGS = {
         Mapping('ParameterValue', 'Any'),
     ],
     'ros_gz_interfaces': [
+        Mapping('AirSpeed', 'AirSpeed'),
         Mapping('Altimeter', 'Altimeter'),
         Mapping('Contact', 'Contact'),
         Mapping('Contacts', 'Contacts'),

--- a/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
+++ b/ros_gz_bridge/src/convert/ros_gz_interfaces.cpp
@@ -50,6 +50,28 @@ convert_gz_to_ros(
 template<>
 void
 convert_ros_to_gz(
+  const ros_gz_interfaces::msg::AirSpeed & ros_msg,
+  gz::msgs::AirSpeed & gz_msg)
+{
+  convert_ros_to_gz(ros_msg.header, (*gz_msg.mutable_header()));
+  gz_msg.set_diff_pressure(ros_msg.diff_pressure);
+  gz_msg.set_temperature(ros_msg.temperature);
+}
+
+template<>
+void
+convert_gz_to_ros(
+  const gz::msgs::AirSpeed & gz_msg,
+  ros_gz_interfaces::msg::AirSpeed & ros_msg)
+{
+  convert_gz_to_ros(gz_msg.header(), ros_msg.header);
+  ros_msg.diff_pressure = gz_msg.diff_pressure();
+  ros_msg.temperature = gz_msg.temperature();
+}
+
+template<>
+void
+convert_ros_to_gz(
   const ros_gz_interfaces::msg::Altimeter & ros_msg,
   gz::msgs::Altimeter & gz_msg)
 {

--- a/ros_gz_bridge/test/utils/gz_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.cpp
@@ -405,6 +405,23 @@ void compareTestMsg(const std::shared_ptr<gz::msgs::Vector3d> & _msg)
   EXPECT_EQ(expected_msg.z(), _msg->z());
 }
 
+void createTestMsg(gz::msgs::AirSpeed & _msg)
+{
+  createTestMsg(*_msg.mutable_header());
+  _msg.set_diff_pressure(100);
+  _msg.set_temperature(200);
+}
+
+void compareTestMsg(const std::shared_ptr<gz::msgs::AirSpeed> & _msg)
+{
+  gz::msgs::AirSpeed expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.diff_pressure(), _msg->diff_pressure());
+  EXPECT_EQ(expected_msg.temperature(), _msg->temperature());
+  compareTestMsg(std::make_shared<gz::msgs::Header>(_msg->header()));
+}
+
 void createTestMsg(gz::msgs::Altimeter & _msg)
 {
   createTestMsg(*_msg.mutable_header());

--- a/ros_gz_bridge/test/utils/gz_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/gz_test_msg.hpp
@@ -16,6 +16,7 @@
 #define UTILS__GZ_TEST_MSG_HPP_
 
 #include <gz/msgs/actuators.pb.h>
+#include <gz/msgs/air_speed.pb.h>
 #include <gz/msgs/altimeter.pb.h>
 #include <gz/msgs/any.pb.h>
 #include <gz/msgs/axis.pb.h>
@@ -313,6 +314,14 @@ void createTestMsg(gz::msgs::JointWrench & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<gz::msgs::JointWrench> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(gz::msgs::AirSpeed & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<gz::msgs::AirSpeed> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_gz_bridge/test/utils/ros_test_msg.cpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.cpp
@@ -903,6 +903,24 @@ void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::JointWrench> &
   compareTestMsg(std::make_shared<geometry_msgs::msg::Wrench>(_msg->body_2_wrench));
 }
 
+void createTestMsg(ros_gz_interfaces::msg::AirSpeed & _msg)
+{
+  createTestMsg(_msg.header);
+  _msg.diff_pressure = 100;
+  _msg.temperature = 200;
+}
+
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::AirSpeed> & _msg)
+{
+  ros_gz_interfaces::msg::AirSpeed expected_msg;
+  createTestMsg(expected_msg);
+
+  EXPECT_EQ(expected_msg.diff_pressure, _msg->diff_pressure);
+  EXPECT_EQ(expected_msg.temperature, _msg->temperature);
+
+  compareTestMsg(_msg->header);
+}
+
 void createTestMsg(ros_gz_interfaces::msg::Altimeter & _msg)
 {
   createTestMsg(_msg.header);

--- a/ros_gz_bridge/test/utils/ros_test_msg.hpp
+++ b/ros_gz_bridge/test/utils/ros_test_msg.hpp
@@ -49,6 +49,7 @@
 #include <gps_msgs/msg/gps_fix.hpp>
 #include <marine_acoustic_msgs/msg/dvl.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <ros_gz_interfaces/msg/air_speed.hpp>
 #include <ros_gz_interfaces/msg/altimeter.hpp>
 #include <ros_gz_interfaces/msg/entity.hpp>
 #include <ros_gz_interfaces/msg/entity_factory.hpp>
@@ -409,6 +410,14 @@ void createTestMsg(ros_gz_interfaces::msg::JointWrench & _msg);
 /// \brief Compare a message with the populated for testing.
 /// \param[in] _msg The message to compare.
 void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::JointWrench> & _msg);
+
+/// \brief Create a message used for testing.
+/// \param[out] _msg The message populated.
+void createTestMsg(ros_gz_interfaces::msg::AirSpeed & _msg);
+
+/// \brief Compare a message with the populated for testing.
+/// \param[in] _msg The message to compare.
+void compareTestMsg(const std::shared_ptr<ros_gz_interfaces::msg::AirSpeed> & _msg);
 
 /// \brief Create a message used for testing.
 /// \param[out] _msg The message populated.

--- a/ros_gz_interfaces/CMakeLists.txt
+++ b/ros_gz_interfaces/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
+  "msg/AirSpeed.msg"
   "msg/Altimeter.msg"
   "msg/Contact.msg"
   "msg/Contacts.msg"

--- a/ros_gz_interfaces/msg/AirSpeed.msg
+++ b/ros_gz_interfaces/msg/AirSpeed.msg
@@ -1,0 +1,10 @@
+# A message for AirSpeed readings.
+
+# Optional header data.
+std_msgs/Header header
+
+# Differential pressure data, in hectopascals (hPa), matching gz.msgs.AirSpeed.
+float64 diff_pressure
+
+# Temperature data, in kelvin.
+float64 temperature


### PR DESCRIPTION
Fixes #382.

Adds a `ros_gz_interfaces/msg/AirSpeed` message and bidirectional bridge conversions between it and `gz.msgs.AirSpeed`, following the same pattern as the Altimeter mapping (PR #413). Per the issue discussion this bridges `gz.msgs.AirSpeed` (the sensor reading), not `AirSpeedSensor`.

The ROS message mirrors the proto field-for-field: `header`, `diff_pressure` (double, hPa), and `temperature` (double, kelvin). The bridge factory and the round-trip pub/sub test are generated from `mappings.py`, so no factory or template edits are needed; I added the mapping entry, the convert functions in both directions, and the createTestMsg/compareTestMsg helpers for the round-trip test, matching the Altimeter entry.

I was not able to build a full ROS 2 + Gazebo workspace locally, so compilation and the round-trip test run in CI. I verified the field mapping against the current `gz.msgs.AirSpeed` proto and checked the change mirrors the merged Altimeter mapping.