### PR TITLE
ros_gz_bridge: Explicitly handle visibility of exported symbols

### DIFF
--- a/ros_gz_bridge/CMakeLists.txt
+++ b/ros_gz_bridge/CMakeLists.txt
@@ -9,8 +9,6 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -99,6 +97,13 @@ add_library(${bridge_lib}
   ${generated_files}
 )
 
+include(GenerateExportHeader)
+generate_export_header(${bridge_lib}
+  EXPORT_FILE_NAME
+    "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME}/visibility_control.hpp"
+  EXPORT_MACRO_NAME ROS_GZ_BRIDGE_VISIBLE
+)
+
 target_link_libraries(${bridge_lib}
   PUBLIC
     gz-msgs::core
@@ -126,14 +131,24 @@ target_link_libraries(${bridge_lib}
 target_include_directories(${bridge_lib}
   PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>"
 )
 
+# Many tests do not link ${bridge_lib} even if they include its headers,
+# ensure that ${CMAKE_CURRENT_BINARY_DIR}/include that includes the visibility_control.hpp header
+# is properly visible
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+
 if(MSVC)
   target_compile_options(${bridge_lib} PRIVATE "/bigobj")
+  # This is used to ensure that all the heavy-templated tests
+  # defined in this directory use /bigobj,
+  # without the need to manually specify if for each test
+  add_compile_options("/bigobj")
 endif()
 
 rclcpp_components_register_node(
@@ -149,6 +164,11 @@ install(TARGETS ${bridge_lib} EXPORT export_${PROJECT_NAME}
 install(
   DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
+)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME}/visibility_control.hpp"
+  DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME}
 )
 
 install(

--- a/ros_gz_bridge/include/ros_gz_bridge/bridge_config.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/bridge_config.hpp
@@ -21,6 +21,8 @@
 
 #include <rclcpp/qos.hpp>
 
+#include "ros_gz_bridge/visibility_control.hpp"
+
 namespace ros_gz_bridge
 {
 
@@ -49,9 +51,9 @@ static constexpr BridgeDirection kDefaultDirection = BridgeDirection::BIDIRECTIO
 /// \param[in] qos_profile Uppercase string, e.g. "SENSOR_DATA".
 /// \return The corresponding QoS profile.
 /// \throws std::invalid_argument if the profile cannot be parsed.
-rclcpp::QoS parseQoS(const std::string & qos_profile);
+ROS_GZ_BRIDGE_VISIBLE rclcpp::QoS parseQoS(const std::string & qos_profile);
 
-struct BridgeConfig
+struct ROS_GZ_BRIDGE_VISIBLE BridgeConfig
 {
   /// \brief The ROS message type (eg std_msgs/msg/String)
   std::string ros_type_name;
@@ -105,12 +107,12 @@ struct BridgeConfig
 /// \brief Generate a group of BridgeConfigs from a YAML String
 /// \param[in] data string containing YAML of bridge configurations
 /// \return Vector of bridge configurations
-std::vector<BridgeConfig> readFromYamlString(const std::string & data);
+ROS_GZ_BRIDGE_VISIBLE std::vector<BridgeConfig> readFromYamlString(const std::string & data);
 
 /// \brief Generate a group of BridgeConfigs from a YAML File
 /// \param[in] filename name of file containing YAML of bridge configurations
 /// \return Vector of bridge configurations
-std::vector<BridgeConfig> readFromYamlFile(const std::string & filename);
+ROS_GZ_BRIDGE_VISIBLE std::vector<BridgeConfig> readFromYamlFile(const std::string & filename);
 
 }  // namespace ros_gz_bridge
 

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/actuator_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/actuator_msgs.hpp
@@ -27,13 +27,13 @@ namespace ros_gz_bridge
 {
 // actuator_msgs
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const actuator_msgs::msg::Actuators & ros_msg,
   gz::msgs::Actuators & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Actuators & gz_msg,
   actuator_msgs::msg::Actuators & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/builtin_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/builtin_interfaces.hpp
@@ -25,13 +25,13 @@ namespace ros_gz_bridge
 {
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const builtin_interfaces::msg::Time & ros_msg,
   gz::msgs::Time & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Time & gz_msg,
   builtin_interfaces::msg::Time & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/geometry_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/geometry_msgs.hpp
@@ -48,193 +48,193 @@ namespace ros_gz_bridge
 
 // geometry_msgs
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::Quaternion & ros_msg,
   gz::msgs::Quaternion & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Quaternion & gz_msg,
   geometry_msgs::msg::Quaternion & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::Vector3 & ros_msg,
   gz::msgs::Vector3d & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Vector3d & gz_msg,
   geometry_msgs::msg::Vector3 & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::Point & ros_msg,
   gz::msgs::Vector3d & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Vector3d & gz_msg,
   geometry_msgs::msg::Point & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::Pose & ros_msg,
   gz::msgs::Pose & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Pose & gz_msg,
   geometry_msgs::msg::Pose & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::PoseArray & ros_msg,
   gz::msgs::Pose_V & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Pose_V & gz_msg,
   geometry_msgs::msg::PoseArray & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::PoseWithCovariance & ros_msg,
   gz::msgs::PoseWithCovariance & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::PoseWithCovariance & gz_msg,
   geometry_msgs::msg::PoseWithCovarianceStamped & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::PoseWithCovarianceStamped & ros_msg,
   gz::msgs::PoseWithCovariance & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::PoseWithCovariance & gz_msg,
   geometry_msgs::msg::PoseWithCovariance & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::PoseStamped & ros_msg,
   gz::msgs::Pose & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Pose & gz_msg,
   geometry_msgs::msg::PoseStamped & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::Transform & ros_msg,
   gz::msgs::Pose & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Pose & gz_msg,
   geometry_msgs::msg::Transform & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::TransformStamped & ros_msg,
   gz::msgs::Pose & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Pose & gz_msg,
   geometry_msgs::msg::TransformStamped & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::Twist & ros_msg,
   gz::msgs::Twist & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Twist & gz_msg,
   geometry_msgs::msg::Twist & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::TwistStamped & ros_msg,
   gz::msgs::Twist & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Twist & gz_msg,
   geometry_msgs::msg::TwistStamped & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::TwistWithCovariance & ros_msg,
   gz::msgs::TwistWithCovariance & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::TwistWithCovariance & gz_msg,
   geometry_msgs::msg::TwistWithCovariance & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::TwistWithCovarianceStamped & ros_msg,
   gz::msgs::TwistWithCovariance & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::TwistWithCovariance & gz_msg,
   geometry_msgs::msg::TwistWithCovarianceStamped & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::Wrench & ros_msg,
   gz::msgs::Wrench & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Wrench & gz_msg,
   geometry_msgs::msg::Wrench & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const geometry_msgs::msg::WrenchStamped & ros_msg,
   gz::msgs::Wrench & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Wrench & gz_msg,
   geometry_msgs::msg::WrenchStamped & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/gps_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/gps_msgs.hpp
@@ -26,13 +26,13 @@
 namespace ros_gz_bridge
 {
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const gps_msgs::msg::GPSFix & ros_msg,
   gz::msgs::NavSat & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::NavSat & gz_msg,
   gps_msgs::msg::GPSFix & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/marine_acoustic_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/marine_acoustic_msgs.hpp
@@ -27,13 +27,13 @@ namespace ros_gz_bridge
 {
 // marine_acoustic_msgs
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const marine_acoustic_msgs::msg::Dvl & ros_msg,
   gz::msgs::DVLVelocityTracking & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::DVLVelocityTracking & gz_msg,
   marine_acoustic_msgs::msg::Dvl & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/nav_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/nav_msgs.hpp
@@ -28,25 +28,25 @@ namespace ros_gz_bridge
 {
 // nav_msgs
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const nav_msgs::msg::Odometry & ros_msg,
   gz::msgs::Odometry & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Odometry & gz_msg,
   nav_msgs::msg::Odometry & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const nav_msgs::msg::Odometry & ros_msg,
   gz::msgs::OdometryWithCovariance & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::OdometryWithCovariance & gz_msg,
   nav_msgs::msg::Odometry & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/rcl_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/rcl_interfaces.hpp
@@ -29,13 +29,13 @@ namespace ros_gz_bridge
 {
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const rcl_interfaces::msg::ParameterValue & ros_msg,
   gz::msgs::Any & ign_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Any & ign_msg,
   rcl_interfaces::msg::ParameterValue & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/ros_gz_interfaces.hpp
@@ -72,296 +72,296 @@ namespace ros_gz_bridge
 {
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::JointWrench & ros_msg,
   gz::msgs::JointWrench & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::JointWrench & gz_msg,
   ros_gz_interfaces::msg::JointWrench & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::AirSpeed & ros_msg,
   gz::msgs::AirSpeed & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::AirSpeed & gz_msg,
   ros_gz_interfaces::msg::AirSpeed & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Altimeter & ros_msg,
   gz::msgs::Altimeter & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Altimeter & gz_msg,
   ros_gz_interfaces::msg::Altimeter & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Entity & ros_msg,
   gz::msgs::Entity & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Entity & ros_msg,
   gz::msgs::Pose & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Entity & gz_msg,
   ros_gz_interfaces::msg::Entity & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::EntityFactory & ros_msg,
   gz::msgs::EntityFactory & gz_msg);
 
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::EntityFactory & gz_msg,
   ros_gz_interfaces::msg::EntityFactory & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::EntityWrench & ros_msg,
   gz::msgs::EntityWrench & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::EntityWrench & gz_msg,
   ros_gz_interfaces::msg::EntityWrench & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Contact & ros_msg,
   gz::msgs::Contact & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Contact & gz_msg,
   ros_gz_interfaces::msg::Contact & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Contacts & ros_msg,
   gz::msgs::Contacts & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Contacts & gz_msg,
   ros_gz_interfaces::msg::Contacts & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Dataframe & ros_msg,
   gz::msgs::Dataframe & ign_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Dataframe & ign_msg,
   ros_gz_interfaces::msg::Dataframe & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::GuiCamera & ros_msg,
   gz::msgs::GUICamera & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::GUICamera & gz_msg,
   ros_gz_interfaces::msg::GuiCamera & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Light & ros_msg,
   gz::msgs::Light & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Light & gz_msg,
   ros_gz_interfaces::msg::Light & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::MaterialColor & ros_msg,
   gz::msgs::MaterialColor & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::MaterialColor & gz_msg,
   ros_gz_interfaces::msg::MaterialColor & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::SensorNoise & ros_msg,
   gz::msgs::SensorNoise & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::SensorNoise & gz_msg,
   ros_gz_interfaces::msg::SensorNoise & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::StringVec & ros_msg,
   gz::msgs::StringMsg_V & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::StringMsg_V & gz_msg,
   ros_gz_interfaces::msg::StringVec & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::ParamVec & ros_msg,
   gz::msgs::Param & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Param & gz_msg,
   ros_gz_interfaces::msg::ParamVec & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::ParamVec & ros_msg,
   gz::msgs::Param_V & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Param_V & gz_msg,
   ros_gz_interfaces::msg::ParamVec & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::TrackVisual & ros_msg,
   gz::msgs::TrackVisual & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::TrackVisual & gz_msg,
   ros_gz_interfaces::msg::TrackVisual & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::VideoRecord & ros_msg,
   gz::msgs::VideoRecord & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::VideoRecord & gz_msg,
   ros_gz_interfaces::msg::VideoRecord & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::WorldControl & ros_msg,
   gz::msgs::WorldControl & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::WorldControl & gz_msg,
   ros_gz_interfaces::msg::WorldControl & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::WorldReset & ros_msg,
   gz::msgs::WorldReset & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::WorldReset & gz_msg,
   ros_gz_interfaces::msg::WorldReset & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::WorldStatistics & gz_msg,
   ros_gz_interfaces::msg::WorldStatistics & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::WorldStatistics & ros_msg,
   gz::msgs::WorldStatistics & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::Float32Array & ros_msg,
   gz::msgs::Float_V & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Float_V & gz_msg,
   ros_gz_interfaces::msg::Float32Array & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::LogicalCameraImage & ros_msg,
   gz::msgs::LogicalCameraImage & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::LogicalCameraImage & gz_msg,
   ros_gz_interfaces::msg::LogicalCameraImage & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ros_gz_interfaces::msg::LogPlaybackStatistics & ros_msg,
   gz::msgs::LogPlaybackStatistics & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::LogPlaybackStatistics & gz_msg,
   ros_gz_interfaces::msg::LogPlaybackStatistics & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/rosgraph_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/rosgraph_msgs.hpp
@@ -27,13 +27,13 @@ namespace ros_gz_bridge
 {
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Clock & gz_msg,
   rosgraph_msgs::msg::Clock & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const rosgraph_msgs::msg::Clock & ros_msg,
   gz::msgs::Clock & gz_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/sensor_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/sensor_msgs.hpp
@@ -49,133 +49,133 @@ namespace ros_gz_bridge
 
 // sensor_msgs
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::Joy & ros_msg,
   gz::msgs::Joy & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Joy & gz_msg,
   sensor_msgs::msg::Joy & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::FluidPressure & ros_msg,
   gz::msgs::FluidPressure & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::FluidPressure & gz_msg,
   sensor_msgs::msg::FluidPressure & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::Image & ros_msg,
   gz::msgs::Image & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Image & gz_msg,
   sensor_msgs::msg::Image & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::CameraInfo & ros_msg,
   gz::msgs::CameraInfo & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::CameraInfo & gz_msg,
   sensor_msgs::msg::CameraInfo & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::Imu & ros_msg,
   gz::msgs::IMU & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::IMU & gz_msg,
   sensor_msgs::msg::Imu & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::JointState & ros_msg,
   gz::msgs::Model & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Model & gz_msg,
   sensor_msgs::msg::JointState & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::LaserScan & ros_msg,
   gz::msgs::LaserScan & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::LaserScan & gz_msg,
   sensor_msgs::msg::LaserScan & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::MagneticField & ros_msg,
   gz::msgs::Magnetometer & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Magnetometer & gz_msg,
   sensor_msgs::msg::MagneticField & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::NavSatFix & ros_msg,
   gz::msgs::NavSat & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::NavSat & gz_msg,
   sensor_msgs::msg::NavSatFix & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::PointCloud2 & ros_msg,
   gz::msgs::PointCloudPacked & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::PointCloudPacked & gz_msg,
   sensor_msgs::msg::PointCloud2 & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const sensor_msgs::msg::BatteryState & ros_msg,
   gz::msgs::BatteryState & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::BatteryState & gz_msg,
   sensor_msgs::msg::BatteryState & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/std_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/std_msgs.hpp
@@ -43,109 +43,109 @@ namespace ros_gz_bridge
 {
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::Bool & ros_msg,
   gz::msgs::Boolean & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Boolean & gz_msg,
   std_msgs::msg::Bool & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::ColorRGBA & ros_msg,
   gz::msgs::Color & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Color & gz_msg,
   std_msgs::msg::ColorRGBA & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::Empty & ros_msg,
   gz::msgs::Empty & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Empty & gz_msg,
   std_msgs::msg::Empty & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::UInt32 & ros_msg,
   gz::msgs::UInt32 & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::UInt32 & gz_msg,
   std_msgs::msg::UInt32 & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::Float32 & ros_msg,
   gz::msgs::Float & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Float & gz_msg,
   std_msgs::msg::Float32 & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::Float64 & ros_msg,
   gz::msgs::Double & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Double & gz_msg,
   std_msgs::msg::Float64 & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::Header & ros_msg,
   gz::msgs::Header & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Header & gz_msg,
   std_msgs::msg::Header & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::Int32 & ros_msg,
   gz::msgs::Int32 & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Int32 & gz_msg,
   std_msgs::msg::Int32 & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const std_msgs::msg::String & ros_msg,
   gz::msgs::StringMsg & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::StringMsg & gz_msg,
   std_msgs::msg::String & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/tf2_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/tf2_msgs.hpp
@@ -27,13 +27,13 @@ namespace ros_gz_bridge
 {
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const tf2_msgs::msg::TFMessage & ros_msg,
   gz::msgs::Pose_V & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::Pose_V & gz_msg,
   tf2_msgs::msg::TFMessage & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/trajectory_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/trajectory_msgs.hpp
@@ -27,25 +27,25 @@ namespace ros_gz_bridge
 {
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const trajectory_msgs::msg::JointTrajectoryPoint & ros_msg,
   gz::msgs::JointTrajectoryPoint & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::JointTrajectoryPoint & gz_msg,
   trajectory_msgs::msg::JointTrajectoryPoint & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const trajectory_msgs::msg::JointTrajectory & ros_msg,
   gz::msgs::JointTrajectory & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::JointTrajectory & gz_msg,
   trajectory_msgs::msg::JointTrajectory & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert/vision_msgs.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert/vision_msgs.hpp
@@ -27,49 +27,49 @@
 namespace ros_gz_bridge
 {
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const vision_msgs::msg::Detection2D & ros_msg,
   gz::msgs::AnnotatedAxisAligned2DBox & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::AnnotatedAxisAligned2DBox & gz_msg,
   vision_msgs::msg::Detection2D & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const vision_msgs::msg::Detection2DArray & ros_msg,
   gz::msgs::AnnotatedAxisAligned2DBox_V & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::AnnotatedAxisAligned2DBox_V & gz_msg,
   vision_msgs::msg::Detection2DArray & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const vision_msgs::msg::Detection3D & ros_msg,
   gz::msgs::AnnotatedOriented3DBox & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::AnnotatedOriented3DBox & gz_msg,
   vision_msgs::msg::Detection3D & ros_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const vision_msgs::msg::Detection3DArray & ros_msg,
   gz::msgs::AnnotatedOriented3DBox_V & gz_msg);
 
 template<>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const gz::msgs::AnnotatedOriented3DBox_V & gz_msg,
   vision_msgs::msg::Detection3DArray & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/convert_decl.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/convert_decl.hpp
@@ -15,17 +15,19 @@
 #ifndef ROS_GZ_BRIDGE__CONVERT_DECL_HPP_
 #define ROS_GZ_BRIDGE__CONVERT_DECL_HPP_
 
+#include "ros_gz_bridge/visibility_control.hpp"
+
 namespace ros_gz_bridge
 {
 
 template<typename ROS_T, typename GZ_T>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_ros_to_gz(
   const ROS_T & ros_msg,
   GZ_T & gz_msg);
 
 template<typename ROS_T, typename GZ_T>
-void
+ROS_GZ_BRIDGE_VISIBLE void
 convert_gz_to_ros(
   const GZ_T & gz_msg,
   ROS_T & ros_msg);

--- a/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
+++ b/ros_gz_bridge/include/ros_gz_bridge/ros_gz_bridge.hpp
@@ -23,6 +23,7 @@
 #include <gz/transport/Node.hh>
 #include <rclcpp/node.hpp>
 #include "ros_gz_bridge/bridge_config.hpp"
+#include "ros_gz_bridge/visibility_control.hpp"
 
 namespace ros_gz_bridge
 {
@@ -30,7 +31,7 @@ namespace ros_gz_bridge
 class BridgeHandle;
 
 /// \brief Component container for the ROS-GZ Bridge
-class RosGzBridge : public rclcpp::Node
+class ROS_GZ_BRIDGE_VISIBLE RosGzBridge : public rclcpp::Node
 {
 public:
   /// \brief Constructor

--- a/ros_gz_bridge/src/factory_interface.hpp
+++ b/ros_gz_bridge/src/factory_interface.hpp
@@ -25,11 +25,12 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include "bridge_handle_gz_to_ros_parameters.hpp"
+#include "ros_gz_bridge/visibility_control.hpp"
 
 namespace ros_gz_bridge
 {
 
-class FactoryInterface
+class ROS_GZ_BRIDGE_VISIBLE FactoryInterface
 {
 public:
   virtual ~FactoryInterface() = 0;

--- a/ros_gz_bridge/src/get_factory.hpp
+++ b/ros_gz_bridge/src/get_factory.hpp
@@ -20,16 +20,17 @@
 
 #include "factory_interface.hpp"
 #include "service_factory_interface.hpp"
+#include "ros_gz_bridge/visibility_control.hpp"
 
 namespace ros_gz_bridge
 {
 
-std::shared_ptr<FactoryInterface>
+ROS_GZ_BRIDGE_VISIBLE std::shared_ptr<FactoryInterface>
 get_factory(
   const std::string & ros_type_name,
   const std::string & gz_type_name);
 
-std::shared_ptr<ServiceFactoryInterface>
+ROS_GZ_BRIDGE_VISIBLE std::shared_ptr<ServiceFactoryInterface>
 get_service_factory(
   const std::string & ros_type_name,
   const std::string & gz_req_type_name,

--- a/ros_gz_bridge/src/get_mappings.hpp
+++ b/ros_gz_bridge/src/get_mappings.hpp
@@ -18,16 +18,18 @@
 #include <map>
 #include <string>
 
+#include "ros_gz_bridge/visibility_control.hpp"
+
 namespace ros_gz_bridge
 {
 
-bool
+ROS_GZ_BRIDGE_VISIBLE bool
 get_gz_to_ros_mapping(const std::string & gz_type_name, std::string & ros_type_name);
 
-bool
+ROS_GZ_BRIDGE_VISIBLE bool
 get_ros_to_gz_mapping(const std::string & ros_type_name, std::string & gz_type_name);
 
-std::multimap<std::string, std::string>
+ROS_GZ_BRIDGE_VISIBLE std::multimap<std::string, std::string>
 get_all_message_mappings_ros_to_gz();
 
 }  // namespace ros_gz_bridge

--- a/ros_gz_bridge/src/service_factory_interface.hpp
+++ b/ros_gz_bridge/src/service_factory_interface.hpp
@@ -23,10 +23,12 @@
 #include <rclcpp/service.hpp>
 #include <rclcpp/node.hpp>
 
+#include "ros_gz_bridge/visibility_control.hpp"
+
 namespace ros_gz_bridge
 {
 
-class ServiceFactoryInterface
+class ROS_GZ_BRIDGE_VISIBLE ServiceFactoryInterface
 {
 public:
   virtual ~ServiceFactoryInterface() = 0;


### PR DESCRIPTION
# 🦟 Bug fix

Under some circumstances (in our case, by using the latest CMake, but that can be influenced by several factors) the link of `ros_gz_bridge` on Windows could fail with the message:

~~~
Auto build dll exports
LINK : fatal error LNK1189: library limit of 65535 objects exceeded [%SRC_DIR%\build\ros_gz_bridge.vcxproj]
~~~

This was due to the use of `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` to export all symbols in the library, that however (probably due to template instantiation) could reach the maximum limit of 65535 . 

## Summary

To avoid the problem, this PR switches `ros_gz_bridge` to use explicit visibility headers to manage the visible symbols, as fone for the rest of gz-* projects.

To build the workspace for Windows, I used this pixi.toml :

~~~toml
[workspace]
name = "ros_gz"
channels = [
    "https://prefix.dev/robostack-rolling",
    "https://prefix.dev/conda-forge",
]
platforms = ["win-64"]

[tasks]
build = "colcon build --merge-install --event-handlers console_direct+ --cmake-args -G Ninja -DCMAKE_BUILD_TYPE=Release"
test = { cmd = "colcon test --merge-install --event-handlers console_direct+ && colcon test-result --verbose", depends-on = [
    "build",
] }

[dependencies]
# Build tooling.
colcon-common-extensions = "*"
cmake = "*"
ninja = "*"
c-compiler = "*"
cxx-compiler = "*"
pkg-config = "*"
cli11 = "*"
gflags = "*"

# ament / rosidl buildtools.
ros-rolling-ament-cmake = "*"
ros-rolling-ament-cmake-python = "*"
ros-rolling-rosidl-pycommon = "*"
ros-rolling-rosidl-default-generators = "*"

# Message / interface packages.
ros-rolling-actuator-msgs = "*"
ros-rolling-builtin-interfaces = "*"
ros-rolling-geometry-msgs = "*"
ros-rolling-gps-msgs = "*"
ros-rolling-marine-acoustic-msgs = "*"
ros-rolling-nav-msgs = "*"
ros-rolling-rcl-interfaces = "*"
ros-rolling-rosgraph-msgs = "*"
ros-rolling-sensor-msgs = "*"
ros-rolling-simulation-interfaces = "*"
ros-rolling-std-msgs = "*"
ros-rolling-tf2-msgs = "*"
ros-rolling-trajectory-msgs = "*"
ros-rolling-vision-msgs = "*"

# ROS client library / tooling packages.
ros-rolling-ament-index-python = "*"
ros-rolling-image-transport = "*"
ros-rolling-launch = "*"
ros-rolling-launch-ros = "*"
ros-rolling-rclcpp = "*"
ros-rolling-rclcpp-action = "*"
ros-rolling-rclcpp-components = "*"
ros-rolling-rcpputils = "*"
ros-rolling-ros2pkg = "*"
ros-rolling-tf2 = "*"
ros-rolling-tf2-ros = "*"
ros-rolling-yaml-cpp-vendor = "*"

# Gazebo vendor packages.
ros-rolling-gz-math-vendor = "*"
ros-rolling-gz-msgs-vendor = "*"
ros-rolling-gz-sim-vendor = "*"
ros-rolling-gz-transport-vendor = "*"

# Test dependencies.
ros-rolling-ament-cmake-gtest = "*"
ros-rolling-ament-lint-auto = "*"
ros-rolling-ament-lint-common = "*"
ros-rolling-launch-testing = "*"
ros-rolling-launch-testing-ament-cmake = "*"
~~~

## Backport Policy

<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [x] Other (fill in yourself)

It would be great to backport this, but given the huge number of files touched, I guess it is not trivial to do so, at least using mergify or similar.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

