### PR TITLE
Support automated bridging

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -364,6 +364,13 @@ if(BUILD_TESTING)
     rclcpp::rclcpp
     ${std_msgs_TARGETS}
   )
+
+  ament_add_gtest(${PROJECT_NAME}_automated_bridge test/automated_bridge.cpp)
+  target_include_directories(${PROJECT_NAME}_automated_bridge PRIVATE src test)
+  target_link_libraries(${PROJECT_NAME}_automated_bridge
+    ${bridge_lib}
+    test_utils
+  )
 endif()
 
 # Export old-style CMake variables

--- a/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
@@ -81,6 +81,22 @@ protected:
   /// \brief Periodic callback to check connectivity and liveliness
   void spin();
 
+  /// \brief Get Gazebo topic information, including type and direction
+  /// \param[in] topic_name Name of the Gazebo topic
+  /// \param[out] gz_type_name Type of the Gazebo topic
+  /// \param[out] direction Direction of the bridge
+  /// \return True if successfully gets the Gazebo topic information
+  bool get_gz_topic_info(const std::string & topic_name,
+    std::string & gz_type_name, BridgeDirection & direction);
+  
+  /// \brief Get ROS topic information, including type
+  /// \param[in] topic_name Name of the ROS topic
+  /// \param[out] ros_type_name Type of the ROS topic
+  /// \param[in] direction Direction of the bridge
+  /// \return True if successfully gets the ROS topic information
+  bool get_ros_topic_info(const std::string & topic_name,
+    std::string & ros_type_name, const BridgeDirection & direction);
+
   /// \brief Log a bridge warning while avoiding repeated messages for the same
   /// topic and warning type.
   /// \param[in] warning_type Type of warning to log.

--- a/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
@@ -15,6 +15,7 @@
 #ifndef ROS_GZ_BRIDGE__ROS_GZ_BRIDGE_HPP_
 #define ROS_GZ_BRIDGE__ROS_GZ_BRIDGE_HPP_
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -89,24 +90,30 @@ protected:
   /// \param[out] gz_type_name Type of the Gazebo topic
   /// \param[out] direction Direction of the bridge
   /// \return True if successfully gets the Gazebo topic information
-  bool get_gz_topic_info(const std::string & topic_name,
-    std::string & gz_type_name, BridgeDirection & direction);
-  
+  bool get_gz_topic_info(
+    const std::string & topic_name,
+    std::string & gz_type_name,
+    BridgeDirection & direction);
+
   /// \brief Get ROS topic information, including type
   /// \param[in] topic_name Name of the ROS topic
   /// \param[out] ros_type_name Type of the ROS topic
   /// \param[in] direction Direction of the bridge
   /// \return True if successfully gets the ROS topic information
-  bool get_ros_topic_info(const std::string & topic_name,
-    std::string & ros_type_name, const BridgeDirection & direction);
+  bool get_ros_topic_info(
+    const std::string & topic_name,
+    std::string & ros_type_name,
+    const BridgeDirection & direction);
 
   /// \brief Get Gazebo service information, including request and response types
   /// \param[in] service_name Name of the Gazebo service
   /// \param[out] gz_req_type_name Type of the Gazebo service request
   /// \param[out] gz_rep_type_name Type of the Gazebo service response
   /// \return True if successfully gets the Gazebo service information
-  bool get_gz_service_info(const std::string & service_name,
-    std::string & gz_req_type_name, std::string & gz_rep_type_name);
+  bool get_gz_service_info(
+    const std::string & service_name,
+    std::string & gz_req_type_name,
+    std::string & gz_rep_type_name);
 
   /// \brief Get ROS service information, including type
   /// \param[in] ros_services Map of ROS services and their types

--- a/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
@@ -51,6 +51,7 @@ enum class BridgeWarningType
 
 /// Forward declarations
 class BridgeHandle;
+class ServiceFactoryInterface;
 
 /// \brief Component container for the ROS-GZ Bridge
 class RosGzBridge : public rclcpp::Node
@@ -69,11 +70,13 @@ public:
   /// \param[in] gz_req_type_name Gazebo service request type
   /// \param[in] gz_rep_type_name Gazebo service response type
   /// \param[in] service_name Address of the service to be bridged
+  /// \param[in] factory Factory to create the service bridge
   void add_service_bridge(
     const std::string & ros_type_name,
     const std::string & gz_req_type_name,
     const std::string & gz_rep_type_name,
-    const std::string & service_name);
+    const std::string & service_name,
+    std::shared_ptr<ServiceFactoryInterface> factory = nullptr);
 
   void create_automated_bridges();
 
@@ -97,16 +100,35 @@ protected:
   bool get_ros_topic_info(const std::string & topic_name,
     std::string & ros_type_name, const BridgeDirection & direction);
 
+  /// \brief Get Gazebo service information, including request and response types
+  /// \param[in] service_name Name of the Gazebo service
+  /// \param[out] gz_req_type_name Type of the Gazebo service request
+  /// \param[out] gz_rep_type_name Type of the Gazebo service response
+  /// \return True if successfully gets the Gazebo service information
+  bool get_gz_service_info(const std::string & service_name,
+    std::string & gz_req_type_name, std::string & gz_rep_type_name);
+
+  /// \brief Get ROS service information, including type
+  /// \param[in] ros_services Map of ROS services and their types
+  /// \param[in] service_name Name of the ROS service
+  /// \param[out] ros_type_name Type of the ROS service
+  /// \return True if successfully gets the ROS service information
+  bool get_ros_service_info(
+    const std::map<std::string, std::vector<std::string>> & ros_services,
+    const std::string & service_name, std::string & ros_type_name);
+
   /// \brief Log a bridge warning while avoiding repeated messages for the same
-  /// topic and warning type
+  /// topic /service and warning type
   /// \param[in] warning_type Type of warning to log
-  /// \param[in] topic_name Topic associated with the warning.
+  /// \param[in] name Topic /service associated with the warning.
+  /// \param[in] resource_type Type of resource (topic or service)
   /// \param[in] ros_type_name ROS message type related to the warning
   /// \param[in] gz_type_name Gazebo message type related to the warning
   /// \param[in] extra_info Additional warning context
   void log_bridge_warning(
     const BridgeWarningType & warning_type,
-    const std::string & topic_name,
+    const std::string & name,
+    const std::string & resource_type = "topic",
     const std::string & ros_type_name = "",
     const std::string & gz_type_name = "",
     const std::string & extra_info = "");

--- a/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
@@ -98,12 +98,12 @@ protected:
     std::string & ros_type_name, const BridgeDirection & direction);
 
   /// \brief Log a bridge warning while avoiding repeated messages for the same
-  /// topic and warning type.
-  /// \param[in] warning_type Type of warning to log.
+  /// topic and warning type
+  /// \param[in] warning_type Type of warning to log
   /// \param[in] topic_name Topic associated with the warning.
-  /// \param[in] ros_type_name ROS message type related to the warning, if available.
-  /// \param[in] gz_type_name Gazebo message type related to the warning, if available.
-  /// \param[in] extra_info Additional warning context, such as an exception message.
+  /// \param[in] ros_type_name ROS message type related to the warning
+  /// \param[in] gz_type_name Gazebo message type related to the warning
+  /// \param[in] extra_info Additional warning context
   void log_bridge_warning(
     const BridgeWarningType & warning_type,
     const std::string & topic_name,

--- a/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
@@ -26,6 +26,29 @@
 
 namespace ros_gz_bridge
 {
+
+/// \brief Enumeration for bridge warning types
+enum class BridgeWarningType
+{
+  /// \brief No warning
+  NONE,
+
+  /// \brief Gazebo topic has multiple types or no types
+  GZ_TYPE_UNDETERMINED,
+
+  /// \brief No mapping found from current Gazebo type to ROS type
+  GZ_TO_ROS_MAPPING_NOT_FOUND,
+
+  /// \brief Failed to discover ROS topic info
+  ROS_TYPE_DISCOVERED_FAILED,
+
+  /// \brief ROS topic has multiple types or no types
+  ROS_TYPE_UNDETERMINED,
+
+  /// \brief Mismatch between the detected Gazebo and ROS types.
+  ROS_GZ_TYPE_MISMATCH,
+};
+
 /// Forward declarations
 class BridgeHandle;
 
@@ -58,6 +81,20 @@ protected:
   /// \brief Periodic callback to check connectivity and liveliness
   void spin();
 
+  /// \brief Log a bridge warning while avoiding repeated messages for the same
+  /// topic and warning type.
+  /// \param[in] warning_type Type of warning to log.
+  /// \param[in] topic_name Topic associated with the warning.
+  /// \param[in] ros_type_name ROS message type related to the warning, if available.
+  /// \param[in] gz_type_name Gazebo message type related to the warning, if available.
+  /// \param[in] extra_info Additional warning context, such as an exception message.
+  void log_bridge_warning(
+    const BridgeWarningType & warning_type,
+    const std::string & topic_name,
+    const std::string & ros_type_name = "",
+    const std::string & gz_type_name = "",
+    const std::string & extra_info = "");
+
 protected:
   /// \brief Pointer to Gazebo node used to create publishers/subscribers
   std::shared_ptr<gz::transport::Node> gz_node_;
@@ -70,6 +107,9 @@ protected:
 
   /// \brief Timer to control periodic callback
   rclcpp::TimerBase::SharedPtr heartbeat_timer_;
+
+  /// \brief Map of bridge warnings
+  std::map<std::string, BridgeWarningType> bridge_warnings_;
 };
 }  // namespace ros_gz_bridge
 

--- a/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
@@ -52,6 +52,8 @@ public:
     const std::string & gz_rep_type_name,
     const std::string & service_name);
 
+  void create_automated_bridges();
+
 protected:
   /// \brief Periodic callback to check connectivity and liveliness
   void spin();

--- a/ros_gz_bridge/resource/get_mappings.cpp.em
+++ b/ros_gz_bridge/resource/get_mappings.cpp.em
@@ -17,6 +17,7 @@
 @
 #include <map>
 #include <string>
+#include <vector>
 
 #include "get_mappings.hpp"
 
@@ -42,6 +43,23 @@ get_gz_to_ros_mapping(const std::string & gz_type_name, std::string & ros_type_n
   return false;
 }
 
+bool 
+get_gz_to_ros_mapping(
+  const std::string & gz_type_name,
+  std::vector<std::string> & ros_type_names)
+{
+  ros_type_names.clear();
+
+  const auto & mappings = get_all_message_mappings_ros_to_gz();
+  for (const auto & mapping : mappings) {
+    if (mapping.second == gz_type_name) {
+      ros_type_names.push_back(mapping.first);
+    }
+  }
+
+  return !ros_type_names.empty();
+}
+
 bool
 get_ros_to_gz_mapping(const std::string & ros_type_name, std::string & gz_type_name)
 {
@@ -59,6 +77,23 @@ get_ros_to_gz_mapping(const std::string & ros_type_name, std::string & gz_type_n
 @[end for]@
 
   return false;
+}
+
+bool
+get_ros_to_gz_mapping(
+  const std::string & ros_type_name,
+  std::vector<std::string> & gz_type_names)
+{
+  gz_type_names.clear();
+
+  const auto & mappings = get_all_message_mappings_ros_to_gz();
+  for (const auto & mapping : mappings) {
+    if (mapping.first == ros_type_name) {
+      gz_type_names.push_back(mapping.second);
+    }
+  }
+
+  return !gz_type_names.empty();
 }
 
 std::multimap<std::string, std::string>

--- a/ros_gz_bridge/resource/get_mappings.cpp.em
+++ b/ros_gz_bridge/resource/get_mappings.cpp.em
@@ -43,7 +43,7 @@ get_gz_to_ros_mapping(const std::string & gz_type_name, std::string & ros_type_n
   return false;
 }
 
-bool 
+bool
 get_gz_to_ros_mapping(
   const std::string & gz_type_name,
   std::vector<std::string> & ros_type_names)

--- a/ros_gz_bridge/src/bridge_handle.cpp
+++ b/ros_gz_bridge/src/bridge_handle.cpp
@@ -39,6 +39,11 @@ bool BridgeHandle::IsLazy() const
   return config_.is_lazy.value_or(kDefaultLazy);
 }
 
+BridgeConfig BridgeHandle::GetConfig() const
+{
+  return config_;
+}
+
 void BridgeHandle::Start()
 {
   if (!this->HasPublisher()) {

--- a/ros_gz_bridge/src/bridge_handle.hpp
+++ b/ros_gz_bridge/src/bridge_handle.hpp
@@ -70,6 +70,10 @@ public:
   /// \return true if lazy
   bool IsLazy() const;
 
+  /// \brief Get the configuration parameters of the bridge
+  /// \return The configuration parameters of the bridge
+  BridgeConfig GetConfig() const;
+
 protected:
   /// \brief Get the number of subscriptions on the output side of the bridge
   virtual size_t NumSubscriptions() const = 0;

--- a/ros_gz_bridge/src/get_mappings.hpp
+++ b/ros_gz_bridge/src/get_mappings.hpp
@@ -25,7 +25,7 @@ namespace ros_gz_bridge
 bool
 get_gz_to_ros_mapping(const std::string & gz_type_name, std::string & ros_type_name);
 
-bool 
+bool
 get_gz_to_ros_mapping(
   const std::string & gz_type_name,
   std::vector<std::string> & ros_type_names);

--- a/ros_gz_bridge/src/get_mappings.hpp
+++ b/ros_gz_bridge/src/get_mappings.hpp
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 namespace ros_gz_bridge
 {
@@ -24,8 +25,18 @@ namespace ros_gz_bridge
 bool
 get_gz_to_ros_mapping(const std::string & gz_type_name, std::string & ros_type_name);
 
+bool 
+get_gz_to_ros_mapping(
+  const std::string & gz_type_name,
+  std::vector<std::string> & ros_type_names);
+
 bool
 get_ros_to_gz_mapping(const std::string & ros_type_name, std::string & gz_type_name);
+
+bool
+get_ros_to_gz_mapping(
+  const std::string & ros_type_name,
+  std::vector<std::string> & gz_type_names);
 
 std::multimap<std::string, std::string>
 get_all_message_mappings_ros_to_gz();

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -351,35 +351,30 @@ void RosGzBridge::create_automated_bridges()
   std::vector<std::string> gz_topics;
   gz_node_->TopicList(gz_topics);
 
-  for (const auto & gz_topic : gz_topics)
-  {
+  for (const auto & gz_topic : gz_topics) {
     // Skip topics that are already bridged
     bool already_bridged = false;
-    for (const auto & handle : handles_)
-    {
-      if (handle->GetConfig().gz_topic_name == gz_topic)
-      {
+    for (const auto & handle : handles_) {
+      if (handle->GetConfig().gz_topic_name == gz_topic) {
         already_bridged = true;
         break;
       }
     }
-    if (already_bridged) 
-    {
+
+    if (already_bridged) {
       continue;
     }
 
     // Get Gazebo topic info
     BridgeDirection direction {BridgeDirection::NONE};
     std::string gz_type_name;
-    if (!get_gz_topic_info(gz_topic, gz_type_name, direction))
-    {
+    if (!get_gz_topic_info(gz_topic, gz_type_name, direction)) {
       continue;
     }
 
     // Get candidate ROS types for the Gazebo type
     std::vector<std::string> ros_candidate_types;
-    if (!get_gz_to_ros_mapping(gz_type_name, ros_candidate_types))
-    {
+    if (!get_gz_to_ros_mapping(gz_type_name, ros_candidate_types)) {
       this->log_bridge_warning(
         BridgeWarningType::GZ_TO_ROS_MAPPING_NOT_FOUND, gz_topic,
         "topic", "", gz_type_name);
@@ -388,23 +383,19 @@ void RosGzBridge::create_automated_bridges()
 
     // Get ROS topic info
     std::string ros_type_name;
-    if (!get_ros_topic_info(gz_topic, ros_type_name, direction))
-    {
+    if (!get_ros_topic_info(gz_topic, ros_type_name, direction)) {
       continue;
     }
 
     bool is_mapping_valid = false;
-    for (const auto & candidate : ros_candidate_types)
-    {
-      if (candidate == ros_type_name)
-      {
+    for (const auto & candidate : ros_candidate_types) {
+      if (candidate == ros_type_name) {
         is_mapping_valid = true;
         break;
       }
     }
 
-    if (!is_mapping_valid)
-    {
+    if (!is_mapping_valid) {
       this->log_bridge_warning(
         BridgeWarningType::ROS_GZ_TYPE_MISMATCH, gz_topic,
         "topic", ros_type_name, gz_type_name);
@@ -424,70 +415,57 @@ void RosGzBridge::create_automated_bridges()
   gz_node_->ServiceList(gz_services);
 
   std::map<std::string, std::vector<std::string>> ros_services;
-  try
-  {
+  try {
     const auto graph = this->get_node_graph_interface();
     const auto nodes = graph->get_node_names_and_namespaces();
 
-    for (const auto & node : nodes)
-    {
+    for (const auto & node : nodes) {
       const auto services =
         graph->get_client_names_and_types_by_node(node.first, node.second);
-      for (const auto & service : services)
-      {
+      for (const auto & service : services) {
         auto & types = ros_services[service.first];
         types.insert(types.end(), service.second.begin(), service.second.end());
       }
     }
-  }
-  catch(const std::exception& e)
-  {
+  } catch(const std::exception & e) {
     RCLCPP_WARN(
       this->get_logger(),
       "Failed to get ROS service names and types: %s", e.what());
     return;
   }
 
-  for (const auto & gz_service : gz_services)
-  {
+  for (const auto & gz_service : gz_services) {
     // Skip services that are already bridged
     bool already_bridged = false;
-    for (const auto & service : services_)
-    {
-      if (service->get_service_name() == gz_service)
-      {
+    for (const auto & service : services_) {
+      if (service->get_service_name() == gz_service) {
         already_bridged = true;
         break;
       }
     }
-    if (already_bridged)
-    {
+
+    if (already_bridged) {
       continue;
     }
 
     // Get Gazebo service info
     std::string gz_req_type_name, gz_rep_type_name;
-    if (!get_gz_service_info(gz_service, gz_req_type_name, gz_rep_type_name))
-    {
+    if (!get_gz_service_info(gz_service, gz_req_type_name, gz_rep_type_name)) {
       continue;
     }
-  
+
     // Get ROS service info
     std::string ros_type_name;
-    if (!get_ros_service_info(ros_services, gz_service, ros_type_name))
-    {
+    if (!get_ros_service_info(ros_services, gz_service, ros_type_name)) {
       continue;
     }
 
     std::shared_ptr<ServiceFactoryInterface> factory;
-    try
-    {
+    try {
       factory = get_service_factory(ros_type_name,
                                     gz_req_type_name,
                                     gz_rep_type_name);
-    }
-    catch (std::runtime_error & _e)
-    {
+    } catch (std::runtime_error & _e) {
       this->log_bridge_warning(
         BridgeWarningType::ROS_GZ_TYPE_MISMATCH, gz_service, "service",
         ros_type_name, gz_req_type_name + "/" + gz_rep_type_name,
@@ -504,8 +482,10 @@ void RosGzBridge::create_automated_bridges()
   }
 }
 
-bool RosGzBridge::get_gz_topic_info(const std::string & topic_name,
-  std::string & gz_type_name, BridgeDirection & direction)
+bool RosGzBridge::get_gz_topic_info(
+  const std::string & topic_name,
+  std::string & gz_type_name,
+  BridgeDirection & direction)
 {
   std::vector<gz::transport::MessagePublisher> gz_publishers;
   std::vector<gz::transport::MessagePublisher> gz_subscribers;
@@ -514,66 +494,52 @@ bool RosGzBridge::get_gz_topic_info(const std::string & topic_name,
   }
 
   std::unordered_set<std::string> gz_publisher_types;
-  for (const auto & pub : gz_publishers)
-  {
+  for (const auto & pub : gz_publishers) {
     gz_publisher_types.insert(pub.MsgTypeName());
   }
   std::unordered_set<std::string> gz_subscriber_types;
-  for (const auto & sub : gz_subscribers)
-  {
+  for (const auto & sub : gz_subscribers) {
     gz_subscriber_types.insert(sub.MsgTypeName());
   }
 
   if ((gz_publisher_types.size() > 1 || gz_subscriber_types.size() > 1) ||
-      (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 0) ||
-      (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1 &&
-       *gz_publisher_types.begin() != *gz_subscriber_types.begin()))
+    (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 0) ||
+    (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1 &&
+    *gz_publisher_types.begin() != *gz_subscriber_types.begin()))
   {
     this->log_bridge_warning(
       BridgeWarningType::GZ_TYPE_UNDETERMINED, topic_name);
     return false;
-  }
-  else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1)
-  {
+  } else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1) {
     gz_type_name = *gz_publisher_types.begin();
     direction = BridgeDirection::BIDIRECTIONAL;
-  }
-  else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 0)
-  {
+  } else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 0) {
     gz_type_name = *gz_publisher_types.begin();
     direction = BridgeDirection::GZ_TO_ROS;
-  }
-  else if (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 1)
-  {
+  } else if (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 1) {
     gz_type_name = *gz_subscriber_types.begin();
     direction = BridgeDirection::ROS_TO_GZ;
   }
   return true;
 }
 
-bool RosGzBridge::get_ros_topic_info (const std::string & topic_name,
-  std::string & ros_type_name, const BridgeDirection & direction)
+bool RosGzBridge::get_ros_topic_info(
+  const std::string & topic_name,
+  std::string & ros_type_name,
+  const BridgeDirection & direction)
 {
   std::vector<rclcpp::TopicEndpointInfo> ros_publishers;
   std::vector<rclcpp::TopicEndpointInfo> ros_subscribers;
-  try
-  {
-    if (direction == BridgeDirection::ROS_TO_GZ)
-    {
+  try {
+    if (direction == BridgeDirection::ROS_TO_GZ) {
       ros_publishers = this->get_publishers_info_by_topic(topic_name);
-    }
-    else if (direction == BridgeDirection::GZ_TO_ROS)
-    {
+    } else if (direction == BridgeDirection::GZ_TO_ROS) {
       ros_subscribers = this->get_subscriptions_info_by_topic(topic_name);
-    }
-    else if (direction == BridgeDirection::BIDIRECTIONAL)
-    {
+    } else if (direction == BridgeDirection::BIDIRECTIONAL) {
       ros_publishers = this->get_publishers_info_by_topic(topic_name);
       ros_subscribers = this->get_subscriptions_info_by_topic(topic_name);
     }
-  }
-  catch(const std::exception& e)
-  {
+  } catch(const std::exception & e) {
     this->log_bridge_warning(
       BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, topic_name,
       "topic", "", "", e.what());
@@ -581,42 +547,36 @@ bool RosGzBridge::get_ros_topic_info (const std::string & topic_name,
   }
 
   std::unordered_set<std::string> ros_publisher_types;
-  for (const auto & pub : ros_publishers)
-  {
+  for (const auto & pub : ros_publishers) {
     ros_publisher_types.insert(pub.topic_type());
   }
   std::unordered_set<std::string> ros_subscriber_types;
-  for (const auto & sub : ros_subscribers)
-  {
+  for (const auto & sub : ros_subscribers) {
     ros_subscriber_types.insert(sub.topic_type());
   }
 
   if ((ros_publisher_types.size() > 1 || ros_subscriber_types.size() > 1) ||
-      (ros_publisher_types.size() == 0 && ros_subscriber_types.size() == 0) ||
-      (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 1 &&
-       *ros_publisher_types.begin() != *ros_subscriber_types.begin()))
+    (ros_publisher_types.size() == 0 && ros_subscriber_types.size() == 0) ||
+    (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 1 &&
+    *ros_publisher_types.begin() != *ros_subscriber_types.begin()))
   {
     this->log_bridge_warning(
       BridgeWarningType::ROS_TYPE_UNDETERMINED, topic_name);
     return false;
-  }
-  else if (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 1)
-  {
+  } else if (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 1) {
     ros_type_name = *ros_publisher_types.begin();
-  }
-  else if (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 0)
-  {
+  } else if (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 0) {
     ros_type_name = *ros_publisher_types.begin();
-  }
-  else if (ros_publisher_types.size() == 0 && ros_subscriber_types.size() == 1)
-  {
+  } else if (ros_publisher_types.size() == 0 && ros_subscriber_types.size() == 1) {
     ros_type_name = *ros_subscriber_types.begin();
   }
   return true;
 }
 
-bool RosGzBridge::get_gz_service_info(const std::string & service_name,
-  std::string & gz_req_type_name, std::string & gz_rep_type_name)
+bool RosGzBridge::get_gz_service_info(
+  const std::string & service_name,
+  std::string & gz_req_type_name,
+  std::string & gz_rep_type_name)
 {
   std::vector<gz::transport::ServicePublisher> gz_services_publishers;
   if (!gz_node_->ServiceInfo(service_name, gz_services_publishers)) {
@@ -624,14 +584,12 @@ bool RosGzBridge::get_gz_service_info(const std::string & service_name,
   }
 
   std::set<std::pair<std::string, std::string>> service_types;
-  for (const auto & pub : gz_services_publishers)
-  {
+  for (const auto & pub : gz_services_publishers) {
     service_types.insert(
       {pub.ReqTypeName(), pub.RepTypeName()});
   }
 
-  if (service_types.size() != 1)
-  {
+  if (service_types.size() != 1) {
     this->log_bridge_warning(
       BridgeWarningType::GZ_TYPE_UNDETERMINED, service_name, "service");
     return false;
@@ -648,17 +606,15 @@ bool RosGzBridge::get_ros_service_info(
   const std::string & service_name, std::string & ros_type_name)
 {
   const auto ros_service = ros_services.find(service_name);
-  if (ros_service == ros_services.end())
-  {
+  if (ros_service == ros_services.end()) {
     return false;
   }
 
   std::set<std::string> ros_service_types(
     ros_service->second.begin(),
     ros_service->second.end());
-  
-  if (ros_service_types.size() != 1)
-  {
+
+  if (ros_service_types.size() != 1) {
     this->log_bridge_warning(
       BridgeWarningType::ROS_TYPE_UNDETERMINED, service_name, "service");
     return false;

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -393,7 +393,8 @@ void RosGzBridge::create_automated_bridges()
         gz_topic.c_str());
       continue;
     }
-    else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1)
+    else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1 &&
+             *gz_publisher_types.begin() == *gz_subscriber_types.begin())
     {
       gz_type_name = *gz_publisher_types.begin();
       direction = BridgeDirection::BIDIRECTIONAL;
@@ -420,7 +421,7 @@ void RosGzBridge::create_automated_bridges()
     std::vector<std::string> ros_candidate_types;
     if (!get_gz_to_ros_mapping(gz_type_name, ros_candidate_types))
     {
-      RCLCPP_DEBUG(
+      RCLCPP_WARN(
         this->get_logger(),
         "Skipping automated bridge for topic [%s] for Gazebo message type "
         "[%s] with no known ROS message type mapping.",
@@ -559,7 +560,7 @@ void RosGzBridge::create_automated_bridges()
 
     if (!is_mapping_valid)
     {
-      RCLCPP_DEBUG(
+      RCLCPP_WARN(
         this->get_logger(),
         "Skipping automated bridge for topic [%s] for ROS message type "
         "[%s] with no known mapping to Gazebo message type [%s].",

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -490,7 +490,7 @@ void RosGzBridge::create_automated_bridges()
     {
       this->log_bridge_warning(
         BridgeWarningType::ROS_GZ_TYPE_MISMATCH, gz_service, "service",
-        ros_type_name, "req:" + gz_req_type_name + "/rep:" + gz_rep_type_name,
+        ros_type_name, gz_req_type_name + "/" + gz_rep_type_name,
         _e.what());
       continue;
     }

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -343,7 +343,6 @@ void RosGzBridge::add_service_bridge(
   }
 }
 
-// TODO: Avoid flooding the log with repeated messages during retries.
 void RosGzBridge::create_automated_bridges()
 {
   std::vector<std::string> gz_topics;
@@ -384,17 +383,16 @@ void RosGzBridge::create_automated_bridges()
 
     BridgeDirection direction {BridgeDirection::NONE};
     std::string gz_type_name;
-    if (gz_publisher_types.size() > 1 || gz_subscriber_types.size() > 1)
+    if ((gz_publisher_types.size() > 1 || gz_subscriber_types.size() > 1) ||
+        (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 0) ||
+        (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1 &&
+         *gz_publisher_types.begin() != *gz_subscriber_types.begin()))
     {
-      RCLCPP_WARN(
-        this->get_logger(),
-        "Skipping automated bridge for topic [%s] for multiple "
-        "Gazebo message types.",
-        gz_topic.c_str());
+      this->log_bridge_warning(
+        BridgeWarningType::GZ_TYPE_UNDETERMINED, gz_topic);
       continue;
     }
-    else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1 &&
-             *gz_publisher_types.begin() == *gz_subscriber_types.begin())
+    else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1)
     {
       gz_type_name = *gz_publisher_types.begin();
       direction = BridgeDirection::BIDIRECTIONAL;
@@ -409,23 +407,13 @@ void RosGzBridge::create_automated_bridges()
       gz_type_name = *gz_subscriber_types.begin();
       direction = BridgeDirection::ROS_TO_GZ;
     }
-    else
-    {
-      RCLCPP_WARN(
-        this->get_logger(),
-        "Skipping automated bridge for topic [%s] for no Gazebo message "
-        "types discovered.", gz_topic.c_str());
-      continue;
-    }
 
     std::vector<std::string> ros_candidate_types;
     if (!get_gz_to_ros_mapping(gz_type_name, ros_candidate_types))
     {
-      RCLCPP_WARN(
-        this->get_logger(),
-        "Skipping automated bridge for topic [%s] for Gazebo message type "
-        "[%s] with no known ROS message type mapping.",
-        gz_topic.c_str(), gz_type_name.c_str());
+      this->log_bridge_warning(
+        BridgeWarningType::GZ_TO_ROS_MAPPING_NOT_FOUND, gz_topic,
+        "", gz_type_name);
       continue;
     }
 
@@ -452,11 +440,9 @@ void RosGzBridge::create_automated_bridges()
       }
       catch(const std::exception& e)
       {
-        RCLCPP_WARN(
-          this->get_logger(),
-          "Skipping automated bridge for topic [%s] for ROS message type "
-          "discovery error: %s",
-          gz_topic.c_str(), e.what());
+        this->log_bridge_warning(
+          BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, gz_topic,
+          "", "", e.what());
         continue;
       }
       
@@ -483,11 +469,9 @@ void RosGzBridge::create_automated_bridges()
       }
       catch(const std::exception& e)
       {
-        RCLCPP_WARN(
-          this->get_logger(),
-          "Skipping automated bridge for topic [%s] for ROS message type "
-          "discovery error: %s",
-          gz_topic.c_str(), e.what());
+        this->log_bridge_warning(
+          BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, gz_topic,
+          "", "", e.what());
         continue;
       }
     }
@@ -539,11 +523,9 @@ void RosGzBridge::create_automated_bridges()
       }
       catch(const std::exception& e)
       {
-        RCLCPP_WARN(
-          this->get_logger(),
-          "Skipping automated bridge for topic [%s] for ROS message type "
-          "discovery error: %s",
-          gz_topic.c_str(), e.what());
+        this->log_bridge_warning(
+          BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, gz_topic,
+          "", "", e.what());
         continue;
       }
     }
@@ -560,11 +542,9 @@ void RosGzBridge::create_automated_bridges()
 
     if (!is_mapping_valid)
     {
-      RCLCPP_WARN(
-        this->get_logger(),
-        "Skipping automated bridge for topic [%s] for ROS message type "
-        "[%s] with no known mapping to Gazebo message type [%s].",
-        gz_topic.c_str(), ros_type_name.c_str(), gz_type_name.c_str());
+      this->log_bridge_warning(
+        BridgeWarningType::ROS_GZ_TYPE_MISMATCH, gz_topic,
+        ros_type_name, gz_type_name);
       continue;
     }
 
@@ -577,6 +557,60 @@ void RosGzBridge::create_automated_bridges()
     this->add_bridge(config);
   }
 }
+
+void RosGzBridge::log_bridge_warning(
+  const BridgeWarningType & warning_type,
+  const std::string & topic_name,
+  const std::string & ros_type_name,
+  const std::string & gz_type_name,
+  const std::string & extra_info)
+{
+  auto it = bridge_warnings_.find(topic_name);
+  if (it == bridge_warnings_.end() || it->second != warning_type) {
+    bridge_warnings_[topic_name] = warning_type;
+    switch (warning_type) {
+      case BridgeWarningType::NONE:
+        break;
+      case BridgeWarningType::GZ_TYPE_UNDETERMINED:
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Skipping automated bridge for topic [%s] : "
+          "found multiple or no Gazebo message types.",
+          topic_name.c_str());
+        break;
+      case BridgeWarningType::GZ_TO_ROS_MAPPING_NOT_FOUND:
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Skipping automated bridge for topic [%s] : "
+          "no mapping found for Gazebo message type [%s] .",
+          topic_name.c_str(), gz_type_name.c_str());
+        break;
+      case BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED:
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Skipping automated bridge for topic [%s] : "
+          "failed to discover ROS topic info for it: %s",
+          topic_name.c_str(), extra_info.c_str());
+        break;
+      case BridgeWarningType::ROS_TYPE_UNDETERMINED:
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Skipping automated bridge for topic [%s] : "
+          "found multiple or zero ROS message types.",
+          topic_name.c_str());
+        break;
+      case BridgeWarningType::ROS_GZ_TYPE_MISMATCH:
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Skipping automated bridge for topic [%s] : "
+          "mismatch between the detected "
+          "Gazebo message type [%s] and ROS message type [%s].",
+          topic_name.c_str(), gz_type_name.c_str(), ros_type_name.c_str());
+        break;
+    }
+  }
+}
+
 }  // namespace ros_gz_bridge
 
 #include "rclcpp_components/register_node_macro.hpp"

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -322,7 +322,8 @@ void RosGzBridge::add_service_bridge(
   const std::string & ros_type_name,
   const std::string & gz_req_type_name,
   const std::string & gz_rep_type_name,
-  const std::string & service_name)
+  const std::string & service_name,
+  std::shared_ptr<ServiceFactoryInterface> factory)
 {
   try {
     RCLCPP_INFO(
@@ -330,7 +331,9 @@ void RosGzBridge::add_service_bridge(
       "Creating ROS->GZ service bridge [%s (%s -> %s/%s)]",
       service_name.c_str(), ros_type_name.c_str(),
       gz_req_type_name.c_str(), gz_rep_type_name.c_str());
-    auto factory = get_service_factory(ros_type_name, gz_req_type_name, gz_rep_type_name);
+    if (!factory) {
+      factory = get_service_factory(ros_type_name, gz_req_type_name, gz_rep_type_name);
+    }
     services_.push_back(factory->create_ros_service(shared_from_this(), gz_node_, service_name));
   } catch (std::runtime_error & _e) {
     RCLCPP_WARN(
@@ -379,7 +382,7 @@ void RosGzBridge::create_automated_bridges()
     {
       this->log_bridge_warning(
         BridgeWarningType::GZ_TO_ROS_MAPPING_NOT_FOUND, gz_topic,
-        "", gz_type_name);
+        "topic", "", gz_type_name);
       continue;
     }
 
@@ -404,7 +407,7 @@ void RosGzBridge::create_automated_bridges()
     {
       this->log_bridge_warning(
         BridgeWarningType::ROS_GZ_TYPE_MISMATCH, gz_topic,
-        ros_type_name, gz_type_name);
+        "topic", ros_type_name, gz_type_name);
       continue;
     }
 
@@ -415,6 +418,77 @@ void RosGzBridge::create_automated_bridges()
     config.gz_topic_name = gz_topic;
     config.direction = direction;
     this->add_bridge(config);
+  }
+
+  std::vector<std::string> gz_services;
+  gz_node_->ServiceList(gz_services);
+
+  std::map<std::string, std::vector<std::string>> ros_services;
+  try
+  {
+    ros_services = this->get_service_names_and_types();
+  }
+  catch(const std::exception& e)
+  {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "Failed to get ROS service names and types: %s", e.what());
+    return;
+  }
+
+  for (const auto & gz_service : gz_services)
+  {
+    // Skip services that are already bridged
+    bool already_bridged = false;
+    for (const auto & service : services_)
+    {
+      if (service->get_service_name() == gz_service)
+      {
+        already_bridged = true;
+        break;
+      }
+    }
+    if (already_bridged)
+    {
+      continue;
+    }
+
+    // Get Gazebo service info
+    std::string gz_req_type_name, gz_rep_type_name;
+    if (!get_gz_service_info(gz_service, gz_req_type_name, gz_rep_type_name))
+    {
+      continue;
+    }
+  
+    // Get ROS service info
+    std::string ros_type_name;
+    if (!get_ros_service_info(ros_services, gz_service, ros_type_name))
+    {
+      continue;
+    }
+
+    std::shared_ptr<ServiceFactoryInterface> factory;
+    try
+    {
+      factory = get_service_factory(ros_type_name,
+                                    gz_req_type_name,
+                                    gz_rep_type_name);
+    }
+    catch (std::runtime_error & _e)
+    {
+      this->log_bridge_warning(
+        BridgeWarningType::ROS_GZ_TYPE_MISMATCH, gz_service, "service",
+        ros_type_name, "req:" + gz_req_type_name + "/rep:" + gz_rep_type_name,
+        _e.what());
+      continue;
+    }
+
+    this->add_service_bridge(
+      ros_type_name,
+      gz_req_type_name,
+      gz_rep_type_name,
+      gz_service,
+      factory);
   }
 }
 
@@ -490,7 +564,7 @@ bool RosGzBridge::get_ros_topic_info (const std::string & topic_name,
   {
     this->log_bridge_warning(
       BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, topic_name,
-      "", "", e.what());
+      "topic", "", "", e.what());
     return false;
   }
 
@@ -529,54 +603,111 @@ bool RosGzBridge::get_ros_topic_info (const std::string & topic_name,
   return true;
 }
 
+bool RosGzBridge::get_gz_service_info(const std::string & service_name,
+  std::string & gz_req_type_name, std::string & gz_rep_type_name)
+{
+  std::vector<gz::transport::ServicePublisher> gz_services_publishers;
+  if (!gz_node_->ServiceInfo(service_name, gz_services_publishers)) {
+    return false;
+  }
+
+  std::set<std::pair<std::string, std::string>> service_types;
+  for (const auto & pub : gz_services_publishers)
+  {
+    service_types.insert(
+      {pub.ReqTypeName(), pub.RepTypeName()});
+  }
+
+  if (service_types.size() != 1)
+  {
+    this->log_bridge_warning(
+      BridgeWarningType::GZ_TYPE_UNDETERMINED, service_name, "service");
+    return false;
+  }
+
+  gz_req_type_name = service_types.begin()->first;
+  gz_rep_type_name = service_types.begin()->second;
+
+  return true;
+}
+
+bool RosGzBridge::get_ros_service_info(
+  const std::map<std::string, std::vector<std::string>> & ros_services,
+  const std::string & service_name, std::string & ros_type_name)
+{
+  const auto ros_service = ros_services.find(service_name);
+  if (ros_service == ros_services.end())
+  {
+    return false;
+  }
+
+  std::set<std::string> ros_service_types(
+    ros_service->second.begin(),
+    ros_service->second.end());
+  
+  if (ros_service_types.size() != 1)
+  {
+    this->log_bridge_warning(
+      BridgeWarningType::ROS_TYPE_UNDETERMINED, service_name, "service");
+    return false;
+  }
+
+  ros_type_name = *ros_service_types.begin();
+  return true;
+}
+
 void RosGzBridge::log_bridge_warning(
   const BridgeWarningType & warning_type,
-  const std::string & topic_name,
+  const std::string & name,
+  const std::string & resource_type,
   const std::string & ros_type_name,
   const std::string & gz_type_name,
   const std::string & extra_info)
 {
-  auto it = bridge_warnings_.find(topic_name);
+  const auto warning_key = resource_type + ":" + name;
+  auto it = bridge_warnings_.find(warning_key);
   if (it == bridge_warnings_.end() || it->second != warning_type) {
-    bridge_warnings_[topic_name] = warning_type;
+    bridge_warnings_[warning_key] = warning_type;
     switch (warning_type) {
       case BridgeWarningType::NONE:
         break;
       case BridgeWarningType::GZ_TYPE_UNDETERMINED:
         RCLCPP_WARN(
           this->get_logger(),
-          "Skipping automated bridge for topic [%s] : "
+          "Skipping automated bridge for %s [%s] : "
           "found multiple or no Gazebo message types.",
-          topic_name.c_str());
+          resource_type.c_str(), name.c_str());
         break;
       case BridgeWarningType::GZ_TO_ROS_MAPPING_NOT_FOUND:
         RCLCPP_WARN(
           this->get_logger(),
-          "Skipping automated bridge for topic [%s] : "
+          "Skipping automated bridge for %s [%s] : "
           "no mapping found for Gazebo message type [%s] .",
-          topic_name.c_str(), gz_type_name.c_str());
+          resource_type.c_str(), name.c_str(), gz_type_name.c_str());
         break;
       case BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED:
         RCLCPP_WARN(
           this->get_logger(),
-          "Skipping automated bridge for topic [%s] : "
-          "failed to discover ROS topic info for it: %s",
-          topic_name.c_str(), extra_info.c_str());
+          "Skipping automated bridge for %s [%s] : "
+          "failed to discover ROS %s info for it: %s",
+          resource_type.c_str(), name.c_str(),
+          resource_type.c_str(), extra_info.c_str());
         break;
       case BridgeWarningType::ROS_TYPE_UNDETERMINED:
         RCLCPP_WARN(
           this->get_logger(),
-          "Skipping automated bridge for topic [%s] : "
+          "Skipping automated bridge for %s [%s] : "
           "found multiple or zero ROS message types.",
-          topic_name.c_str());
+          resource_type.c_str(), name.c_str());
         break;
       case BridgeWarningType::ROS_GZ_TYPE_MISMATCH:
         RCLCPP_WARN(
           this->get_logger(),
-          "Skipping automated bridge for topic [%s] : "
+          "Skipping automated bridge for %s [%s] : "
           "mismatch between the detected "
           "Gazebo message type [%s] and ROS message type [%s].",
-          topic_name.c_str(), gz_type_name.c_str(), ros_type_name.c_str());
+          resource_type.c_str(), name.c_str(),
+          gz_type_name.c_str(), ros_type_name.c_str());
         break;
     }
   }

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -352,12 +352,17 @@ void RosGzBridge::create_automated_bridges()
   for (const auto & gz_topic : gz_topics)
   {
     // Skip topics that are already bridged
+    bool already_bridged = false;
     for (const auto & handle : handles_)
     {
       if (handle->GetConfig().gz_topic_name == gz_topic)
       {
-        continue;
+        already_bridged = true;
+        break;
       }
+    }
+    if (already_bridged) {
+      continue;
     }
 
     std::vector<gz::transport::MessagePublisher> gz_publishers;
@@ -415,7 +420,7 @@ void RosGzBridge::create_automated_bridges()
     std::vector<std::string> ros_candidate_types;
     if (!get_gz_to_ros_mapping(gz_type_name, ros_candidate_types))
     {
-      RCLCPP_WARN(
+      RCLCPP_DEBUG(
         this->get_logger(),
         "Skipping automated bridge for topic [%s] for Gazebo message type "
         "[%s] with no known ROS message type mapping.",
@@ -455,7 +460,7 @@ void RosGzBridge::create_automated_bridges()
       }
       
     }
-    else if (direction == BridgeDirection::ROS_TO_GZ)
+    else if (direction == BridgeDirection::GZ_TO_ROS)
     {
       try
       {
@@ -554,7 +559,7 @@ void RosGzBridge::create_automated_bridges()
 
     if (!is_mapping_valid)
     {
-      RCLCPP_WARN(
+      RCLCPP_DEBUG(
         this->get_logger(),
         "Skipping automated bridge for topic [%s] for ROS message type "
         "[%s] with no known mapping to Gazebo message type [%s].",

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -426,7 +426,19 @@ void RosGzBridge::create_automated_bridges()
   std::map<std::string, std::vector<std::string>> ros_services;
   try
   {
-    ros_services = this->get_service_names_and_types();
+    const auto graph = this->get_node_graph_interface();
+    const auto nodes = graph->get_node_names_and_namespaces();
+
+    for (const auto & node : nodes)
+    {
+      const auto services =
+        graph->get_client_names_and_types_by_node(node.first, node.second);
+      for (const auto & service : services)
+      {
+        auto & types = ros_services[service.first];
+        types.insert(types.end(), service.second.begin(), service.second.end());
+      }
+    }
   }
   catch(const std::exception& e)
   {

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -360,54 +360,20 @@ void RosGzBridge::create_automated_bridges()
         break;
       }
     }
-    if (already_bridged) {
+    if (already_bridged) 
+    {
       continue;
     }
 
-    std::vector<gz::transport::MessagePublisher> gz_publishers;
-    std::vector<gz::transport::MessagePublisher> gz_subscribers;
-    if (!gz_node_->TopicInfo(gz_topic, gz_publishers, gz_subscribers)) {
-      continue;
-    }
-
-    std::unordered_set<std::string> gz_publisher_types;
-    for (const auto & pub : gz_publishers)
-    {
-      gz_publisher_types.insert(pub.MsgTypeName());
-    }
-    std::unordered_set<std::string> gz_subscriber_types;
-    for (const auto & sub : gz_subscribers)
-    {
-      gz_subscriber_types.insert(sub.MsgTypeName());
-    }
-
+    // Get Gazebo topic info
     BridgeDirection direction {BridgeDirection::NONE};
     std::string gz_type_name;
-    if ((gz_publisher_types.size() > 1 || gz_subscriber_types.size() > 1) ||
-        (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 0) ||
-        (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1 &&
-         *gz_publisher_types.begin() != *gz_subscriber_types.begin()))
+    if (!get_gz_topic_info(gz_topic, gz_type_name, direction))
     {
-      this->log_bridge_warning(
-        BridgeWarningType::GZ_TYPE_UNDETERMINED, gz_topic);
       continue;
     }
-    else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1)
-    {
-      gz_type_name = *gz_publisher_types.begin();
-      direction = BridgeDirection::BIDIRECTIONAL;
-    }
-    else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 0)
-    {
-      gz_type_name = *gz_publisher_types.begin();
-      direction = BridgeDirection::GZ_TO_ROS;
-    }
-    else if (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 1)
-    {
-      gz_type_name = *gz_subscriber_types.begin();
-      direction = BridgeDirection::ROS_TO_GZ;
-    }
 
+    // Get candidate ROS types for the Gazebo type
     std::vector<std::string> ros_candidate_types;
     if (!get_gz_to_ros_mapping(gz_type_name, ros_candidate_types))
     {
@@ -417,117 +383,11 @@ void RosGzBridge::create_automated_bridges()
       continue;
     }
 
+    // Get ROS topic info
     std::string ros_type_name;
-    if (direction == BridgeDirection::ROS_TO_GZ)
+    if (!get_ros_topic_info(gz_topic, ros_type_name, direction))
     {
-      try
-      {
-        auto publishers = this->get_publishers_info_by_topic(gz_topic);
-
-        std::unordered_set<std::string> ros_publisher_types;
-        for (const auto & pub : publishers)
-        {
-          ros_publisher_types.insert(pub.topic_type());
-        }
-        if (ros_publisher_types.size() == 1)
-        {
-          ros_type_name = *ros_publisher_types.begin();
-        }
-        else
-        {
-          continue;
-        }
-      }
-      catch(const std::exception& e)
-      {
-        this->log_bridge_warning(
-          BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, gz_topic,
-          "", "", e.what());
-        continue;
-      }
-      
-    }
-    else if (direction == BridgeDirection::GZ_TO_ROS)
-    {
-      try
-      {
-        auto subscribers = this->get_subscriptions_info_by_topic(gz_topic);
-
-        std::unordered_set<std::string> ros_subscriber_types;
-        for (const auto & sub : subscribers)
-        {
-          ros_subscriber_types.insert(sub.topic_type());
-        }
-        if (ros_subscriber_types.size() == 1)
-        {
-          ros_type_name = *ros_subscriber_types.begin();
-        }
-        else
-        {
-          continue;
-        }
-      }
-      catch(const std::exception& e)
-      {
-        this->log_bridge_warning(
-          BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, gz_topic,
-          "", "", e.what());
-        continue;
-      }
-    }
-    else if (direction == BridgeDirection::BIDIRECTIONAL)
-    {
-      try
-      {
-        auto publishers = this->get_publishers_info_by_topic(gz_topic);
-        auto subscribers = this->get_subscriptions_info_by_topic(gz_topic);
-
-        std::unordered_set<std::string> ros_publisher_types;
-        for (const auto & pub : publishers)
-        {
-          ros_publisher_types.insert(pub.topic_type());
-        }
-        std::unordered_set<std::string> ros_subscriber_types;
-        for (const auto & sub : subscribers)
-        {
-          ros_subscriber_types.insert(sub.topic_type());
-        }
-
-        if ((ros_publisher_types.size() > 1 || ros_subscriber_types.size() > 1) ||
-            (ros_publisher_types.size() == 0 && ros_subscriber_types.size() == 0))
-        {
-          continue;
-        }
-        else if (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 1)
-        {
-          if (*ros_publisher_types.begin() == *ros_subscriber_types.begin())
-          {
-            ros_type_name = *ros_publisher_types.begin();
-          }
-          else
-          {
-            continue;
-          }
-        }
-        else
-        {
-          if (ros_publisher_types.size() == 1)
-          {
-            ros_type_name = *ros_publisher_types.begin();
-          }
-          else
-          {
-            ros_type_name = *ros_subscriber_types.begin();
-          }
-        }
-      }
-      catch(const std::exception& e)
-      {
-        this->log_bridge_warning(
-          BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, gz_topic,
-          "", "", e.what());
-        continue;
-      }
+      continue;
     }
 
     bool is_mapping_valid = false;
@@ -556,6 +416,117 @@ void RosGzBridge::create_automated_bridges()
     config.direction = direction;
     this->add_bridge(config);
   }
+}
+
+bool RosGzBridge::get_gz_topic_info(const std::string & topic_name,
+  std::string & gz_type_name, BridgeDirection & direction)
+{
+  std::vector<gz::transport::MessagePublisher> gz_publishers;
+  std::vector<gz::transport::MessagePublisher> gz_subscribers;
+  if (!gz_node_->TopicInfo(topic_name, gz_publishers, gz_subscribers)) {
+    return false;
+  }
+
+  std::unordered_set<std::string> gz_publisher_types;
+  for (const auto & pub : gz_publishers)
+  {
+    gz_publisher_types.insert(pub.MsgTypeName());
+  }
+  std::unordered_set<std::string> gz_subscriber_types;
+  for (const auto & sub : gz_subscribers)
+  {
+    gz_subscriber_types.insert(sub.MsgTypeName());
+  }
+
+  if ((gz_publisher_types.size() > 1 || gz_subscriber_types.size() > 1) ||
+      (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 0) ||
+      (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1 &&
+       *gz_publisher_types.begin() != *gz_subscriber_types.begin()))
+  {
+    this->log_bridge_warning(
+      BridgeWarningType::GZ_TYPE_UNDETERMINED, topic_name);
+    return false;
+  }
+  else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1)
+  {
+    gz_type_name = *gz_publisher_types.begin();
+    direction = BridgeDirection::BIDIRECTIONAL;
+  }
+  else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 0)
+  {
+    gz_type_name = *gz_publisher_types.begin();
+    direction = BridgeDirection::GZ_TO_ROS;
+  }
+  else if (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 1)
+  {
+    gz_type_name = *gz_subscriber_types.begin();
+    direction = BridgeDirection::ROS_TO_GZ;
+  }
+  return true;
+}
+
+bool RosGzBridge::get_ros_topic_info (const std::string & topic_name,
+  std::string & ros_type_name, const BridgeDirection & direction)
+{
+  std::vector<rclcpp::TopicEndpointInfo> ros_publishers;
+  std::vector<rclcpp::TopicEndpointInfo> ros_subscribers;
+  try
+  {
+    if (direction == BridgeDirection::ROS_TO_GZ)
+    {
+      ros_publishers = this->get_publishers_info_by_topic(topic_name);
+    }
+    else if (direction == BridgeDirection::GZ_TO_ROS)
+    {
+      ros_subscribers = this->get_subscriptions_info_by_topic(topic_name);
+    }
+    else if (direction == BridgeDirection::BIDIRECTIONAL)
+    {
+      ros_publishers = this->get_publishers_info_by_topic(topic_name);
+      ros_subscribers = this->get_subscriptions_info_by_topic(topic_name);
+    }
+  }
+  catch(const std::exception& e)
+  {
+    this->log_bridge_warning(
+      BridgeWarningType::ROS_TYPE_DISCOVERED_FAILED, topic_name,
+      "", "", e.what());
+    return false;
+  }
+
+  std::unordered_set<std::string> ros_publisher_types;
+  for (const auto & pub : ros_publishers)
+  {
+    ros_publisher_types.insert(pub.topic_type());
+  }
+  std::unordered_set<std::string> ros_subscriber_types;
+  for (const auto & sub : ros_subscribers)
+  {
+    ros_subscriber_types.insert(sub.topic_type());
+  }
+
+  if ((ros_publisher_types.size() > 1 || ros_subscriber_types.size() > 1) ||
+      (ros_publisher_types.size() == 0 && ros_subscriber_types.size() == 0) ||
+      (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 1 &&
+       *ros_publisher_types.begin() != *ros_subscriber_types.begin()))
+  {
+    this->log_bridge_warning(
+      BridgeWarningType::ROS_TYPE_UNDETERMINED, topic_name);
+    return false;
+  }
+  else if (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 1)
+  {
+    ros_type_name = *ros_publisher_types.begin();
+  }
+  else if (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 0)
+  {
+    ros_type_name = *ros_publisher_types.begin();
+  }
+  else if (ros_publisher_types.size() == 0 && ros_subscriber_types.size() == 1)
+  {
+    ros_type_name = *ros_subscriber_types.begin();
+  }
+  return true;
 }
 
 void RosGzBridge::log_bridge_warning(

--- a/ros_gz_bridge/src/ros_gz_bridge.cpp
+++ b/ros_gz_bridge/src/ros_gz_bridge.cpp
@@ -21,6 +21,7 @@
 
 #include "bridge_handle_ros_to_gz.hpp"
 #include "bridge_handle_gz_to_ros.hpp"
+#include "get_mappings.hpp"
 
 #include <rclcpp/expand_topic_or_service_name.hpp>
 
@@ -39,6 +40,7 @@ RosGzBridge::RosGzBridge(const rclcpp::NodeOptions & options)
   this->declare_parameter<bool>("override_timestamps_with_wall_time", false);
   this->declare_parameter<std::string>("override_frame_id", "");
   this->declare_parameter("bridge_names", std::vector<std::string>());
+  this->declare_parameter("enable_automated_bridge", false);
   const auto names = this->get_parameter("bridge_names").as_string_array();
 
   using rclcpp::PARAMETER_STRING;
@@ -235,6 +237,13 @@ void RosGzBridge::spin()
       }
     }
   }
+
+  bool enable_automated_bridge = false;
+  this->get_parameter("enable_automated_bridge", enable_automated_bridge);
+  if (enable_automated_bridge) {
+    create_automated_bridges();
+  }
+
   for (auto & bridge : handles_) {
     bridge->Spin();
   }
@@ -334,6 +343,234 @@ void RosGzBridge::add_service_bridge(
   }
 }
 
+// TODO: Avoid flooding the log with repeated messages during retries.
+void RosGzBridge::create_automated_bridges()
+{
+  std::vector<std::string> gz_topics;
+  gz_node_->TopicList(gz_topics);
+
+  for (const auto & gz_topic : gz_topics)
+  {
+    // Skip topics that are already bridged
+    for (const auto & handle : handles_)
+    {
+      if (handle->GetConfig().gz_topic_name == gz_topic)
+      {
+        continue;
+      }
+    }
+
+    std::vector<gz::transport::MessagePublisher> gz_publishers;
+    std::vector<gz::transport::MessagePublisher> gz_subscribers;
+    if (!gz_node_->TopicInfo(gz_topic, gz_publishers, gz_subscribers)) {
+      continue;
+    }
+
+    std::unordered_set<std::string> gz_publisher_types;
+    for (const auto & pub : gz_publishers)
+    {
+      gz_publisher_types.insert(pub.MsgTypeName());
+    }
+    std::unordered_set<std::string> gz_subscriber_types;
+    for (const auto & sub : gz_subscribers)
+    {
+      gz_subscriber_types.insert(sub.MsgTypeName());
+    }
+
+    BridgeDirection direction {BridgeDirection::NONE};
+    std::string gz_type_name;
+    if (gz_publisher_types.size() > 1 || gz_subscriber_types.size() > 1)
+    {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Skipping automated bridge for topic [%s] for multiple "
+        "Gazebo message types.",
+        gz_topic.c_str());
+      continue;
+    }
+    else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 1)
+    {
+      gz_type_name = *gz_publisher_types.begin();
+      direction = BridgeDirection::BIDIRECTIONAL;
+    }
+    else if (gz_publisher_types.size() == 1 && gz_subscriber_types.size() == 0)
+    {
+      gz_type_name = *gz_publisher_types.begin();
+      direction = BridgeDirection::GZ_TO_ROS;
+    }
+    else if (gz_publisher_types.size() == 0 && gz_subscriber_types.size() == 1)
+    {
+      gz_type_name = *gz_subscriber_types.begin();
+      direction = BridgeDirection::ROS_TO_GZ;
+    }
+    else
+    {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Skipping automated bridge for topic [%s] for no Gazebo message "
+        "types discovered.", gz_topic.c_str());
+      continue;
+    }
+
+    std::vector<std::string> ros_candidate_types;
+    if (!get_gz_to_ros_mapping(gz_type_name, ros_candidate_types))
+    {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Skipping automated bridge for topic [%s] for Gazebo message type "
+        "[%s] with no known ROS message type mapping.",
+        gz_topic.c_str(), gz_type_name.c_str());
+      continue;
+    }
+
+    std::string ros_type_name;
+    if (direction == BridgeDirection::ROS_TO_GZ)
+    {
+      try
+      {
+        auto publishers = this->get_publishers_info_by_topic(gz_topic);
+
+        std::unordered_set<std::string> ros_publisher_types;
+        for (const auto & pub : publishers)
+        {
+          ros_publisher_types.insert(pub.topic_type());
+        }
+        if (ros_publisher_types.size() == 1)
+        {
+          ros_type_name = *ros_publisher_types.begin();
+        }
+        else
+        {
+          continue;
+        }
+      }
+      catch(const std::exception& e)
+      {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Skipping automated bridge for topic [%s] for ROS message type "
+          "discovery error: %s",
+          gz_topic.c_str(), e.what());
+        continue;
+      }
+      
+    }
+    else if (direction == BridgeDirection::ROS_TO_GZ)
+    {
+      try
+      {
+        auto subscribers = this->get_subscriptions_info_by_topic(gz_topic);
+
+        std::unordered_set<std::string> ros_subscriber_types;
+        for (const auto & sub : subscribers)
+        {
+          ros_subscriber_types.insert(sub.topic_type());
+        }
+        if (ros_subscriber_types.size() == 1)
+        {
+          ros_type_name = *ros_subscriber_types.begin();
+        }
+        else
+        {
+          continue;
+        }
+      }
+      catch(const std::exception& e)
+      {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Skipping automated bridge for topic [%s] for ROS message type "
+          "discovery error: %s",
+          gz_topic.c_str(), e.what());
+        continue;
+      }
+    }
+    else if (direction == BridgeDirection::BIDIRECTIONAL)
+    {
+      try
+      {
+        auto publishers = this->get_publishers_info_by_topic(gz_topic);
+        auto subscribers = this->get_subscriptions_info_by_topic(gz_topic);
+
+        std::unordered_set<std::string> ros_publisher_types;
+        for (const auto & pub : publishers)
+        {
+          ros_publisher_types.insert(pub.topic_type());
+        }
+        std::unordered_set<std::string> ros_subscriber_types;
+        for (const auto & sub : subscribers)
+        {
+          ros_subscriber_types.insert(sub.topic_type());
+        }
+
+        if ((ros_publisher_types.size() > 1 || ros_subscriber_types.size() > 1) ||
+            (ros_publisher_types.size() == 0 && ros_subscriber_types.size() == 0))
+        {
+          continue;
+        }
+        else if (ros_publisher_types.size() == 1 && ros_subscriber_types.size() == 1)
+        {
+          if (*ros_publisher_types.begin() == *ros_subscriber_types.begin())
+          {
+            ros_type_name = *ros_publisher_types.begin();
+          }
+          else
+          {
+            continue;
+          }
+        }
+        else
+        {
+          if (ros_publisher_types.size() == 1)
+          {
+            ros_type_name = *ros_publisher_types.begin();
+          }
+          else
+          {
+            ros_type_name = *ros_subscriber_types.begin();
+          }
+        }
+      }
+      catch(const std::exception& e)
+      {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Skipping automated bridge for topic [%s] for ROS message type "
+          "discovery error: %s",
+          gz_topic.c_str(), e.what());
+        continue;
+      }
+    }
+
+    bool is_mapping_valid = false;
+    for (const auto & candidate : ros_candidate_types)
+    {
+      if (candidate == ros_type_name)
+      {
+        is_mapping_valid = true;
+        break;
+      }
+    }
+
+    if (!is_mapping_valid)
+    {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Skipping automated bridge for topic [%s] for ROS message type "
+        "[%s] with no known mapping to Gazebo message type [%s].",
+        gz_topic.c_str(), ros_type_name.c_str(), gz_type_name.c_str());
+      continue;
+    }
+
+    BridgeConfig config;
+    config.ros_type_name = ros_type_name;
+    config.ros_topic_name = gz_topic;
+    config.gz_type_name = gz_type_name;
+    config.gz_topic_name = gz_topic;
+    config.direction = direction;
+    this->add_bridge(config);
+  }
+}
 }  // namespace ros_gz_bridge
 
 #include "rclcpp_components/register_node_macro.hpp"

--- a/ros_gz_bridge/test/automated_bridge.cpp
+++ b/ros_gz_bridge/test/automated_bridge.cpp
@@ -422,22 +422,33 @@ TEST_F(AutomatedBridgeTest, RosToGzWhenGzSubExist)
     std::make_shared<gz::msgs::StringMsg>(gz_sub.message()));
 }
 
-TEST_F(AutomatedBridgeTest, RosToGzSkipUntilGzSubAppear)
+TEST_F(AutomatedBridgeTest, RosToGzSkipUntilRosPubAppear)
 {
   const std::string topic_name = "/auto_ros_to_gz_late_sub";
-  RosPublisher<std_msgs::msg::String> ros_pub(this->ros_node_, topic_name);
+  GzSubscriber<gz::msgs::StringMsg> gz_sub(this->gz_node_, topic_name);
+  ASSERT_TRUE(gz_sub.subscribed());
 
   rclcpp::WallRate rate(20.0);
+
+  // Make sure Gazebo discovery has seen the subscriber.
+  for (int i = 0; i < 50; ++i) {
+    if (this->bridge_->check_gz_topic(topic_name)) {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(this->bridge_->check_gz_topic(topic_name));
 
   for (int i = 0; i < 5; ++i) {
     this->bridge_->create_automated_bridges();
     rate.sleep();
   }
-  // There is no Gazebo subscriber yet, so no bridge should be created.
+  // There is no ROS publisher yet, so no bridge should be created.
   EXPECT_EQ(0, this->bridge_->topic_bridge_count(topic_name));
 
-  GzSubscriber<gz::msgs::StringMsg> gz_sub(this->gz_node_, topic_name);
-  ASSERT_TRUE(gz_sub.subscribed());
+  RosPublisher<std_msgs::msg::String> ros_pub(this->ros_node_, topic_name);
 
   for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();

--- a/ros_gz_bridge/test/automated_bridge.cpp
+++ b/ros_gz_bridge/test/automated_bridge.cpp
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest.h>
+
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
+#include <gz/msgs/world_control.pb.h>
+
 #include <algorithm>
 #include <chrono>
 #include <future>
@@ -19,14 +25,8 @@
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
-
-#include <rclcpp/rclcpp.hpp>
-
-#include <gz/msgs/boolean.pb.h>
-#include <gz/msgs/stringmsg.pb.h>
-#include <gz/msgs/world_control.pb.h>
 #include <gz/transport.hh>
+#include <rclcpp/rclcpp.hpp>
 
 #include <ros_gz_bridge/ros_gz_bridge.hpp>
 #include <ros_gz_interfaces/srv/control_world.hpp>
@@ -61,10 +61,8 @@ public:
   size_t topic_bridge_count(const std::string & topic_name) const
   {
     size_t count = 0;
-    for (const auto & handle : this->handles_)
-    {
-      if (handle->GetConfig().gz_topic_name == topic_name)
-      {
+    for (const auto & handle : this->handles_) {
+      if (handle->GetConfig().gz_topic_name == topic_name) {
         ++count;
       }
     }
@@ -74,10 +72,8 @@ public:
   size_t service_bridge_count(const std::string & service_name) const
   {
     size_t count = 0;
-    for (const auto & service : this->services_)
-    {
-      if (service->get_service_name() == service_name)
-      {
+    for (const auto & service : this->services_) {
+      if (service->get_service_name() == service_name) {
         ++count;
       }
     }
@@ -283,8 +279,7 @@ protected:
     this->ros_node_.reset();
     this->bridge_.reset();
 
-    if (rclcpp::ok())
-    {
+    if (rclcpp::ok()) {
       rclcpp::shutdown();
     }
   }
@@ -302,8 +297,7 @@ TEST_F(AutomatedBridgeTest, GzToRosWhenRosSubExist)
 
   rclcpp::WallRate rate(20.0);
 
-  for (int i = 0; i < 50; ++i)
-  {
+  for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();
 
     if (this->bridge_->topic_bridge_count(topic_name) == 1) {
@@ -318,8 +312,7 @@ TEST_F(AutomatedBridgeTest, GzToRosWhenRosSubExist)
   gz::msgs::StringMsg msg;
   ros_gz_bridge::testing::createTestMsg(msg);
 
-  for (int i = 0; i < 50 && !ros_sub.received(); ++i)
-  {
+  for (int i = 0; i < 50 && !ros_sub.received(); ++i) {
     gz_pub.Publish(msg);
 
     rclcpp::spin_some(this->bridge_);
@@ -342,10 +335,8 @@ TEST_F(AutomatedBridgeTest, GzToRosSkipUntilRosSubAppear)
   rclcpp::WallRate rate(20.0);
 
   // Make sure Gazebo discovery has seen the publisher.
-  for (int i = 0; i < 50; ++i)
-  {
-    if (this->bridge_->check_gz_topic(topic_name))
-    {
+  for (int i = 0; i < 50; ++i) {
+    if (this->bridge_->check_gz_topic(topic_name)) {
       break;
     }
 
@@ -354,8 +345,7 @@ TEST_F(AutomatedBridgeTest, GzToRosSkipUntilRosSubAppear)
 
   ASSERT_TRUE(this->bridge_->check_gz_topic(topic_name));
 
-  for (int i = 0; i < 5; ++i)
-  {
+  for (int i = 0; i < 5; ++i) {
     this->bridge_->create_automated_bridges();
     rate.sleep();
   }
@@ -364,12 +354,10 @@ TEST_F(AutomatedBridgeTest, GzToRosSkipUntilRosSubAppear)
 
   RosSubscriber<std_msgs::msg::String> ros_sub(this->ros_node_, topic_name);
 
-  for (int i = 0; i < 50; ++i)
-  {
+  for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();
 
-    if (this->bridge_->topic_bridge_count(topic_name) == 1)
-    {
+    if (this->bridge_->topic_bridge_count(topic_name) == 1) {
       break;
     }
 
@@ -381,8 +369,7 @@ TEST_F(AutomatedBridgeTest, GzToRosSkipUntilRosSubAppear)
   gz::msgs::StringMsg msg;
   ros_gz_bridge::testing::createTestMsg(msg);
 
-  for (int i = 0; i < 50 && !ros_sub.received(); ++i)
-  {
+  for (int i = 0; i < 50 && !ros_sub.received(); ++i) {
     gz_pub.Publish(msg);
 
     rclcpp::spin_some(this->bridge_);
@@ -407,12 +394,10 @@ TEST_F(AutomatedBridgeTest, RosToGzWhenGzSubExist)
 
   rclcpp::WallRate rate(20.0);
 
-  for (int i = 0; i < 50; ++i)
-  {
+  for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();
 
-    if (this->bridge_->topic_bridge_count(topic_name) == 1)
-    {
+    if (this->bridge_->topic_bridge_count(topic_name) == 1) {
       break;
     }
 
@@ -424,8 +409,7 @@ TEST_F(AutomatedBridgeTest, RosToGzWhenGzSubExist)
   std_msgs::msg::String msg;
   ros_gz_bridge::testing::createTestMsg(msg);
 
-  for (int i = 0; i < 50 && !gz_sub.received(); ++i)
-  {
+  for (int i = 0; i < 50 && !gz_sub.received(); ++i) {
     ros_pub.Publish(msg);
     rclcpp::spin_some(this->bridge_);
 
@@ -440,13 +424,12 @@ TEST_F(AutomatedBridgeTest, RosToGzWhenGzSubExist)
 
 TEST_F(AutomatedBridgeTest, RosToGzSkipUntilGzSubAppear)
 {
-  const std::string topic_name ="/auto_ros_to_gz_late_sub";
+  const std::string topic_name = "/auto_ros_to_gz_late_sub";
   RosPublisher<std_msgs::msg::String> ros_pub(this->ros_node_, topic_name);
 
   rclcpp::WallRate rate(20.0);
 
-  for (int i = 0; i < 5; ++i)
-  {
+  for (int i = 0; i < 5; ++i) {
     this->bridge_->create_automated_bridges();
     rate.sleep();
   }
@@ -456,12 +439,10 @@ TEST_F(AutomatedBridgeTest, RosToGzSkipUntilGzSubAppear)
   GzSubscriber<gz::msgs::StringMsg> gz_sub(this->gz_node_, topic_name);
   ASSERT_TRUE(gz_sub.subscribed());
 
-  for (int i = 0; i < 50; ++i)
-  {
+  for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();
 
-    if (this->bridge_->topic_bridge_count(topic_name) == 1)
-    {
+    if (this->bridge_->topic_bridge_count(topic_name) == 1) {
       break;
     }
 
@@ -473,8 +454,7 @@ TEST_F(AutomatedBridgeTest, RosToGzSkipUntilGzSubAppear)
   std_msgs::msg::String msg;
   ros_gz_bridge::testing::createTestMsg(msg);
 
-  for (int i = 0; i < 50 && !gz_sub.received(); ++i)
-  {
+  for (int i = 0; i < 50 && !gz_sub.received(); ++i) {
     ros_pub.Publish(msg);
 
     rclcpp::spin_some(this->bridge_);
@@ -502,12 +482,10 @@ TEST_F(AutomatedBridgeTest, ServiceWhenRosClientExist)
 
   rclcpp::WallRate rate(20.0);
 
-  for (int i = 0; i < 50; ++i)
-  {
+  for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();
 
-    if (this->bridge_->service_bridge_count(service_name) == 1)
-    {
+    if (this->bridge_->service_bridge_count(service_name) == 1) {
       break;
     }
 
@@ -516,8 +494,7 @@ TEST_F(AutomatedBridgeTest, ServiceWhenRosClientExist)
 
   ASSERT_EQ(1, this->bridge_->service_bridge_count(service_name));
 
-  for (int i = 0; i < 50 && !ros_client.available(); ++i)
-  {
+  for (int i = 0; i < 50 && !ros_client.available(); ++i) {
     rate.sleep();
   }
 
@@ -525,13 +502,11 @@ TEST_F(AutomatedBridgeTest, ServiceWhenRosClientExist)
 
   auto future = ros_client.SendRequest();
 
-  for (int i = 0; i < 100; ++i)
-  {
+  for (int i = 0; i < 100; ++i) {
     rclcpp::spin_some(this->bridge_);
     rclcpp::spin_some(this->ros_node_);
 
-    if (future.wait_for(0s) == std::future_status::ready)
-    {
+    if (future.wait_for(0s) == std::future_status::ready) {
       break;
     }
 
@@ -559,10 +534,8 @@ TEST_F(AutomatedBridgeTest, ServiceSkipUntilRosClientAppear)
   rclcpp::WallRate rate(20.0);
 
   // Make sure the Gazebo service is visible.
-  for (int i = 0; i < 50; ++i)
-  {
-    if (this->bridge_->check_gz_service(service_name))
-    {
+  for (int i = 0; i < 50; ++i) {
+    if (this->bridge_->check_gz_service(service_name)) {
       break;
     }
 
@@ -571,8 +544,7 @@ TEST_F(AutomatedBridgeTest, ServiceSkipUntilRosClientAppear)
 
   ASSERT_TRUE(this->bridge_->check_gz_service(service_name));
 
-  for (int i = 0; i < 5; ++i)
-  {
+  for (int i = 0; i < 5; ++i) {
     this->bridge_->create_automated_bridges();
     rate.sleep();
   }
@@ -583,12 +555,10 @@ TEST_F(AutomatedBridgeTest, ServiceSkipUntilRosClientAppear)
   RosClient<ros_gz_interfaces::srv::ControlWorld>
     ros_client(this->ros_node_, service_name);
 
-  for (int i = 0; i < 50; ++i)
-  {
+  for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();
 
-    if (this->bridge_->service_bridge_count(service_name) == 1)
-    {
+    if (this->bridge_->service_bridge_count(service_name) == 1) {
       break;
     }
 
@@ -597,8 +567,7 @@ TEST_F(AutomatedBridgeTest, ServiceSkipUntilRosClientAppear)
 
   ASSERT_EQ(1, this->bridge_->service_bridge_count(service_name));
 
-  for (int i = 0; i < 50 && !ros_client.available(); ++i)
-  {
+  for (int i = 0; i < 50 && !ros_client.available(); ++i) {
     rate.sleep();
   }
 
@@ -606,13 +575,11 @@ TEST_F(AutomatedBridgeTest, ServiceSkipUntilRosClientAppear)
 
   auto future = ros_client.SendRequest();
 
-  for (int i = 0; i < 100; ++i)
-  {
+  for (int i = 0; i < 100; ++i) {
     rclcpp::spin_some(this->bridge_);
     rclcpp::spin_some(this->ros_node_);
 
-    if (future.wait_for(0s) == std::future_status::ready)
-    {
+    if (future.wait_for(0s) == std::future_status::ready) {
       break;
     }
 
@@ -638,12 +605,10 @@ TEST_F(AutomatedBridgeTest, AvoidDuplicateCreation)
 
   rclcpp::WallRate rate(20.0);
 
-  for (int i = 0; i < 50; ++i)
-  {
+  for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();
 
-    if (this->bridge_->topic_bridge_count(topic_name) == 1)
-    {
+    if (this->bridge_->topic_bridge_count(topic_name) == 1) {
       break;
     }
 
@@ -652,8 +617,7 @@ TEST_F(AutomatedBridgeTest, AvoidDuplicateCreation)
 
   ASSERT_EQ(1, this->bridge_->topic_bridge_count(topic_name));
 
-  for (int i = 0; i < 3; ++i)
-  {
+  for (int i = 0; i < 3; ++i) {
     this->bridge_->create_automated_bridges();
     rate.sleep();
   }
@@ -670,12 +634,10 @@ TEST_F(AutomatedBridgeTest, AvoidDuplicateCreation)
 
   ASSERT_TRUE(gz_server.advertised());
 
-  for (int i = 0; i < 50; ++i)
-  {
+  for (int i = 0; i < 50; ++i) {
     this->bridge_->create_automated_bridges();
 
-    if (this->bridge_->service_bridge_count(service_name) == 1)
-    {
+    if (this->bridge_->service_bridge_count(service_name) == 1) {
       break;
     }
 
@@ -684,8 +646,7 @@ TEST_F(AutomatedBridgeTest, AvoidDuplicateCreation)
 
   ASSERT_EQ(1, this->bridge_->service_bridge_count(service_name));
 
-  for (int i = 0; i < 3; ++i)
-  {
+  for (int i = 0; i < 3; ++i) {
     this->bridge_->create_automated_bridges();
     rate.sleep();
   }

--- a/ros_gz_bridge/test/automated_bridge.cpp
+++ b/ros_gz_bridge/test/automated_bridge.cpp
@@ -270,14 +270,25 @@ protected:
     rclcpp::init(0, nullptr);
 
     this->bridge_ = std::make_shared<TestableRosGzBridge>();
-
     this->ros_node_ = std::make_shared<rclcpp::Node>("automated_bridge_test");
+
+    this->bridge_executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+    this->ros_executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+
+    this->bridge_executor_->add_node(this->bridge_);
+    this->ros_executor_->add_node(this->ros_node_);
   }
 
   void TearDown() override
   {
-    this->ros_node_.reset();
+    this->bridge_executor_->remove_node(this->bridge_);
+    this->ros_executor_->remove_node(this->ros_node_);
+
+    this->bridge_executor_.reset();
+    this->ros_executor_.reset();
+
     this->bridge_.reset();
+    this->ros_node_.reset();
 
     if (rclcpp::ok()) {
       rclcpp::shutdown();
@@ -287,6 +298,9 @@ protected:
   std::shared_ptr<TestableRosGzBridge> bridge_;
   rclcpp::Node::SharedPtr ros_node_;
   gz::transport::Node gz_node_;
+
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> bridge_executor_;
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> ros_executor_;
 };
 
 TEST_F(AutomatedBridgeTest, GzToRosWhenRosSubExist)
@@ -315,8 +329,8 @@ TEST_F(AutomatedBridgeTest, GzToRosWhenRosSubExist)
   for (int i = 0; i < 50 && !ros_sub.received(); ++i) {
     gz_pub.Publish(msg);
 
-    rclcpp::spin_some(this->bridge_);
-    rclcpp::spin_some(this->ros_node_);
+    this->bridge_executor_->spin_some();
+    this->ros_executor_->spin_some();
 
     rate.sleep();
   }
@@ -372,8 +386,8 @@ TEST_F(AutomatedBridgeTest, GzToRosSkipUntilRosSubAppear)
   for (int i = 0; i < 50 && !ros_sub.received(); ++i) {
     gz_pub.Publish(msg);
 
-    rclcpp::spin_some(this->bridge_);
-    rclcpp::spin_some(this->ros_node_);
+    this->bridge_executor_->spin_some();
+    this->ros_executor_->spin_some();
 
     rate.sleep();
   }
@@ -411,7 +425,8 @@ TEST_F(AutomatedBridgeTest, RosToGzWhenGzSubExist)
 
   for (int i = 0; i < 50 && !gz_sub.received(); ++i) {
     ros_pub.Publish(msg);
-    rclcpp::spin_some(this->bridge_);
+
+    this->bridge_executor_->spin_some();
 
     rate.sleep();
   }
@@ -468,7 +483,7 @@ TEST_F(AutomatedBridgeTest, RosToGzSkipUntilRosPubAppear)
   for (int i = 0; i < 50 && !gz_sub.received(); ++i) {
     ros_pub.Publish(msg);
 
-    rclcpp::spin_some(this->bridge_);
+    this->bridge_executor_->spin_some();
 
     rate.sleep();
   }
@@ -514,8 +529,8 @@ TEST_F(AutomatedBridgeTest, ServiceWhenRosClientExist)
   auto future = ros_client.SendRequest();
 
   for (int i = 0; i < 100; ++i) {
-    rclcpp::spin_some(this->bridge_);
-    rclcpp::spin_some(this->ros_node_);
+    this->bridge_executor_->spin_some();
+    this->ros_executor_->spin_some();
 
     if (future.wait_for(0s) == std::future_status::ready) {
       break;
@@ -587,8 +602,8 @@ TEST_F(AutomatedBridgeTest, ServiceSkipUntilRosClientAppear)
   auto future = ros_client.SendRequest();
 
   for (int i = 0; i < 100; ++i) {
-    rclcpp::spin_some(this->bridge_);
-    rclcpp::spin_some(this->ros_node_);
+    this->bridge_executor_->spin_some();
+    this->ros_executor_->spin_some();
 
     if (future.wait_for(0s) == std::future_status::ready) {
       break;

--- a/ros_gz_bridge/test/automated_bridge.cpp
+++ b/ros_gz_bridge/test/automated_bridge.cpp
@@ -1,0 +1,694 @@
+// Copyright 2026 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
+#include <gz/msgs/world_control.pb.h>
+#include <gz/transport.hh>
+
+#include <ros_gz_bridge/ros_gz_bridge.hpp>
+#include <ros_gz_interfaces/srv/control_world.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include "bridge_handle.hpp"
+#include "utils/gz_test_msg.hpp"
+#include "utils/ros_test_msg.hpp"
+
+using namespace std::chrono_literals;
+
+class TestableRosGzBridge : public ros_gz_bridge::RosGzBridge
+{
+public:
+  explicit TestableRosGzBridge(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+  : RosGzBridge(options)
+  {
+  }
+
+  using RosGzBridge::create_automated_bridges;
+
+  size_t topic_bridge_count() const
+  {
+    return this->handles_.size();
+  }
+
+  size_t service_bridge_count() const
+  {
+    return this->services_.size();
+  }
+
+  size_t topic_bridge_count(const std::string & topic_name) const
+  {
+    size_t count = 0;
+    for (const auto & handle : this->handles_)
+    {
+      if (handle->GetConfig().gz_topic_name == topic_name)
+      {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  size_t service_bridge_count(const std::string & service_name) const
+  {
+    size_t count = 0;
+    for (const auto & service : this->services_)
+    {
+      if (service->get_service_name() == service_name)
+      {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  bool check_gz_topic(const std::string & topic_name) const
+  {
+    std::vector<std::string> topics;
+    this->gz_node_->TopicList(topics);
+
+    return std::find(topics.begin(), topics.end(), topic_name) != topics.end();
+  }
+
+  bool check_gz_service(const std::string & service_name) const
+  {
+    std::vector<std::string> services;
+    this->gz_node_->ServiceList(services);
+
+    return std::find(services.begin(), services.end(), service_name) != services.end();
+  }
+};
+
+template<typename T>
+class RosPublisher
+{
+public:
+  RosPublisher(const rclcpp::Node::SharedPtr & node, const std::string & topic_name)
+  {
+    this->pub_ = node->create_publisher<T>(topic_name, 10);
+  }
+
+  void Publish(const T & msg) const
+  {
+    this->pub_->publish(msg);
+  }
+
+private:
+  typename rclcpp::Publisher<T>::SharedPtr pub_;
+};
+
+template<typename T>
+class GzPublisher
+{
+public:
+  GzPublisher(gz::transport::Node & node, const std::string & topic_name)
+  {
+    this->pub_ = node.Advertise<T>(topic_name);
+  }
+
+  void Publish(const T & msg)
+  {
+    this->pub_.Publish(msg);
+  }
+
+private:
+  gz::transport::Node::Publisher pub_;
+};
+
+template<typename T>
+class RosSubscriber
+{
+public:
+  RosSubscriber(const rclcpp::Node::SharedPtr & node, const std::string & topic_name)
+  {
+    this->sub_ = node->create_subscription<T>(
+      topic_name,
+      10,
+      [this](const T & msg)
+      {
+        this->msg_ = msg;
+        this->received_ = true;
+      });
+  }
+
+  bool received() const
+  {
+    return this->received_;
+  }
+
+  T message() const
+  {
+    return this->msg_;
+  }
+
+private:
+  typename rclcpp::Subscription<T>::SharedPtr sub_;
+  bool received_{false};
+  T msg_;
+};
+
+template<typename T>
+class GzSubscriber
+{
+public:
+  GzSubscriber(gz::transport::Node & node, const std::string & topic_name)
+  {
+    this->subscribed_ = node.Subscribe(
+      topic_name, &GzSubscriber::OnMessage, this);
+  }
+
+  bool subscribed() const
+  {
+    return this->subscribed_;
+  }
+
+  bool received() const
+  {
+    return this->received_;
+  }
+
+  T message() const
+  {
+    return this->msg_;
+  }
+
+private:
+  void OnMessage(const T & msg)
+  {
+    this->msg_ = msg;
+    this->received_ = true;
+  }
+
+  bool subscribed_{false};
+  bool received_{false};
+  T msg_;
+};
+
+template<typename ReqT, typename RepT>
+class GzServer
+{
+public:
+  GzServer(gz::transport::Node & node, const std::string & service_name)
+  {
+    this->advertised_ = node.Advertise(
+      service_name,
+      &GzServer::HandleRequest,
+      this);
+  }
+
+  bool advertised() const
+  {
+    return this->advertised_;
+  }
+
+  bool called() const
+  {
+    return this->called_;
+  }
+
+private:
+  bool HandleRequest(const ReqT &, RepT & response)
+  {
+    response.set_data(true);
+    this->called_ = true;
+    return true;
+  }
+
+  bool advertised_{false};
+  bool called_{false};
+};
+
+template<typename T>
+class RosClient
+{
+public:
+  RosClient(const rclcpp::Node::SharedPtr & node, const std::string & service_name)
+  {
+    this->client_ = node->create_client<T>(service_name);
+  }
+
+  bool available() const
+  {
+    return this->client_->wait_for_service(0s);
+  }
+
+  auto SendRequest()
+  {
+    auto request =
+      std::make_shared<typename T::Request>();
+
+    return this->client_->async_send_request(request);
+  }
+
+private:
+  typename rclcpp::Client<T>::SharedPtr client_;
+};
+
+class AutomatedBridgeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    this->bridge_ = std::make_shared<TestableRosGzBridge>();
+
+    this->ros_node_ = std::make_shared<rclcpp::Node>("automated_bridge_test");
+  }
+
+  void TearDown() override
+  {
+    this->ros_node_.reset();
+    this->bridge_.reset();
+
+    if (rclcpp::ok())
+    {
+      rclcpp::shutdown();
+    }
+  }
+
+  std::shared_ptr<TestableRosGzBridge> bridge_;
+  rclcpp::Node::SharedPtr ros_node_;
+  gz::transport::Node gz_node_;
+};
+
+TEST_F(AutomatedBridgeTest, GzToRosWhenRosSubExist)
+{
+  const std::string topic_name = "/auto_gz_to_ros";
+  GzPublisher<gz::msgs::StringMsg> gz_pub(this->gz_node_, topic_name);
+  RosSubscriber<std_msgs::msg::String> ros_sub(this->ros_node_, topic_name);
+
+  rclcpp::WallRate rate(20.0);
+
+  for (int i = 0; i < 50; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+
+    if (this->bridge_->topic_bridge_count(topic_name) == 1) {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(1, this->bridge_->topic_bridge_count(topic_name));
+
+  gz::msgs::StringMsg msg;
+  ros_gz_bridge::testing::createTestMsg(msg);
+
+  for (int i = 0; i < 50 && !ros_sub.received(); ++i)
+  {
+    gz_pub.Publish(msg);
+
+    rclcpp::spin_some(this->bridge_);
+    rclcpp::spin_some(this->ros_node_);
+
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(ros_sub.received());
+
+  ros_gz_bridge::testing::compareTestMsg(
+    std::make_shared<std_msgs::msg::String>(ros_sub.message()));
+}
+
+TEST_F(AutomatedBridgeTest, GzToRosSkipUntilRosSubAppear)
+{
+  const std::string topic_name = "/auto_gz_to_ros_late_sub";
+  GzPublisher<gz::msgs::StringMsg> gz_pub(this->gz_node_, topic_name);
+
+  rclcpp::WallRate rate(20.0);
+
+  // Make sure Gazebo discovery has seen the publisher.
+  for (int i = 0; i < 50; ++i)
+  {
+    if (this->bridge_->check_gz_topic(topic_name))
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(this->bridge_->check_gz_topic(topic_name));
+
+  for (int i = 0; i < 5; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+    rate.sleep();
+  }
+  // There is no ROS subscriber yet, so no bridge should be created.
+  EXPECT_EQ(0, this->bridge_->topic_bridge_count(topic_name));
+
+  RosSubscriber<std_msgs::msg::String> ros_sub(this->ros_node_, topic_name);
+
+  for (int i = 0; i < 50; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+
+    if (this->bridge_->topic_bridge_count(topic_name) == 1)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(1, this->bridge_->topic_bridge_count(topic_name));
+
+  gz::msgs::StringMsg msg;
+  ros_gz_bridge::testing::createTestMsg(msg);
+
+  for (int i = 0; i < 50 && !ros_sub.received(); ++i)
+  {
+    gz_pub.Publish(msg);
+
+    rclcpp::spin_some(this->bridge_);
+    rclcpp::spin_some(this->ros_node_);
+
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(ros_sub.received());
+
+  ros_gz_bridge::testing::compareTestMsg(
+    std::make_shared<std_msgs::msg::String>(ros_sub.message()));
+}
+
+TEST_F(AutomatedBridgeTest, RosToGzWhenGzSubExist)
+{
+  const std::string topic_name = "/auto_ros_to_gz";
+  RosPublisher<std_msgs::msg::String> ros_pub(this->ros_node_, topic_name);
+  GzSubscriber<gz::msgs::StringMsg> gz_sub(this->gz_node_, topic_name);
+
+  ASSERT_TRUE(gz_sub.subscribed());
+
+  rclcpp::WallRate rate(20.0);
+
+  for (int i = 0; i < 50; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+
+    if (this->bridge_->topic_bridge_count(topic_name) == 1)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(1, this->bridge_->topic_bridge_count(topic_name));
+
+  std_msgs::msg::String msg;
+  ros_gz_bridge::testing::createTestMsg(msg);
+
+  for (int i = 0; i < 50 && !gz_sub.received(); ++i)
+  {
+    ros_pub.Publish(msg);
+    rclcpp::spin_some(this->bridge_);
+
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(gz_sub.received());
+
+  ros_gz_bridge::testing::compareTestMsg(
+    std::make_shared<gz::msgs::StringMsg>(gz_sub.message()));
+}
+
+TEST_F(AutomatedBridgeTest, RosToGzSkipUntilGzSubAppear)
+{
+  const std::string topic_name ="/auto_ros_to_gz_late_sub";
+  RosPublisher<std_msgs::msg::String> ros_pub(this->ros_node_, topic_name);
+
+  rclcpp::WallRate rate(20.0);
+
+  for (int i = 0; i < 5; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+    rate.sleep();
+  }
+  // There is no Gazebo subscriber yet, so no bridge should be created.
+  EXPECT_EQ(0, this->bridge_->topic_bridge_count(topic_name));
+
+  GzSubscriber<gz::msgs::StringMsg> gz_sub(this->gz_node_, topic_name);
+  ASSERT_TRUE(gz_sub.subscribed());
+
+  for (int i = 0; i < 50; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+
+    if (this->bridge_->topic_bridge_count(topic_name) == 1)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(1, this->bridge_->topic_bridge_count(topic_name));
+
+  std_msgs::msg::String msg;
+  ros_gz_bridge::testing::createTestMsg(msg);
+
+  for (int i = 0; i < 50 && !gz_sub.received(); ++i)
+  {
+    ros_pub.Publish(msg);
+
+    rclcpp::spin_some(this->bridge_);
+
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(gz_sub.received());
+
+  ros_gz_bridge::testing::compareTestMsg(
+    std::make_shared<gz::msgs::StringMsg>(gz_sub.message()));
+}
+
+TEST_F(AutomatedBridgeTest, ServiceWhenRosClientExist)
+{
+  const std::string service_name = "/auto_control_world";
+
+  GzServer<gz::msgs::WorldControl, gz::msgs::Boolean>
+    gz_server(this->gz_node_, service_name);
+
+  RosClient<ros_gz_interfaces::srv::ControlWorld>
+    ros_client(this->ros_node_, service_name);
+
+  ASSERT_TRUE(gz_server.advertised());
+
+  rclcpp::WallRate rate(20.0);
+
+  for (int i = 0; i < 50; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+
+    if (this->bridge_->service_bridge_count(service_name) == 1)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(1, this->bridge_->service_bridge_count(service_name));
+
+  for (int i = 0; i < 50 && !ros_client.available(); ++i)
+  {
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(ros_client.available());
+
+  auto future = ros_client.SendRequest();
+
+  for (int i = 0; i < 100; ++i)
+  {
+    rclcpp::spin_some(this->bridge_);
+    rclcpp::spin_some(this->ros_node_);
+
+    if (future.wait_for(0s) == std::future_status::ready)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(std::future_status::ready, future.wait_for(0s));
+
+  const auto response = future.get();
+
+  ASSERT_NE(nullptr, response);
+  EXPECT_TRUE(response->success);
+  EXPECT_TRUE(gz_server.called());
+}
+
+TEST_F(AutomatedBridgeTest, ServiceSkipUntilRosClientAppear)
+{
+  const std::string service_name = "/auto_control_world_late_client";
+
+  GzServer<gz::msgs::WorldControl, gz::msgs::Boolean>
+    gz_server(this->gz_node_, service_name);
+
+  ASSERT_TRUE(gz_server.advertised());
+
+  rclcpp::WallRate rate(20.0);
+
+  // Make sure the Gazebo service is visible.
+  for (int i = 0; i < 50; ++i)
+  {
+    if (this->bridge_->check_gz_service(service_name))
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(this->bridge_->check_gz_service(service_name));
+
+  for (int i = 0; i < 5; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+    rate.sleep();
+  }
+
+  // There is no ROS client yet, so no bridge should be created.
+  EXPECT_EQ(0, this->bridge_->service_bridge_count(service_name));
+
+  RosClient<ros_gz_interfaces::srv::ControlWorld>
+    ros_client(this->ros_node_, service_name);
+
+  for (int i = 0; i < 50; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+
+    if (this->bridge_->service_bridge_count(service_name) == 1)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(1, this->bridge_->service_bridge_count(service_name));
+
+  for (int i = 0; i < 50 && !ros_client.available(); ++i)
+  {
+    rate.sleep();
+  }
+
+  ASSERT_TRUE(ros_client.available());
+
+  auto future = ros_client.SendRequest();
+
+  for (int i = 0; i < 100; ++i)
+  {
+    rclcpp::spin_some(this->bridge_);
+    rclcpp::spin_some(this->ros_node_);
+
+    if (future.wait_for(0s) == std::future_status::ready)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(std::future_status::ready, future.wait_for(0s));
+
+  const auto response = future.get();
+
+  ASSERT_NE(nullptr, response);
+  EXPECT_TRUE(response->success);
+  EXPECT_TRUE(gz_server.called());
+}
+
+TEST_F(AutomatedBridgeTest, AvoidDuplicateCreation)
+{
+  const std::string topic_name = "/auto_no_duplicate_topic";
+
+  GzPublisher<gz::msgs::StringMsg> gz_pub(this->gz_node_, topic_name);
+
+  RosSubscriber<std_msgs::msg::String> ros_sub(this->ros_node_, topic_name);
+
+  rclcpp::WallRate rate(20.0);
+
+  for (int i = 0; i < 50; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+
+    if (this->bridge_->topic_bridge_count(topic_name) == 1)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(1, this->bridge_->topic_bridge_count(topic_name));
+
+  for (int i = 0; i < 3; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+    rate.sleep();
+  }
+
+  EXPECT_EQ(1, this->bridge_->topic_bridge_count(topic_name));
+
+  const std::string service_name = "/auto_no_duplicate_service";
+
+  GzServer<gz::msgs::WorldControl, gz::msgs::Boolean>
+    gz_server(this->gz_node_, service_name);
+
+  RosClient<ros_gz_interfaces::srv::ControlWorld>
+    ros_client(this->ros_node_, service_name);
+
+  ASSERT_TRUE(gz_server.advertised());
+
+  for (int i = 0; i < 50; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+
+    if (this->bridge_->service_bridge_count(service_name) == 1)
+    {
+      break;
+    }
+
+    rate.sleep();
+  }
+
+  ASSERT_EQ(1, this->bridge_->service_bridge_count(service_name));
+
+  for (int i = 0; i < 3; ++i)
+  {
+    this->bridge_->create_automated_bridges();
+    rate.sleep();
+  }
+
+  EXPECT_EQ(1, this->bridge_->service_bridge_count(service_name));
+}


### PR DESCRIPTION
# 🎉 New feature

Closes #849 

## Summary
This PR adds opt-in automated bridge discovery to `ros_gz_bridge`.

When `enable_automated_bridge` is set to `true`, `RosGzBridge` will periodically inspect Gazebo topics / services and the ROS graph, infer the bridge direction, validate the ROS<->Gazebo type mapping, and create bridges automatically once a compatible endpoint is detected on both sides.

The optional `automated_bridge_exclude_patterns` parameter accepts a list of regular expressions. Gazebo topics and services whose full names match any configured pattern are excluded from automated bridge discovery. Invalid regular expressions are reported as errors and ignored.

In addition to the bridge creation logic, this PR also:
  - Extends the mapping helpers to support one-to-many type lookups needed for automatic type resolution;
  - Avoids duplicate topic / service bridge creation during repeated discovery passes;
  - Deduplicates warning messages for unresolved or mismatched endpoints;
  - Adds dedicated tests covering topic bridging, service bridging, delayed subscriber / client discovery, and duplicate-prevention behavior.

Expected behavior:
  - No automated bridge is created until a matching ROS / Gazebo endpoint is actually discovered;
  - Topic bridges are created automatically for both `GZ->ROS` and `ROS->GZ` cases when the message types are compatible;
  - Service bridges are created automatically when a matching Gazebo service and ROS client are present;
  - Incompatible or ambiguous endpoints are skipped with a warning instead of creating an invalid bridge.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it
### Setup
A minimal test package is provided for this PR: https://github.com/azeey/gsoc2026_multirobot/tree/main/bridge/auto_bridge_test

The package contains a simple ROS 2 test node (`ros_pub_sub_node`), a Gazebo test world, and a launch file used to validate automated bridge creation in`ros_gz_bridge`.

---
The launch file:
  - Starts a custom Gazebo world with a diff-drive vehicle, IMU, and RGBD camera.
  - Starts `ros_gz_bridge` with `enable_automated_bridge:=true`.
  - Loads the `ros_pub_sub_node` test node after startup.

The launch file supports the following parameter:
  - `use_composition`: whether to load the test node as a composable node.
    - Default: `False`

---
The `ros_pub_sub_node` node can create:
  - ROS subscribers for `GZ->ROS` validation, such as `/clock`, `/imu`, `/rgbd_camera/camera_info`, `/rgbd_camera/depth_image`, `/rgbd_camera/image`, `/rgbd_camera/points`, `/model/vehicle/odometry`, and `/model/vehicle/tf`.
  - ROS publishers for `ROS->GZ` validation, such as `/model/vehicle/cmd_vel` and `/model/vehicle/enable`.
  - ROS service clients for automated service bridge validation, such as `/world/test_world/control`, `/world/test_world/remove`, `/world/test_world/create`, and `/world/test_world/set_pose`.

The `ros_pub_sub_node` is parameter-driven. For each test interface, the package can independently configure:
  - Whether the interface is enabled.
  - The ROS topic name or service name to use.

### Steps
1. Build & Source
2. Launch
    ``` bash
     ros2 launch auto_bridge_test auto_bridge_test.launch.py
    ```

### Expected result:
`ros_gz_bridge` creates automated bridges after the configured ROS-side endpoints are created by `ros_pub_sub_node`.
  
## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Codex(GPT-5.5)