### PR TITLE
Break the parameter bridge handle ownership cycle

### DIFF
--- a/ros_gz_bridge/src/bridge_handle.cpp
+++ b/ros_gz_bridge/src/bridge_handle.cpp
@@ -14,6 +14,8 @@
 //
 #include "bridge_handle.hpp"
 
+#include <stdexcept>
+
 #include <memory>
 #include <string>
 
@@ -33,6 +35,15 @@ BridgeHandle::BridgeHandle(
 }
 
 BridgeHandle::~BridgeHandle() = default;
+
+rclcpp::Node::SharedPtr BridgeHandle::RosNode() const
+{
+  auto node = this->ros_node_.lock();
+  if (!node) {
+    throw std::runtime_error("ROS node expired while bridge handle was active");
+  }
+  return node;
+}
 
 bool BridgeHandle::IsLazy() const
 {
@@ -58,13 +69,13 @@ void BridgeHandle::Spin()
 
   if (this->HasSubscriber() && this->NumSubscriptions() == 0) {
     RCLCPP_DEBUG(
-      this->ros_node_->get_logger(),
+      this->RosNode()->get_logger(),
       "Bridge [%s] - No subscriptions found, stopping bridge",
       config_.ros_topic_name.c_str());
     this->StopSubscriber();
   } else if (!this->HasSubscriber() && this->NumSubscriptions() > 0) {
     RCLCPP_DEBUG(
-      this->ros_node_->get_logger(),
+      this->RosNode()->get_logger(),
       "Bridge [%s] - Subscriptions found, starting bridge",
       config_.ros_topic_name.c_str());
     this->StartSubscriber();

--- a/ros_gz_bridge/src/bridge_handle.hpp
+++ b/ros_gz_bridge/src/bridge_handle.hpp
@@ -91,7 +91,11 @@ protected:
 
 protected:
   /// \brief The ROS node used to create publishers/subscriptions
-  rclcpp::Node::SharedPtr ros_node_;
+  rclcpp::Node::SharedPtr RosNode() const;
+
+  // RosGzBridge owns its bridge handles. Keep the back-reference weak so the
+  // handle vector does not form a reference cycle with the owning node.
+  rclcpp::Node::WeakPtr ros_node_;
 
   /// \brief The Gazebo node used to create publishers/subscriptions
   std::shared_ptr<gz::transport::Node> gz_node_;

--- a/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
+++ b/ros_gz_bridge/src/bridge_handle_gz_to_ros.cpp
@@ -25,11 +25,13 @@ BridgeHandleGzToRos::BridgeHandleGzToRos(
   const BridgeConfig & config)
 : BridgeHandle(ros_node, gz_node, config)
 {
-  ros_node_->get_parameter("override_timestamps_with_wall_time",
-      gz_to_ros_parameters_.override_timestamps_with_wall_time);
-
-  ros_node_->get_parameter("override_frame_id",
-      gz_to_ros_parameters_.override_frame_id);
+  auto node = this->RosNode();
+  node->get_parameter(
+    "override_timestamps_with_wall_time",
+    gz_to_ros_parameters_.override_timestamps_with_wall_time);
+  node->get_parameter(
+    "override_frame_id",
+    gz_to_ros_parameters_.override_frame_id);
 }
 
 BridgeHandleGzToRos::~BridgeHandleGzToRos() = default;
@@ -42,11 +44,12 @@ size_t BridgeHandleGzToRos::NumSubscriptions() const
   if (this->ros_publisher_ != nullptr) {
     // Use info_by_topic rather than get_subscription_count
     // to filter out potential bidirectional bridge
-    auto topic_info = this->ros_node_->get_subscriptions_info_by_topic(
+    auto node = this->RosNode();
+    auto topic_info = node->get_subscriptions_info_by_topic(
       this->config_.ros_topic_name);
 
     for (auto & topic : topic_info) {
-      if (topic.node_name() == this->ros_node_->get_name()) {
+      if (topic.node_name() == node->get_name()) {
         continue;
       }
       valid_subscriptions++;
@@ -65,7 +68,7 @@ void BridgeHandleGzToRos::StartPublisher()
 {
   // Start ROS publisher
   this->ros_publisher_ = this->factory_->create_ros_publisher(
-    this->ros_node_,
+    this->RosNode(),
     this->config_.ros_topic_name,
     this->config_.PublisherQoS());
 }

--- a/ros_gz_bridge/src/bridge_handle_ros_to_gz.cpp
+++ b/ros_gz_bridge/src/bridge_handle_ros_to_gz.cpp
@@ -61,7 +61,7 @@ void BridgeHandleRosToGz::StartSubscriber()
 {
   // Start ROS subscriber
   this->ros_subscriber_ = this->factory_->create_ros_subscriber(
-    this->ros_node_,
+    this->RosNode(),
     this->config_.ros_topic_name,
     this->config_.SubscriberQoS(),
     this->gz_publisher_);


### PR DESCRIPTION
## Summary

Fixes #951.

`RosGzBridge` owns each `BridgeHandle` through `shared_ptr`, while each handle
currently retains a `shared_ptr` back to the owning node. This patch changes
only that back-reference to `rclcpp::Node::WeakPtr` and locks it at the call
sites that need node access.

The node continues to own its handles strongly, but handles no longer keep the
node and its middleware endpoints alive after `rclcpp::spin()` returns.

## Changes

- store the owner node as `rclcpp::Node::WeakPtr` in publisher, subscription and
  service bridge handles;
- lock the weak reference before using node APIs;
- handle an expired owner without dereferencing it;
- keep the existing public factory inputs and node-to-handle ownership.

## Validation

The original failure was reproduced against exact `ros_gz` 3.0.9. The same
four-file ownership change was then validated on this current `ros2` branch:

- DAVE sonar bridge-first shutdown: payloads 20/20, bridge clean 20/20;
- DAVE sonar process-group shutdown: payloads 10/10, launch rc 0 in 10/10;
- direct ROS→GZ String: payload and clean exit 20/20;
- active stock camera and PointCloud GZ→ROS: 5/5 each;
- official ARM64 Humble, Jazzy and Kilted source builds: 8/8 topic directions
  plus 1/1 service each, clean bridge exit;
- Jazzy `linux/amd64` under Docker Desktop emulation: 8/8 topic directions plus
  1/1 service, clean bridge exit;
- ordinary-layout isolated clone: 24/24 topic directions across 13 unique type
  pairs and 4/4 service factories;
- the candidate applied cleanly to the ordinary user workspace while preserving
  two pre-existing unrelated CMake edits, and `ros_gz_bridge` built successfully;
- all 73 generated topic mapping pairs were instantiated in both directions:
  73/73 GZ→ROS generated payload assertions and, after waiting for all generated
  endpoints before starting assertions, 73/73 ROS→GZ payload assertions;
- the ordered 73-pair ROS→GZ run shut `parameter_bridge` down with exit 0 and no
  escalation; five repeated payload runs and eleven lifecycle-only runs also
  exited cleanly.

The package's non-launch unit and lint targets passed after satisfying local
test dependencies. The stock macOS launch-test harness still exposes separate
startup-order and test-client teardown failures (`mutex lock failed` and a
component shutdown context error). An ordered component run passed its three
payload assertions and one service assertion, but `bridge_node` still exited
139 on SIGINT. These component/test-helper failures remain separate open scope;
the ordered `parameter_bridge` conversion oracle itself exits cleanly and this
patch does not claim to fix every macOS component shutdown path.

## Scope

The matrix covers every generated mapping registered by this checkout, but it
is still bounded. Native x86_64 hardware, Windows, hardware GPU paths and the
full upstream CI matrix remain appropriate maintainer / CI scope.
