### PR TITLE
Document all supported service bridge types

### DIFF
--- a/ros_gz_bridge/README.md
+++ b/ros_gz_bridge/README.md
@@ -84,6 +84,9 @@ And the following for services:
 | ROS type                             | Gazebo request             | Gazebo response       |
 |--------------------------------------|:--------------------------:| --------------------- |
 | ros_gz_interfaces/srv/ControlWorld   | gz.msgs.WorldControl       | gz.msgs.Boolean       |
+| ros_gz_interfaces/srv/DeleteEntity   | gz.msgs.Entity             | gz.msgs.Boolean       |
+| ros_gz_interfaces/srv/SpawnEntity    | gz.msgs.EntityFactory      | gz.msgs.Boolean       |
+| ros_gz_interfaces/srv/SetEntityPose  | gz.msgs.Pose               | gz.msgs.Boolean       |
 
 Run `ros2 run ros_gz_bridge parameter_bridge -h` for instructions.
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This PR updates the `ros_gz_bridge` README to list all currently supported service bridge type mappings.

The service bridge implementation supports four ROS service mappings, but the README only documented `ros_gz_interfaces/srv/ControlWorld`. This adds the missing supported service types:

  - `ros_gz_interfaces/srv/DeleteEntity`
  - `ros_gz_interfaces/srv/SpawnEntity`
  - `ros_gz_interfaces/srv/SetEntityPose`

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)