### PR TITLE
Correctly initialize std::atomic_flag with ATOMIC_FLAG_INIT to fix Windows compilation of tests

### DIFF
--- a/ros_gz_bridge/test/serverclient/gz_server.cpp
+++ b/ros_gz_bridge/test/serverclient/gz_server.cpp
@@ -27,7 +27,7 @@
 #include "utils/gz_test_msg.hpp"
 
 /// \brief Flag used to break the waiting loop and terminate the program.
-static std::atomic_flag g_terminateSrv(false);
+static std::atomic_flag g_terminateSrv = ATOMIC_FLAG_INIT;
 
 //////////////////////////////////////////////////
 /// \brief Function callback executed when a SIGINT or SIGTERM signals are


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation of tests under Windows/MSVC.

## Summary

The only C++ standard compliant way to initialize `std::atomic_flag` to false is to use the `ATOMIC_FLAG_INIT` (see https://en.cppreference.com/cpp/atomic/ATOMIC_FLAG_INIT).

Try to initialize it to `false` result in the following errors on Windows/MSVC:

~~~
D:\src\ros_gz\ros_gz_bridge\test\serverclient\gz_server.cpp(30): error C2665: 'std::atomic_flag::atomic_flag': no overloaded function could convert all the argument types
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\atomic(2859): note: could be 'std::atomic_flag::atomic_flag(const std::atomic_flag &)'
D:\src\ros_gz\ros_gz_bridge\test\serverclient\gz_server.cpp(30): note: 'std::atomic_flag::atomic_flag(const std::atomic_flag &)': cannot convert argument 1 from 'bool' to 'const std::atomic_flag &'
D:\src\ros_gz\ros_gz_bridge\test\serverclient\gz_server.cpp(30): note: Reason: cannot convert from 'bool' to 'const std::atomic_flag'
D:\src\ros_gz\ros_gz_bridge\test\serverclient\gz_server.cpp(30): note: while trying to match the argument list '(bool)'
~~~

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

