### PR TITLE
Add entity_namespace support for spawned entities

### DIFF
--- a/ros_gz_sim/doc/executables.rst
+++ b/ros_gz_sim/doc/executables.rst
@@ -33,7 +33,13 @@ for argument parsing (``--helpshort`` for the full list).
        --world default \
        --file https://fuel.gazebosim.org/1.0/openrobotics/models/Gazebo \
        --name my_gazebo \
+       --ns my_gazebo \
        --x 0 --y 0 --z 0.5
+
+Use ``--ns`` to set the namespace for the spawned entity. If ``--ns`` is not
+set or is set to an empty string, the namespace behavior follows the source SDF
+file. The ``{name}`` placeholder is also supported and will be replaced by the
+final spawned entity name.
 
 ``create`` is preferred over ``spawn_entity`` when you already have a running
 Gazebo transport channel and do not want the ROS service layer.

--- a/ros_gz_sim/doc/launch_actions.rst
+++ b/ros_gz_sim/doc/launch_actions.rst
@@ -92,6 +92,7 @@ XML form
          world="default"
          file="$(find-pkg-share my_pkg)/models/robot.sdf"
          entity_name="robot"
+         entity_namespace="robot"
          x="0.0" y="0.0" z="0.5"
          yaw="1.5707"/>
    </launch>
@@ -107,6 +108,7 @@ Python form
        world='default',
        file='/path/to/robot.sdf',
        entity_name='robot',
+       entity_namespace='robot',
        x='0.0', y='0.0', z='0.5', yaw='1.5707',
    )
 
@@ -128,6 +130,11 @@ Arguments
 
 ``entity_name``
     Desired entity name in the simulation.
+
+``entity_namespace``
+    Namespace for the spawned entity. If empty or not set, the namespace
+    behavior follows the source SDF file. The ``{name}`` placeholder is also
+    supported and will be replaced by the final spawned entity name.
 
 ``allow_renaming``
     If ``true``, Gazebo appends a suffix when ``entity_name`` is already

--- a/ros_gz_sim/launch/gz_spawn_model.launch
+++ b/ros_gz_sim/launch/gz_spawn_model.launch
@@ -4,6 +4,7 @@
   <arg name="model_string" default="" />
   <arg name="topic" default="" />
   <arg name="entity_name" default="" />
+  <arg name="entity_namespace" default="" />
   <arg name="allow_renaming" default="False" />
   <arg name="x" default="" />
   <arg name="y" default="" />
@@ -17,6 +18,7 @@
     model_string="$(var model_string)"
     topic="$(var topic)"
     entity_name="$(var entity_name)"
+    entity_namespace="$(var entity_namespace)"
     allow_renaming="$(var allow_renaming)"
     x="$(var x)"
     y="$(var y)"

--- a/ros_gz_sim/launch/gz_spawn_model.launch.py
+++ b/ros_gz_sim/launch/gz_spawn_model.launch.py
@@ -15,46 +15,26 @@
 """Launch create to spawn models in gz sim."""
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, TextSubstitution
 from launch_ros.actions import Node
 
-_ENTITY_NAMESPACE_WAS_PROVIDED = '_entity_namespace_was_provided'
-
-def _capture_namespace_state(context):
-    if _ENTITY_NAMESPACE_WAS_PROVIDED not in context.launch_configurations:
-        context.launch_configurations[_ENTITY_NAMESPACE_WAS_PROVIDED] = str(
-            'entity_namespace' in context.launch_configurations
-        )
-    return []
-
-def _load_create_node(context):
-    parameters = {
-        'world': LaunchConfiguration('world'),
-        'file': LaunchConfiguration('file'),
-        'string': LaunchConfiguration('model_string'),
-        'topic': LaunchConfiguration('topic'),
-        'name': LaunchConfiguration('entity_name'),
-        'allow_renaming': LaunchConfiguration('allow_renaming'),
-        'x': LaunchConfiguration('x', default='0.0'),
-        'y': LaunchConfiguration('y', default='0.0'),
-        'z': LaunchConfiguration('z', default='0.0'),
-        'R': LaunchConfiguration('R', default='0.0'),
-        'P': LaunchConfiguration('P', default='0.0'),
-        'Y': LaunchConfiguration('Y', default='0.0'),
-    }
-
-    if context.launch_configurations[_ENTITY_NAMESPACE_WAS_PROVIDED] == 'True':
-        parameters['ns'] = LaunchConfiguration('entity_namespace')
-
-    return [Node(
-        package='ros_gz_sim',
-        executable='create',
-        output='screen',
-        parameters=[parameters],
-    )]
 
 def generate_launch_description():
+
+    world = LaunchConfiguration('world')
+    file = LaunchConfiguration('file')
+    model_string = LaunchConfiguration('model_string')
+    topic = LaunchConfiguration('topic')
+    entity_name = LaunchConfiguration('entity_name')
+    entity_namespace = LaunchConfiguration('entity_namespace')
+    allow_renaming = LaunchConfiguration('allow_renaming')
+    x = LaunchConfiguration('x', default='0.0')
+    y = LaunchConfiguration('y', default='0.0')
+    z = LaunchConfiguration('z', default='0.0')
+    roll = LaunchConfiguration('R', default='0.0')
+    pitch = LaunchConfiguration('P', default='0.0')
+    yaw = LaunchConfiguration('Y', default='0.0')
 
     declare_world_cmd = DeclareLaunchArgument(
         'world', default_value=TextSubstitution(text=''),
@@ -76,7 +56,7 @@ def generate_launch_description():
         description='Name of the entity'
     )
     declare_entity_namespace_cmd = DeclareLaunchArgument(
-        'entity_namespace', default_value='',
+        'entity_namespace', default_value=TextSubstitution(text=''),
         description='Namespace for the spawned entity.'
     )
     declare_allow_renaming_cmd = DeclareLaunchArgument(
@@ -84,11 +64,30 @@ def generate_launch_description():
         description='Whether the entity allows renaming or not'
     )
 
+    load_nodes = Node(
+        package='ros_gz_sim',
+        executable='create',
+        output='screen',
+        parameters=[{'world': world,
+                     'file': file,
+                     'string': model_string,
+                     'topic': topic,
+                     'name': entity_name,
+                     'ns': entity_namespace,
+                     'allow_renaming': allow_renaming,
+                     'x': x,
+                     'y': y,
+                     'z': z,
+                     'R': roll,
+                     'P': pitch,
+                     'Y': yaw,
+                     }],
+    )
+
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Declare the launch options
-    ld.add_action(OpaqueFunction(function=_capture_namespace_state))
     ld.add_action(declare_world_cmd)
     ld.add_action(declare_file_cmd)
     ld.add_action(declare_model_string_cmd)
@@ -97,6 +96,6 @@ def generate_launch_description():
     ld.add_action(declare_entity_namespace_cmd)
     ld.add_action(declare_allow_renaming_cmd)
     # Add the actions to launch all of the create nodes
-    ld.add_action(OpaqueFunction(function=_load_create_node))
+    ld.add_action(load_nodes)
 
     return ld

--- a/ros_gz_sim/launch/gz_spawn_model.launch.py
+++ b/ros_gz_sim/launch/gz_spawn_model.launch.py
@@ -15,25 +15,46 @@
 """Launch create to spawn models in gz sim."""
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration, TextSubstitution
 from launch_ros.actions import Node
 
+_ENTITY_NAMESPACE_WAS_PROVIDED = '_entity_namespace_was_provided'
+
+def _capture_namespace_state(context):
+    if _ENTITY_NAMESPACE_WAS_PROVIDED not in context.launch_configurations:
+        context.launch_configurations[_ENTITY_NAMESPACE_WAS_PROVIDED] = str(
+            'entity_namespace' in context.launch_configurations
+        )
+    return []
+
+def _load_create_node(context):
+    parameters = {
+        'world': LaunchConfiguration('world'),
+        'file': LaunchConfiguration('file'),
+        'string': LaunchConfiguration('model_string'),
+        'topic': LaunchConfiguration('topic'),
+        'name': LaunchConfiguration('entity_name'),
+        'allow_renaming': LaunchConfiguration('allow_renaming'),
+        'x': LaunchConfiguration('x', default='0.0'),
+        'y': LaunchConfiguration('y', default='0.0'),
+        'z': LaunchConfiguration('z', default='0.0'),
+        'R': LaunchConfiguration('R', default='0.0'),
+        'P': LaunchConfiguration('P', default='0.0'),
+        'Y': LaunchConfiguration('Y', default='0.0'),
+    }
+
+    if context.launch_configurations[_ENTITY_NAMESPACE_WAS_PROVIDED] == 'True':
+        parameters['ns'] = LaunchConfiguration('entity_namespace')
+
+    return [Node(
+        package='ros_gz_sim',
+        executable='create',
+        output='screen',
+        parameters=[parameters],
+    )]
 
 def generate_launch_description():
-
-    world = LaunchConfiguration('world')
-    file = LaunchConfiguration('file')
-    model_string = LaunchConfiguration('model_string')
-    topic = LaunchConfiguration('topic')
-    entity_name = LaunchConfiguration('entity_name')
-    allow_renaming = LaunchConfiguration('allow_renaming')
-    x = LaunchConfiguration('x', default='0.0')
-    y = LaunchConfiguration('y', default='0.0')
-    z = LaunchConfiguration('z', default='0.0')
-    roll = LaunchConfiguration('R', default='0.0')
-    pitch = LaunchConfiguration('P', default='0.0')
-    yaw = LaunchConfiguration('Y', default='0.0')
 
     declare_world_cmd = DeclareLaunchArgument(
         'world', default_value=TextSubstitution(text=''),
@@ -54,41 +75,28 @@ def generate_launch_description():
         'entity_name', default_value=TextSubstitution(text=''),
         description='Name of the entity'
     )
+    declare_entity_namespace_cmd = DeclareLaunchArgument(
+        'entity_namespace', default_value='',
+        description='Namespace for the spawned entity.'
+    )
     declare_allow_renaming_cmd = DeclareLaunchArgument(
         'allow_renaming', default_value='False',
         description='Whether the entity allows renaming or not'
-    )
-
-    load_nodes = Node(
-        package='ros_gz_sim',
-        executable='create',
-        output='screen',
-        parameters=[{'world': world,
-                     'file': file,
-                     'string': model_string,
-                     'topic': topic,
-                     'name': entity_name,
-                     'allow_renaming': allow_renaming,
-                     'x': x,
-                     'y': y,
-                     'z': z,
-                     'R': roll,
-                     'P': pitch,
-                     'Y': yaw,
-                     }],
     )
 
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Declare the launch options
+    ld.add_action(OpaqueFunction(function=_capture_namespace_state))
     ld.add_action(declare_world_cmd)
     ld.add_action(declare_file_cmd)
     ld.add_action(declare_model_string_cmd)
     ld.add_action(declare_topic_cmd)
     ld.add_action(declare_entity_name_cmd)
+    ld.add_action(declare_entity_namespace_cmd)
     ld.add_action(declare_allow_renaming_cmd)
     # Add the actions to launch all of the create nodes
-    ld.add_action(load_nodes)
+    ld.add_action(OpaqueFunction(function=_load_create_node))
 
     return ld

--- a/ros_gz_sim/launch/ros_gz_spawn_model.launch
+++ b/ros_gz_sim/launch/ros_gz_spawn_model.launch
@@ -13,6 +13,7 @@
   <arg name="model_string" default="" />
   <arg name="topic" default="" />
   <arg name="entity_name" default="" />
+  <arg name="entity_namespace" default="" />
   <arg name="allow_renaming" default="False" />
   <arg name="x" default="0.0" />
   <arg name="y" default="0.0" />
@@ -39,6 +40,7 @@
     model_string="$(var model_string)"
     topic="$(var topic)"
     entity_name="$(var entity_name)"
+    entity_namespace="$(var entity_namespace)"
     allow_renaming="$(var allow_renaming)"
     x="$(var x)"
     y="$(var y)"

--- a/ros_gz_sim/launch/ros_gz_spawn_model.launch.py
+++ b/ros_gz_sim/launch/ros_gz_spawn_model.launch.py
@@ -15,50 +15,12 @@
 """Launch gzsim + ros_gz_bridge in a component container."""
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, TextSubstitution
 from launch_ros.substitutions import FindPackageShare
 from ros_gz_bridge.actions import RosGzBridge
 
-_ENTITY_NAMESPACE_WAS_PROVIDED = '_entity_namespace_was_provided'
-
-def _capture_namespace_state(context):
-    if _ENTITY_NAMESPACE_WAS_PROVIDED not in context.launch_configurations:
-        context.launch_configurations[_ENTITY_NAMESPACE_WAS_PROVIDED] = str(
-            'entity_namespace' in context.launch_configurations
-        )
-    return []
-
-def _spawn_model_description(context):
-
-    arguments = [
-        ('world', LaunchConfiguration('world')),
-        ('file', LaunchConfiguration('file')),
-        ('model_string', LaunchConfiguration('model_string')),
-        ('topic', LaunchConfiguration('topic')),
-        ('entity_name', LaunchConfiguration('entity_name')),
-        ('allow_renaming', LaunchConfiguration('allow_renaming')),
-        ('x', LaunchConfiguration('x', default='0.0')),
-        ('y', LaunchConfiguration('y', default='0.0')),
-        ('z', LaunchConfiguration('z', default='0.0')),
-        ('R', LaunchConfiguration('R', default='0.0')),
-        ('P', LaunchConfiguration('P', default='0.0')),
-        ('Y', LaunchConfiguration('Y', default='0.0')),
-    ]
-
-    if context.launch_configurations[_ENTITY_NAMESPACE_WAS_PROVIDED] == 'True':
-        arguments.append(('entity_namespace', LaunchConfiguration('entity_namespace')))
-
-    spawn_model_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
-                                   'launch',
-                                   'gz_spawn_model.launch.py'])]),
-        launch_arguments=arguments,
-    )
-
-    return spawn_model_description
 
 def generate_launch_description():
 
@@ -71,6 +33,20 @@ def generate_launch_description():
     use_respawn = LaunchConfiguration('use_respawn')
     log_level = LaunchConfiguration('log_level')
     bridge_params = LaunchConfiguration('bridge_params')
+
+    world = LaunchConfiguration('world')
+    file = LaunchConfiguration('file')
+    model_string = LaunchConfiguration('model_string')
+    topic = LaunchConfiguration('topic')
+    entity_name = LaunchConfiguration('entity_name')
+    entity_namespace = LaunchConfiguration('entity_namespace')
+    allow_renaming = LaunchConfiguration('allow_renaming')
+    x = LaunchConfiguration('x', default='0.0')
+    y = LaunchConfiguration('y', default='0.0')
+    z = LaunchConfiguration('z', default='0.0')
+    roll = LaunchConfiguration('R', default='0.0')
+    pitch = LaunchConfiguration('P', default='0.0')
+    yaw = LaunchConfiguration('Y', default='0.0')
 
     declare_bridge_name_cmd = DeclareLaunchArgument(
         'bridge_name', description='Name of the bridge'
@@ -137,10 +113,12 @@ def generate_launch_description():
         'entity_name', default_value=TextSubstitution(text=''),
         description='Name of the entity'
     )
+
     declare_entity_namespace_cmd = DeclareLaunchArgument(
-        'entity_namespace', default_value='',
+        'entity_namespace', default_value=TextSubstitution(text=''),
         description='Namespace for the spawned entity.'
     )
+
     declare_allow_renaming_cmd = DeclareLaunchArgument(
         'allow_renaming', default_value='False',
         description='Whether the entity allows renaming or not'
@@ -158,11 +136,29 @@ def generate_launch_description():
         bridge_params=bridge_params,
     )
 
+    spawn_model_description = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
+                                   'launch',
+                                   'gz_spawn_model.launch.py'])]),
+        launch_arguments=[('world', world),
+                          ('file', file),
+                          ('model_string', model_string),
+                          ('topic', topic),
+                          ('entity_name', entity_name),
+                          ('entity_namespace', entity_namespace),
+                          ('allow_renaming', allow_renaming),
+                          ('x', x),
+                          ('y', y),
+                          ('z', z),
+                          ('R', roll),
+                          ('P', pitch),
+                          ('Y', yaw), ])
+
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Declare the launch options
-    ld.add_action(OpaqueFunction(function=_capture_namespace_state))
     ld.add_action(declare_bridge_name_cmd)
     ld.add_action(declare_config_file_cmd)
     ld.add_action(declare_container_name_cmd)
@@ -181,6 +177,6 @@ def generate_launch_description():
     ld.add_action(declare_allow_renaming_cmd)
     # Add the actions to launch all of the bridge + spawn_model nodes
     ld.add_action(ros_gz_bridge_action)
-    ld.add_action(OpaqueFunction(function=_spawn_model_description))
+    ld.add_action(spawn_model_description)
 
     return ld

--- a/ros_gz_sim/launch/ros_gz_spawn_model.launch.py
+++ b/ros_gz_sim/launch/ros_gz_spawn_model.launch.py
@@ -15,12 +15,50 @@
 """Launch gzsim + ros_gz_bridge in a component container."""
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, TextSubstitution
 from launch_ros.substitutions import FindPackageShare
 from ros_gz_bridge.actions import RosGzBridge
 
+_ENTITY_NAMESPACE_WAS_PROVIDED = '_entity_namespace_was_provided'
+
+def _capture_namespace_state(context):
+    if _ENTITY_NAMESPACE_WAS_PROVIDED not in context.launch_configurations:
+        context.launch_configurations[_ENTITY_NAMESPACE_WAS_PROVIDED] = str(
+            'entity_namespace' in context.launch_configurations
+        )
+    return []
+
+def _spawn_model_description(context):
+
+    arguments = [
+        ('world', LaunchConfiguration('world')),
+        ('file', LaunchConfiguration('file')),
+        ('model_string', LaunchConfiguration('model_string')),
+        ('topic', LaunchConfiguration('topic')),
+        ('entity_name', LaunchConfiguration('entity_name')),
+        ('allow_renaming', LaunchConfiguration('allow_renaming')),
+        ('x', LaunchConfiguration('x', default='0.0')),
+        ('y', LaunchConfiguration('y', default='0.0')),
+        ('z', LaunchConfiguration('z', default='0.0')),
+        ('R', LaunchConfiguration('R', default='0.0')),
+        ('P', LaunchConfiguration('P', default='0.0')),
+        ('Y', LaunchConfiguration('Y', default='0.0')),
+    ]
+
+    if context.launch_configurations[_ENTITY_NAMESPACE_WAS_PROVIDED] == 'True':
+        arguments.append(('entity_namespace', LaunchConfiguration('entity_namespace')))
+
+    spawn_model_description = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
+                                   'launch',
+                                   'gz_spawn_model.launch.py'])]),
+        launch_arguments=arguments,
+    )
+
+    return spawn_model_description
 
 def generate_launch_description():
 
@@ -33,19 +71,6 @@ def generate_launch_description():
     use_respawn = LaunchConfiguration('use_respawn')
     log_level = LaunchConfiguration('log_level')
     bridge_params = LaunchConfiguration('bridge_params')
-
-    world = LaunchConfiguration('world')
-    file = LaunchConfiguration('file')
-    model_string = LaunchConfiguration('model_string')
-    topic = LaunchConfiguration('topic')
-    entity_name = LaunchConfiguration('entity_name')
-    allow_renaming = LaunchConfiguration('allow_renaming')
-    x = LaunchConfiguration('x', default='0.0')
-    y = LaunchConfiguration('y', default='0.0')
-    z = LaunchConfiguration('z', default='0.0')
-    roll = LaunchConfiguration('R', default='0.0')
-    pitch = LaunchConfiguration('P', default='0.0')
-    yaw = LaunchConfiguration('Y', default='0.0')
 
     declare_bridge_name_cmd = DeclareLaunchArgument(
         'bridge_name', description='Name of the bridge'
@@ -112,7 +137,10 @@ def generate_launch_description():
         'entity_name', default_value=TextSubstitution(text=''),
         description='Name of the entity'
     )
-
+    declare_entity_namespace_cmd = DeclareLaunchArgument(
+        'entity_namespace', default_value='',
+        description='Namespace for the spawned entity.'
+    )
     declare_allow_renaming_cmd = DeclareLaunchArgument(
         'allow_renaming', default_value='False',
         description='Whether the entity allows renaming or not'
@@ -130,28 +158,11 @@ def generate_launch_description():
         bridge_params=bridge_params,
     )
 
-    spawn_model_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
-                                   'launch',
-                                   'gz_spawn_model.launch.py'])]),
-        launch_arguments=[('world', world),
-                          ('file', file),
-                          ('model_string', model_string),
-                          ('topic', topic),
-                          ('entity_name', entity_name),
-                          ('allow_renaming', allow_renaming),
-                          ('x', x),
-                          ('y', y),
-                          ('z', z),
-                          ('R', roll),
-                          ('P', pitch),
-                          ('Y', yaw), ])
-
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Declare the launch options
+    ld.add_action(OpaqueFunction(function=_capture_namespace_state))
     ld.add_action(declare_bridge_name_cmd)
     ld.add_action(declare_config_file_cmd)
     ld.add_action(declare_container_name_cmd)
@@ -166,9 +177,10 @@ def generate_launch_description():
     ld.add_action(declare_model_string_cmd)
     ld.add_action(declare_topic_cmd)
     ld.add_action(declare_entity_name_cmd)
+    ld.add_action(declare_entity_namespace_cmd)
     ld.add_action(declare_allow_renaming_cmd)
     # Add the actions to launch all of the bridge + spawn_model nodes
     ld.add_action(ros_gz_bridge_action)
-    ld.add_action(spawn_model_description)
+    ld.add_action(OpaqueFunction(function=_spawn_model_description))
 
     return ld

--- a/ros_gz_sim/ros_gz_sim/actions/gz_spawn_model.py
+++ b/ros_gz_sim/ros_gz_sim/actions/gz_spawn_model.py
@@ -39,6 +39,7 @@ class GzSpawnModel(Action):
         model_string: Optional[SomeSubstitutionsType] = '',
         topic: Optional[SomeSubstitutionsType] = '',
         entity_name: Optional[SomeSubstitutionsType] = '',
+        entity_namespace: Optional[SomeSubstitutionsType] = '',
         allow_renaming: Optional[SomeSubstitutionsType] = 'False',
         x: Optional[SomeSubstitutionsType] = '0.0',
         y: Optional[SomeSubstitutionsType] = '0.0',
@@ -59,6 +60,7 @@ class GzSpawnModel(Action):
         :param: model_string XML(SDF) string.
         :param: topic Get XML from this topic.
         :param: entity_name Name of the entity.
+        :param: entity_namespace Namespace for the spawned entity.
         :param: allow_renaming Whether the entity allows renaming or not.
         :param: x X coordinate.
         :param: y Y coordinate.
@@ -73,6 +75,7 @@ class GzSpawnModel(Action):
         self.__model_string = model_string
         self.__topic = topic
         self.__entity_name = entity_name
+        self.__entity_namespace = entity_namespace
         self.__allow_renaming = allow_renaming
         self.__x = x
         self.__y = y
@@ -108,6 +111,10 @@ class GzSpawnModel(Action):
 
         allow_renaming = entity.get_attr(
             'allow_renaming', data_type=str,
+            optional=True)
+
+        entity_namespace = entity.get_attr(
+            'entity_namespace', data_type=str,
             optional=True)
 
         x = entity.get_attr(
@@ -158,6 +165,10 @@ class GzSpawnModel(Action):
             allow_renaming = parser.parse_substitution(allow_renaming)
             kwargs['allow_renaming'] = allow_renaming
 
+        if isinstance(entity_namespace, str):
+            entity_namespace = parser.parse_substitution(entity_namespace)
+            kwargs['entity_namespace'] = entity_namespace
+
         if isinstance(x, str):
             x = parser.parse_substitution(x)
             kwargs['x'] = x
@@ -186,22 +197,28 @@ class GzSpawnModel(Action):
 
     def execute(self, context: LaunchContext) -> Optional[List[Action]]:
         """Execute the action."""
+        launch_arguments = [
+            ('world', self.__world),
+            ('file', self.__file),
+            ('model_string', self.__model_string),
+            ('topic', self.__topic),
+            ('entity_name', self.__entity_name),
+            ('allow_renaming', self.__allow_renaming),
+            ('x', self.__x),
+            ('y', self.__y),
+            ('z', self.__z),
+            ('roll', self.__roll),
+            ('pitch', self.__pitch),
+            ('yaw', self.__yaw),
+        ]
+        if self.__entity_namespace is not None:
+            launch_arguments.append(('entity_namespace', self.__entity_namespace))
+
         gz_spawn_model_description = IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
                 [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
                                        'launch',
                                        'gz_spawn_model.launch.py'])]),
-            launch_arguments=[('world', self.__world),
-                              ('file', self.__file),
-                              ('model_string',   self.__model_string),
-                              ('topic',  self.__topic),
-                              ('entity_name', self.__entity_name),
-                              ('allow_renaming', self.__allow_renaming),
-                              ('x',   self.__x),
-                              ('y',  self.__y),
-                              ('z', self.__z),
-                              ('roll', self.__roll),
-                              ('pitch',   self.__pitch),
-                              ('yaw',  self.__yaw), ])
+            launch_arguments=launch_arguments)
 
         return [gz_spawn_model_description]

--- a/ros_gz_sim/ros_gz_sim/actions/gz_spawn_model.py
+++ b/ros_gz_sim/ros_gz_sim/actions/gz_spawn_model.py
@@ -197,28 +197,24 @@ class GzSpawnModel(Action):
 
     def execute(self, context: LaunchContext) -> Optional[List[Action]]:
         """Execute the action."""
-        launch_arguments = [
-            ('world', self.__world),
-            ('file', self.__file),
-            ('model_string', self.__model_string),
-            ('topic', self.__topic),
-            ('entity_name', self.__entity_name),
-            ('allow_renaming', self.__allow_renaming),
-            ('x', self.__x),
-            ('y', self.__y),
-            ('z', self.__z),
-            ('roll', self.__roll),
-            ('pitch', self.__pitch),
-            ('yaw', self.__yaw),
-        ]
-        if self.__entity_namespace is not None:
-            launch_arguments.append(('entity_namespace', self.__entity_namespace))
-
         gz_spawn_model_description = IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
                 [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
                                        'launch',
                                        'gz_spawn_model.launch.py'])]),
-            launch_arguments=launch_arguments)
+            launch_arguments=[('world', self.__world),
+                              ('file', self.__file),
+                              ('model_string',   self.__model_string),
+                              ('topic',  self.__topic),
+                              ('entity_name', self.__entity_name),
+                              ('entity_namespace', self.__entity_namespace),
+                              ('allow_renaming', self.__allow_renaming),
+                              ('x',   self.__x),
+                              ('y',  self.__y),
+                              ('z', self.__z),
+                              ('roll', self.__roll),
+                              ('pitch',   self.__pitch),
+                              ('yaw',  self.__yaw)])
+
 
         return [gz_spawn_model_description]

--- a/ros_gz_sim/ros_gz_sim/actions/gz_spawn_model.py
+++ b/ros_gz_sim/ros_gz_sim/actions/gz_spawn_model.py
@@ -216,5 +216,4 @@ class GzSpawnModel(Action):
                               ('pitch',   self.__pitch),
                               ('yaw',  self.__yaw)])
 
-
         return [gz_spawn_model_description]

--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -261,9 +261,9 @@ int main(int _argc, char ** _argv)
   // Namespace
   std::string ns = ros2_node->get_parameter("ns").as_string();
   if (!ns.empty()) {
-    req.set_namespace_(ns);
+    req.set_entity_namespace(ns);
   } else if (!FLAGS_ns.empty()) {
-    req.set_namespace_(FLAGS_ns);
+    req.set_entity_namespace(FLAGS_ns);
   }
 
   // Allow Renaming

--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -16,7 +16,7 @@
 
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/entity.pb.h>
-#include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/entity_factory_with_ns.pb.h>
 #include <gz/msgs/stringmsg_v.pb.h>
 
 #include <sstream>
@@ -58,7 +58,7 @@ DEFINE_double(Y, 0, "Yaw component of initial orientation, in radians.");
 
 bool set_XML_from_topic(
   const std::string & topic_name, const rclcpp::Node::SharedPtr ros2_node,
-  gz::msgs::EntityFactory & req)
+  gz::msgs::EntityFactoryWithNs & req)
 {
   const auto timeout = std::chrono::seconds(1);
   std::promise<std::string> xml_promise;
@@ -179,10 +179,10 @@ int main(int _argc, char ** _argv)
       world_name.c_str());
   }
 
-  std::string service{"/world/" + world_name + "/create"};
+  std::string service{"/world/" + world_name + "/create_with_ns"};
 
   // Request message
-  gz::msgs::EntityFactory req;
+  gz::msgs::EntityFactoryWithNs req;
 
   // Get ROS parameters
   std::string file_name = ros2_node->get_parameter("file").as_string();

--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -16,7 +16,6 @@
 
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/entity.pb.h>
-#include <gz/msgs/entity_factory.pb.h>
 #include <gz/msgs/entity_factory_with_ns.pb.h>
 #include <gz/msgs/stringmsg_v.pb.h>
 
@@ -59,7 +58,7 @@ DEFINE_double(Y, 0, "Yaw component of initial orientation, in radians.");
 
 bool set_XML_from_topic(
   const std::string & topic_name, const rclcpp::Node::SharedPtr ros2_node,
-  gz::msgs::EntityFactory & req)
+  gz::msgs::EntityFactoryWithNs & req)
 {
   const auto timeout = std::chrono::seconds(1);
   std::promise<std::string> xml_promise;
@@ -109,10 +108,11 @@ int main(int _argc, char ** _argv)
     snprintf(
       filtered_argv[ii],
       filtered_arguments[ii].size() + 1, "%s", filtered_arguments[ii].c_str());
-      
+
     if (filtered_arguments[ii] == "-ns" || filtered_arguments[ii] == "--ns" ||
-        filtered_arguments[ii].rfind("-ns=") == 0 ||
-        filtered_arguments[ii].rfind("--ns=") == 0) {
+      filtered_arguments[ii].rfind("-ns=") == 0 ||
+      filtered_arguments[ii].rfind("--ns=") == 0)
+    {
       has_ns_arg = true;
     }
   }
@@ -187,16 +187,10 @@ int main(int _argc, char ** _argv)
       world_name.c_str());
   }
 
-  std::string service;
-  if (has_ns_arg) {
-    service = "/world/" + world_name + "/create_with_ns";
-  } else {
-    service = "/world/" + world_name + "/create";
-  }
+  std::string service{"/world/" + world_name + "/create_with_ns"};
 
   // Request message
-  gz::msgs::EntityFactory req;
-  gz::msgs::EntityFactoryWithNs req_with_ns;
+  gz::msgs::EntityFactoryWithNs req;
 
   // Get ROS parameters
   std::string file_name = ros2_node->get_parameter("file").as_string();
@@ -277,12 +271,11 @@ int main(int _argc, char ** _argv)
   req.set_allow_renaming((allow_renaming || FLAGS_allow_renaming));
 
   if (has_ns_arg) {
-    req_with_ns.ParseFromString(req.SerializeAsString());
     std::string ns = ros2_node->get_parameter("ns").as_string();
     if (!ns.empty()) {
-      req_with_ns.mutable_namespace_()->set_data(ns);
+      req.mutable_namespace_()->set_data(ns);
     } else {
-      req_with_ns.mutable_namespace_()->set_data(FLAGS_ns);
+      req.mutable_namespace_()->set_data(FLAGS_ns);
     }
   }
 
@@ -293,30 +286,20 @@ int main(int _argc, char ** _argv)
   unsigned int timeout = 5000;
 
   while(rclcpp::ok()) {
-    bool executed = false;
-    std::string debugString;
-    if (has_ns_arg) {
-      executed = node.Request(service, req_with_ns, timeout, rep, result);
-      debugString = req_with_ns.DebugString();
-    } else {
-      executed = node.Request(service, req, timeout, rep, result);
-      debugString = req.DebugString();
-    }
-
-    if (executed) {
+    if (node.Request(service, req, timeout, rep, result)) {
       if (result && rep.data()) {
         RCLCPP_INFO(ros2_node->get_logger(), "Entity creation successful.");
         return 0;
       } else {
         RCLCPP_ERROR(
           ros2_node->get_logger(), "Entity creation failed.\n %s",
-          debugString.c_str());
+          req.DebugString().c_str());
         return 1;
       }
     } else {
       RCLCPP_WARN(
         ros2_node->get_logger(), "Waiting for service [%s] to become available ...",
-        debugString.c_str());
+        req.DebugString().c_str());
     }
   }
   RCLCPP_INFO(ros2_node->get_logger(), "Entity creation was interrupted.");

--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -100,7 +100,6 @@ int main(int _argc, char ** _argv)
   // Construct a new argc/argv pair from the flags that weren't parsed by ROS
   // Gflags wants a mutable pointer to argv, which is why we can't use a
   // vector of strings here
-  bool has_ns_arg = false;
   int filtered_argc = filtered_arguments.size();
   char ** filtered_argv = new char *[(filtered_argc + 1)];
   for (int ii = 0; ii < filtered_argc; ++ii) {
@@ -108,13 +107,6 @@ int main(int _argc, char ** _argv)
     snprintf(
       filtered_argv[ii],
       filtered_arguments[ii].size() + 1, "%s", filtered_arguments[ii].c_str());
-
-    if (filtered_arguments[ii] == "-ns" || filtered_arguments[ii] == "--ns" ||
-      filtered_arguments[ii].rfind("-ns=") == 0 ||
-      filtered_arguments[ii].rfind("--ns=") == 0)
-    {
-      has_ns_arg = true;
-    }
   }
   filtered_argv[filtered_argc] = nullptr;
 
@@ -145,10 +137,6 @@ int main(int _argc, char ** _argv)
   ros2_node->declare_parameter("R", static_cast<double>(0));
   ros2_node->declare_parameter("P", static_cast<double>(0));
   ros2_node->declare_parameter("Y", static_cast<double>(0));
-
-  const auto & parameter_overrides =
-    ros2_node->get_node_parameters_interface()->get_parameter_overrides();
-  const bool has_ns_param = parameter_overrides.find("ns") != parameter_overrides.end();
 
   auto always_shutdown = rcpputils::make_scope_exit(
     []() {rclcpp::shutdown();});
@@ -270,18 +258,17 @@ int main(int _argc, char ** _argv)
     req.set_name(FLAGS_name);
   }
 
+  // Namespace
+  std::string ns = ros2_node->get_parameter("ns").as_string();
+  if (!ns.empty()) {
+    req.set_namespace_(ns);
+  } else if (!FLAGS_ns.empty()) {
+    req.set_namespace_(FLAGS_ns);
+  }
+
   // Allow Renaming
   bool allow_renaming = ros2_node->get_parameter("allow_renaming").as_bool();
   req.set_allow_renaming((allow_renaming || FLAGS_allow_renaming));
-
-  if (has_ns_arg || has_ns_param) {
-    std::string ns = ros2_node->get_parameter("ns").as_string();
-    if (!ns.empty()) {
-      req.mutable_namespace_()->set_data(ns);
-    } else {
-      req.mutable_namespace_()->set_data(FLAGS_ns);
-    }
-  }
 
   // Request
   gz::transport::Node node;
@@ -303,7 +290,7 @@ int main(int _argc, char ** _argv)
     } else {
       RCLCPP_WARN(
         ros2_node->get_logger(), "Waiting for service [%s] to become available ...",
-        req.DebugString().c_str());
+        service.c_str());
     }
   }
   RCLCPP_INFO(ros2_node->get_logger(), "Entity creation was interrupted.");

--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -17,6 +17,7 @@
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/entity.pb.h>
 #include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/entity_factory_with_ns.pb.h>
 #include <gz/msgs/stringmsg_v.pb.h>
 
 #include <sstream>
@@ -45,6 +46,7 @@ DEFINE_string(param, "", "Load XML from a ROS param.");
 DEFINE_string(string, "", "Load XML from a string.");
 DEFINE_string(topic, "", "Load XML from a ROS string publisher.");
 DEFINE_string(name, "", "Name for spawned entity.");
+DEFINE_string(ns, "", "Namespace for spawned entity.");
 DEFINE_bool(allow_renaming, false, "Rename entity if name already used.");
 DEFINE_double(x, 0, "X component of initial position, in meters.");
 DEFINE_double(y, 0, "Y component of initial position, in meters.");
@@ -99,6 +101,7 @@ int main(int _argc, char ** _argv)
   // Construct a new argc/argv pair from the flags that weren't parsed by ROS
   // Gflags wants a mutable pointer to argv, which is why we can't use a
   // vector of strings here
+  bool has_ns_arg = false;
   int filtered_argc = filtered_arguments.size();
   char ** filtered_argv = new char *[(filtered_argc + 1)];
   for (int ii = 0; ii < filtered_argc; ++ii) {
@@ -106,13 +109,19 @@ int main(int _argc, char ** _argv)
     snprintf(
       filtered_argv[ii],
       filtered_arguments[ii].size() + 1, "%s", filtered_arguments[ii].c_str());
+      
+    if (filtered_arguments[ii] == "-ns" || filtered_arguments[ii] == "--ns" ||
+        filtered_arguments[ii].rfind("-ns=") == 0 ||
+        filtered_arguments[ii].rfind("--ns=") == 0) {
+      has_ns_arg = true;
+    }
   }
   filtered_argv[filtered_argc] = nullptr;
 
   gflags::AllowCommandLineReparsing();
   gflags::SetUsageMessage(
     R"(Usage: create -world [arg] [-file FILE] [-param PARAM] [-topic TOPIC]
-                       [-string STRING] [-name NAME] [-allow_renaming RENAMING] [-x X] [-y Y] [-z Z]
+                       [-string STRING] [-name NAME] [-ns NAMESPACE] [-allow_renaming RENAMING] [-x X] [-y Y] [-z Z]
                        [-R ROLL] [-P PITCH] [-Y YAW])");
   gflags::ParseCommandLineFlags(&filtered_argc, &filtered_argv, false);
 
@@ -128,6 +137,7 @@ int main(int _argc, char ** _argv)
   ros2_node->declare_parameter("string", "");
   ros2_node->declare_parameter("topic", "");
   ros2_node->declare_parameter("name", "");
+  ros2_node->declare_parameter("ns", "");
   ros2_node->declare_parameter("allow_renaming", false);
   ros2_node->declare_parameter("x", static_cast<double>(0));
   ros2_node->declare_parameter("y", static_cast<double>(0));
@@ -176,10 +186,17 @@ int main(int _argc, char ** _argv)
       "World name was not provided. Using [%s] as the default world.",
       world_name.c_str());
   }
-  std::string service{"/world/" + world_name + "/create"};
+
+  std::string service;
+  if (has_ns_arg) {
+    service = "/world/" + world_name + "/create_with_ns";
+  } else {
+    service = "/world/" + world_name + "/create";
+  }
 
   // Request message
   gz::msgs::EntityFactory req;
+  gz::msgs::EntityFactoryWithNs req_with_ns;
 
   // Get ROS parameters
   std::string file_name = ros2_node->get_parameter("file").as_string();
@@ -259,6 +276,16 @@ int main(int _argc, char ** _argv)
   bool allow_renaming = ros2_node->get_parameter("allow_renaming").as_bool();
   req.set_allow_renaming((allow_renaming || FLAGS_allow_renaming));
 
+  if (has_ns_arg) {
+    req_with_ns.ParseFromString(req.SerializeAsString());
+    std::string ns = ros2_node->get_parameter("ns").as_string();
+    if (!ns.empty()) {
+      req_with_ns.mutable_namespace_()->set_data(ns);
+    } else {
+      req_with_ns.mutable_namespace_()->set_data(FLAGS_ns);
+    }
+  }
+
   // Request
   gz::transport::Node node;
   gz::msgs::Boolean rep;
@@ -266,20 +293,30 @@ int main(int _argc, char ** _argv)
   unsigned int timeout = 5000;
 
   while(rclcpp::ok()) {
-    if (node.Request(service, req, timeout, rep, result)) {
+    bool executed = false;
+    std::string debugString;
+    if (has_ns_arg) {
+      executed = node.Request(service, req_with_ns, timeout, rep, result);
+      debugString = req_with_ns.DebugString();
+    } else {
+      executed = node.Request(service, req, timeout, rep, result);
+      debugString = req.DebugString();
+    }
+
+    if (executed) {
       if (result && rep.data()) {
         RCLCPP_INFO(ros2_node->get_logger(), "Entity creation successful.");
         return 0;
       } else {
         RCLCPP_ERROR(
           ros2_node->get_logger(), "Entity creation failed.\n %s",
-          req.DebugString().c_str());
+          debugString.c_str());
         return 1;
       }
     } else {
       RCLCPP_WARN(
         ros2_node->get_logger(), "Waiting for service [%s] to become available ...",
-        service.c_str());
+        debugString.c_str());
     }
   }
   RCLCPP_INFO(ros2_node->get_logger(), "Entity creation was interrupted.");

--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -16,7 +16,7 @@
 
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/entity.pb.h>
-#include <gz/msgs/entity_factory_with_ns.pb.h>
+#include <gz/msgs/entity_factory.pb.h>
 #include <gz/msgs/stringmsg_v.pb.h>
 
 #include <sstream>
@@ -58,7 +58,7 @@ DEFINE_double(Y, 0, "Yaw component of initial orientation, in radians.");
 
 bool set_XML_from_topic(
   const std::string & topic_name, const rclcpp::Node::SharedPtr ros2_node,
-  gz::msgs::EntityFactoryWithNs & req)
+  gz::msgs::EntityFactory & req)
 {
   const auto timeout = std::chrono::seconds(1);
   std::promise<std::string> xml_promise;
@@ -179,10 +179,10 @@ int main(int _argc, char ** _argv)
       world_name.c_str());
   }
 
-  std::string service{"/world/" + world_name + "/create_with_ns"};
+  std::string service{"/world/" + world_name + "/create"};
 
   // Request message
-  gz::msgs::EntityFactoryWithNs req;
+  gz::msgs::EntityFactory req;
 
   // Get ROS parameters
   std::string file_name = ros2_node->get_parameter("file").as_string();

--- a/ros_gz_sim/src/create.cpp
+++ b/ros_gz_sim/src/create.cpp
@@ -146,6 +146,10 @@ int main(int _argc, char ** _argv)
   ros2_node->declare_parameter("P", static_cast<double>(0));
   ros2_node->declare_parameter("Y", static_cast<double>(0));
 
+  const auto & parameter_overrides =
+    ros2_node->get_node_parameters_interface()->get_parameter_overrides();
+  const bool has_ns_param = parameter_overrides.find("ns") != parameter_overrides.end();
+
   auto always_shutdown = rcpputils::make_scope_exit(
     []() {rclcpp::shutdown();});
 
@@ -270,7 +274,7 @@ int main(int _argc, char ** _argv)
   bool allow_renaming = ros2_node->get_parameter("allow_renaming").as_bool();
   req.set_allow_renaming((allow_renaming || FLAGS_allow_renaming));
 
-  if (has_ns_arg) {
+  if (has_ns_arg || has_ns_param) {
     std::string ns = ros2_node->get_parameter("ns").as_string();
     if (!ns.empty()) {
       req.mutable_namespace_()->set_data(ns);

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
@@ -67,10 +67,7 @@ SpawnEntity::SpawnEntity(
         return;
       }
 
-      if (!request->entity_namespace.empty()) {
-        gz_request.mutable_namespace_()->set_data(
-          request->entity_namespace.front());
-      }
+      gz_request.set_namespace_(request->entity_namespace);
 
       // TODO(azeey) Reuse code in ros_gz_bridge/convert/geometry_msgs
       auto * pose = gz_request.mutable_pose();

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
@@ -15,7 +15,7 @@
 #include "spawn_entity.hpp"
 
 #include <gz/msgs/boolean.pb.h>
-#include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/entity_factory_with_ns.pb.h>
 
 #include <memory>
 
@@ -36,7 +36,7 @@ SpawnEntity::SpawnEntity(
   std::shared_ptr<rclcpp::Node> ros_node, std::shared_ptr<GazeboProxy> gz_proxy)
 : HandlerBase(ros_node, gz_proxy)
 {
-  const auto create_service = this->gz_proxy_->PrefixTopic("create/blocking");
+  const auto create_service = this->gz_proxy_->PrefixTopic("create_with_ns/blocking");
   if (!this->gz_proxy_->WaitForGzService(create_service)) {
     RCLCPP_ERROR_STREAM(
       this->ros_node_->get_logger(),
@@ -47,7 +47,7 @@ SpawnEntity::SpawnEntity(
   this->services_handle_ = ros_node->create_service<SpawnEntitySrv>(
     "spawn_entity", [this, create_service](RequestPtr request, ResponsePtr response) {
       using Result = simulation_interfaces::msg::Result;
-      gz::msgs::EntityFactory gz_request;
+      gz::msgs::EntityFactoryWithNs gz_request;
       if (!request->name.empty()) {
         gz_request.set_name(request->name);
       }

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
@@ -15,7 +15,7 @@
 #include "spawn_entity.hpp"
 
 #include <gz/msgs/boolean.pb.h>
-#include <gz/msgs/entity_factory_with_ns.pb.h>
+#include <gz/msgs/entity_factory.pb.h>
 
 #include <memory>
 
@@ -36,7 +36,7 @@ SpawnEntity::SpawnEntity(
   std::shared_ptr<rclcpp::Node> ros_node, std::shared_ptr<GazeboProxy> gz_proxy)
 : HandlerBase(ros_node, gz_proxy)
 {
-  const auto create_service = this->gz_proxy_->PrefixTopic("create_with_ns/blocking");
+  const auto create_service = this->gz_proxy_->PrefixTopic("create/blocking");
   if (!this->gz_proxy_->WaitForGzService(create_service)) {
     RCLCPP_ERROR_STREAM(
       this->ros_node_->get_logger(),
@@ -47,7 +47,7 @@ SpawnEntity::SpawnEntity(
   this->services_handle_ = ros_node->create_service<SpawnEntitySrv>(
     "spawn_entity", [this, create_service](RequestPtr request, ResponsePtr response) {
       using Result = simulation_interfaces::msg::Result;
-      gz::msgs::EntityFactoryWithNs gz_request;
+      gz::msgs::EntityFactory gz_request;
       if (!request->name.empty()) {
         gz_request.set_name(request->name);
       }

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
@@ -67,7 +67,7 @@ SpawnEntity::SpawnEntity(
         return;
       }
 
-      gz_request.set_namespace_(request->entity_namespace);
+      gz_request.set_entity_namespace(request->entity_namespace);
 
       // TODO(azeey) Reuse code in ros_gz_bridge/convert/geometry_msgs
       auto * pose = gz_request.mutable_pose();

--- a/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
+++ b/ros_gz_sim/src/gz_simulation_interfaces/services/spawn_entity.cpp
@@ -15,7 +15,7 @@
 #include "spawn_entity.hpp"
 
 #include <gz/msgs/boolean.pb.h>
-#include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/entity_factory_with_ns.pb.h>
 
 #include <memory>
 
@@ -36,7 +36,7 @@ SpawnEntity::SpawnEntity(
   std::shared_ptr<rclcpp::Node> ros_node, std::shared_ptr<GazeboProxy> gz_proxy)
 : HandlerBase(ros_node, gz_proxy)
 {
-  const auto create_service = this->gz_proxy_->PrefixTopic("create/blocking");
+  const auto create_service = this->gz_proxy_->PrefixTopic("create_with_ns/blocking");
   if (!this->gz_proxy_->WaitForGzService(create_service)) {
     RCLCPP_ERROR_STREAM(
       this->ros_node_->get_logger(),
@@ -47,7 +47,7 @@ SpawnEntity::SpawnEntity(
   this->services_handle_ = ros_node->create_service<SpawnEntitySrv>(
     "spawn_entity", [this, create_service](RequestPtr request, ResponsePtr response) {
       using Result = simulation_interfaces::msg::Result;
-      gz::msgs::EntityFactory gz_request;
+      gz::msgs::EntityFactoryWithNs gz_request;
       if (!request->name.empty()) {
         gz_request.set_name(request->name);
       }
@@ -67,7 +67,11 @@ SpawnEntity::SpawnEntity(
         return;
       }
 
-      // TODO(azeey) Add support for entity_namespace
+      if (!request->entity_namespace.empty()) {
+        gz_request.mutable_namespace_()->set_data(
+          request->entity_namespace.front());
+      }
+
       // TODO(azeey) Reuse code in ros_gz_bridge/convert/geometry_msgs
       auto * pose = gz_request.mutable_pose();
       pose->mutable_position()->set_x(request->initial_pose.pose.position.x);

--- a/ros_gz_sim/test/test_create.cpp
+++ b/ros_gz_sim/test/test_create.cpp
@@ -14,7 +14,7 @@
 
 
 #include <gz/msgs/boolean.pb.h>
-#include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/entity_factory_with_ns.pb.h>
 #include <csignal>
 #include <chrono>
 #include <condition_variable>
@@ -22,7 +22,7 @@
 #include <mutex>
 #include <gz/transport/Node.hh>
 
-// Simple application that provides a `/create` service and prints out the
+// Simple application that provides a `/create_with_ns` service and prints out the
 // sdf_filename of the request. This works in conjection with
 // test_create_node.launch.py
 int main()
@@ -34,7 +34,7 @@ int main()
   gz::transport::Node node;
   auto cb = std::function(
     [&](
-      const gz::msgs::EntityFactory & _req,
+      const gz::msgs::EntityFactoryWithNs & _req,
       gz::msgs::Boolean & _res) -> bool {
       std::cout << _req.sdf_filename() << std::endl;
       _res.set_data(true);
@@ -47,7 +47,7 @@ int main()
       return true;
     });
 
-  node.Advertise("/world/default/create", cb);
+  node.Advertise("/world/default/create_with_ns", cb);
   // wait until we receive a message.
   std::unique_lock<std::mutex> lk(m);
   cv.wait(lk, [&] {return test_complete;});

--- a/ros_gz_sim/test/test_create.cpp
+++ b/ros_gz_sim/test/test_create.cpp
@@ -14,7 +14,7 @@
 
 
 #include <gz/msgs/boolean.pb.h>
-#include <gz/msgs/entity_factory_with_ns.pb.h>
+#include <gz/msgs/entity_factory.pb.h>
 #include <csignal>
 #include <chrono>
 #include <condition_variable>
@@ -22,7 +22,7 @@
 #include <mutex>
 #include <gz/transport/Node.hh>
 
-// Simple application that provides a `/create_with_ns` service and prints out the
+// Simple application that provides a `/create` service and prints out the
 // sdf_filename of the request. This works in conjection with
 // test_create_node.launch.py
 int main()
@@ -34,7 +34,7 @@ int main()
   gz::transport::Node node;
   auto cb = std::function(
     [&](
-      const gz::msgs::EntityFactoryWithNs & _req,
+      const gz::msgs::EntityFactory & _req,
       gz::msgs::Boolean & _res) -> bool {
       std::cout << _req.sdf_filename() << std::endl;
       _res.set_data(true);
@@ -47,7 +47,7 @@ int main()
       return true;
     });
 
-  node.Advertise("/world/default/create_with_ns", cb);
+  node.Advertise("/world/default/create", cb);
   // wait until we receive a message.
   std::unique_lock<std::mutex> lk(m);
   cv.wait(lk, [&] {return test_complete;});


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/gazebosim/gz-sim/pull/3871

## Summary

This PR adds `entity_namespace` support to:

  - `create` node
  - `gz_spawn_model.launch`
  - `gz_spawn_model.launch.py`
  - `ros_gz_spawn_model.launch.py`
  - `GzSpawnModel` launch action
  - simulation interfaces `spawn_entity` service

The create node now uses Gazebo's `/create_with_ns` service and sends `EntityFactoryWithNs` requests. When `entity_namespace` is set, it is passed to Gazebo as the spawned entity namespace. When it is empty, the spawn behavior stays the same as before.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it

First start a Gazebo world. For example, use a world named `default`.

Then test spawning models with `entity_namespace` from the supported entry points.

### 1. Test `ros_gz_sim create`

```bash
export VEHICLE_SDF="$(ros2 pkg prefix --share ros_gz_sim_demos)/models/vehicle/model.sdf"

ros2 run ros_gz_sim create \
  -world default \
  -file "$VEHICLE_SDF" \
  -name robot1 \
  -ns robot1 \
  -y 0.0
```

### 2. Test gz_spawn_model.launch
``` bash
export VEHICLE_SDF="$(ros2 pkg prefix --share ros_gz_sim_demos)/models/vehicle/model.sdf"

ros2 launch ros_gz_sim gz_spawn_model.launch.py \
  world:=default \
  file:="$VEHICLE_SDF" \
  entity_name:=robot2 \
  entity_namespace:=robot2 \
   y:=2.0

ros2 launch ros_gz_sim gz_spawn_model.launch \
  world:=default \
  file:="$VEHICLE_SDF" \
  entity_name:=robot3 \
  entity_namespace:=robot3 \
  x:=0.0 \
  y:=4.0 \
  z:=0.0
```

### 3. Test ros_gz_spawn_model.launch.py
``` bash
export VEHICLE_SDF="$(ros2 pkg prefix --share ros_gz_sim_demos)/models/vehicle/model.sdf"

ros2 launch ros_gz_sim ros_gz_spawn_model.launch.py \
  world:=default \
  file:="$VEHICLE_SDF" \
  entity_name:=robot4 \
  entity_namespace:=robot4 \
  y:=6.0 \
  bridge_name:=default \
  config_file:=test.yaml
```

### 4. Test ROS 2 Simulation Interfaces
``` bash
export VEHICLE_SDF="$(ros2 pkg prefix --share ros_gz_sim_demos)/models/vehicle/model.sdf"

ros2 service call /gzserver/spawn_entity simulation_interfaces/srv/SpawnEntity "{
  name: 'robot5',
  entity_resource: {
    uri: '$VEHICLE_SDF'
  },
  entity_namespace: 'robot5',
  allow_renaming: false,
  initial_pose: {
    pose: {
      position: {x: 0.0, y: 8.0, z: 0.0},
      orientation: {w: 1.0, x: 0.0, y: 0.0, z: 0.0}
    }
  }
}"
``` 

### 5. Test `GzSpawnModel` launch action

Create a test launch file, for example:
<details>
<summary>test_gz_spawn_model_action.launch.xml</summary>

``` xml
<launch>
  <gz_spawn_model
    world="default"
    file="$(find-pkg-share ros_gz_sim_demos)/models/vehicle/model.sdf"
    entity_name="robot6"
    entity_namespace="{name}"
    allow_renaming="false"
    x="0.0"
    y="6.0"
    z="1.0"
    yaw="0.0">
  </gz_spawn_model>
</launch>
```
</details>

Run it with:

``` bash
ros2 launch ./test_gz_spawn_model_action.launch.xml
```

After each command, check that the entity is created successfully. Also check the Gazebo GUI side panel and confirm that the displayed namespace matches the namespace used in the spawn command.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Codex(gpt-5.4)