### PR TITLE
Fix entity type values in sim tools and docs

### DIFF
--- a/ros_gz_sim/src/delete_entity.cpp
+++ b/ros_gz_sim/src/delete_entity.cpp
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
   int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
   app.add_option("--type", entity_type,
                    "Entity type: 0=NONE, 1=LIGHT, 2=MODEL(default), 3=LINK, "
-                   "4=VISUAL, 5=COLLISION, 6=SENSOR");
+                   "4=VISUAL, 5=COLLISION, 6=SENSOR, 7=JOINT");
 
    // Parse and catch any CLI errors
   try {

--- a/ros_gz_sim/src/delete_entity.cpp
+++ b/ros_gz_sim/src/delete_entity.cpp
@@ -118,10 +118,10 @@ int main(int argc, char **argv)
   id_option->excludes(name_option);
 
    // Entity type option
-  int entity_type = 6;     // Default to MODEL type
+  int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
   app.add_option("--type", entity_type,
-                   "Entity type: 0=NONE, 1=LIGHT, 2=LINK, 3=VISUAL, 4=COLLISION, "
-                   "5=SENSOR, 6=MODEL(default)");
+                   "Entity type: 0=NONE, 1=LIGHT, 2=MODEL(default), 3=LINK, "
+                   "4=VISUAL, 5=COLLISION, 6=SENSOR");
 
    // Parse and catch any CLI errors
   try {

--- a/ros_gz_sim/src/set_entity_pose.cpp
+++ b/ros_gz_sim/src/set_entity_pose.cpp
@@ -164,10 +164,10 @@ int main(int argc, char **argv)
   id_option->excludes(name_option);
 
   // Entity type option
-  int entity_type = 6;    // Default to MODEL type
+  int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
   app.add_option("--type", entity_type,
-                "Entity type: 0=NONE, 1=LIGHT, 2=LINK, 3=VISUAL, 4=COLLISION, "
-                "5=SENSOR, 6=MODEL(default)");
+                   "Entity type: 0=NONE, 1=LIGHT, 2=MODEL(default), 3=LINK, "
+                   "4=VISUAL, 5=COLLISION, 6=SENSOR");
 
   // Position parameters
   std::vector<double> position = {0.0, 0.0, 0.0};

--- a/ros_gz_sim/src/set_entity_pose.cpp
+++ b/ros_gz_sim/src/set_entity_pose.cpp
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
   int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
   app.add_option("--type", entity_type,
                    "Entity type: 0=NONE, 1=LIGHT, 2=MODEL(default), 3=LINK, "
-                   "4=VISUAL, 5=COLLISION, 6=SENSOR");
+                   "4=VISUAL, 5=COLLISION, 6=SENSOR, 7=JOINT");
 
   // Position parameters
   std::vector<double> position = {0.0, 0.0, 0.0};

--- a/ros_gz_sim/test/test_delete_entity.cpp
+++ b/ros_gz_sim/test/test_delete_entity.cpp
@@ -103,7 +103,7 @@ TEST(DeleteEntityTest, DeleteEntityIntegration) {
   {
     std::string entity_name = "test_entity";
     int entity_id = 0;
-    int entity_type = 6;  // MODEL type
+    int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
 
     bool result = deleter->delete_entity(entity_name, entity_id, entity_type);
 
@@ -119,7 +119,7 @@ TEST(DeleteEntityTest, DeleteEntityIntegration) {
   {
     std::string entity_name = "";
     int entity_id = 42;
-    int entity_type = 6;  // MODEL type
+    int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
 
     bool result = deleter->delete_entity(entity_name, entity_id, entity_type);
 
@@ -135,7 +135,7 @@ TEST(DeleteEntityTest, DeleteEntityIntegration) {
   {
     std::string entity_name = "test_light";
     int entity_id = 0;
-    int entity_type = 1;  // LIGHT type
+    int entity_type = ros_gz_interfaces::msg::Entity::LIGHT;
 
     bool result = deleter->delete_entity(entity_name, entity_id, entity_type);
 
@@ -148,9 +148,10 @@ TEST(DeleteEntityTest, DeleteEntityIntegration) {
 
   // Test case 4: Test failure response
   {
+    int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
     test_service->set_response(false);
     std::string entity_name = "nonexistent_entity";
-    bool result = deleter->delete_entity(entity_name, 0, 6);
+    bool result = deleter->delete_entity(entity_name, 0, entity_type);
     EXPECT_FALSE(result);
   }
 
@@ -184,7 +185,8 @@ TEST(DeleteEntityTest, InvalidInputs) {
   std::this_thread::sleep_for(1s);
 
   // Test case: Missing both entity name and ID
-  bool result = deleter->delete_entity("", 0, 6);
+  int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
+  bool result = deleter->delete_entity("", 0, entity_type);
   EXPECT_FALSE(result);
 
   // Clean up

--- a/ros_gz_sim/test/test_set_entity_pose.cpp
+++ b/ros_gz_sim/test/test_set_entity_pose.cpp
@@ -107,7 +107,7 @@ TEST(SetEntityPoseTest, SetEntityPoseIntegration) {
   {
     std::string entity_name = "test_entity";
     int entity_id = 0;
-    int entity_type = 6;  // MODEL type
+    int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
     double x = 1.0, y = 2.0, z = 3.0;
     double qx = 0.1, qy = 0.2, qz = 0.3, qw = 0.9165;
     bool use_quaternion = true;
@@ -134,7 +134,7 @@ TEST(SetEntityPoseTest, SetEntityPoseIntegration) {
   {
     std::string entity_name = "";
     int entity_id = 42;
-    int entity_type = 6;  // MODEL type
+    int entity_type = ros_gz_interfaces::msg::Entity::MODEL;
     double x = 4.0, y = 5.0, z = 6.0;
     double roll = 0.1, pitch = 0.2, yaw = 0.3;  // Euler angles in radians
     bool use_quaternion = false;

--- a/ros_gz_sim_demos/README.md
+++ b/ros_gz_sim_demos/README.md
@@ -335,8 +335,8 @@ When using the `set_entity_pose` and `delete_entity` commands, you can specify t
 |-------|-------------|
 | 0     | NONE        |
 | 1     | LIGHT       |
-| 2     | LINK        |
-| 3     | VISUAL      |
-| 4     | COLLISION   |
-| 5     | SENSOR      |
-| 6     | MODEL (default) |
+| 2     | MODEL (default) |
+| 3     | LINK        |
+| 4     | VISUAL      |
+| 5     | COLLISION   |
+| 6     | SENSOR      |

--- a/ros_gz_sim_demos/README.md
+++ b/ros_gz_sim_demos/README.md
@@ -340,3 +340,4 @@ When using the `set_entity_pose` and `delete_entity` commands, you can specify t
 | 4     | VISUAL      |
 | 5     | COLLISION   |
 | 6     | SENSOR      |
+| 7     | JOINT       |


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fix the entity type values used by the `delete_entity` and `set_entity_pose` tools and the `ros_gz_sim_demos` documentation so they match `ros_gz_interfaces/msg/Entity.msg`.

The previous CLI help text and README table were inconsistent with the entity type constants defined in `ros_gz_interfaces/msg/Entity.msg`. This could cause users to pass the wrong entity type value when using `--type`.
https://github.com/gazebosim/ros_gz/blob/0ea9efc010c7427385c6493c1a8016cdf1ef450b/ros_gz_sim_demos/README.md?plain=1#L330-L342
https://github.com/gazebosim/ros_gz/blob/0ea9efc010c7427385c6493c1a8016cdf1ef450b/ros_gz_sim/src/delete_entity.cpp#L121-L124
https://github.com/gazebosim/ros_gz/blob/0ea9efc010c7427385c6493c1a8016cdf1ef450b/ros_gz_sim/src/set_entity_pose.cpp#L167-L170
https://github.com/gazebosim/ros_gz/blob/0ea9efc010c7427385c6493c1a8016cdf1ef450b/ros_gz_interfaces/msg/Entity.msg#L1-L9

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
