### PR TITLE
Set default spawn pose arguments to 0.0

### DIFF
--- a/ros_gz_sim/launch/gz_spawn_model.launch
+++ b/ros_gz_sim/launch/gz_spawn_model.launch
@@ -5,12 +5,12 @@
   <arg name="topic" default="" />
   <arg name="entity_name" default="" />
   <arg name="allow_renaming" default="False" />
-  <arg name="x" default="" />
-  <arg name="y" default="" />
-  <arg name="z" default="" />
-  <arg name="roll" default="" />
-  <arg name="pitch" default="" />
-  <arg name="yaw" default="" />
+  <arg name="x" default="0.0" />
+  <arg name="y" default="0.0" />
+  <arg name="z" default="0.0" />
+  <arg name="roll" default="0.0" />
+  <arg name="pitch" default="0.0" />
+  <arg name="yaw" default="0.0" />
   <gz_spawn_model
     world="$(var world)"
     file="$(var file)"


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This PR fixes an inconsistency between `gz_spawn_model.launch` and `gz_spawn_model.launch.py`.

In `gz_spawn_model.launch.py`, the pose arguments default to `0.0`, so users can omit them and spawn the model at the default pose. However, in `gz_spawn_model.launch`, the same pose arguments defaulted to empty strings. This meant the XML launch file behaved differently from the Python launch file and could fail when pose arguments were not explicitly set.

### Reproduce
For example, running the following command:
``` bash
export VEHICLE_SDF="$(ros2 pkg prefix --share ros_gz_sim_demos)/models/vehicle/model.sdf"

ros2 launch ros_gz_sim gz_spawn_model.launch \
  world:=default \
  file:="$VEHICLE_SDF" \
  entity_name:=robot1 \
  entity_namespace:=robot1
```
resulted in the following error:
``` bash
[create-1] terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterTypeException'
[create-1]   what():  parameter 'x' has invalid type: Wrong parameter type, parameter {x} is of type {double}, setting it to {string} is not allowed.
[ERROR] [create-1]: process has died
```

### Changes
Set default spawn pose arguments (`x`, `y`, `z`, `roll`, `pitch`, `yaw`) in  `gz_spawn_model.launch` to `0.0`

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)